### PR TITLE
feat: integrate GMP for arbitrary-precision integer arithmetic

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 
 CC = gcc
-CFLAGS = -O3 -std=c99 -Wall -Wextra -g -I./src
-LDFLAGS = -lreadline
+CFLAGS = -O3 -std=c99 -Wall -Wextra -g -I./src -I/opt/homebrew/include
+LDFLAGS = -lreadline -L/opt/homebrew/lib -lgmp
 SRC_DIR = src
 SRC = $(wildcard $(SRC_DIR)/*.c)
 OBJ = $(SRC:.c=.o)

--- a/src/arithmetic.c
+++ b/src/arithmetic.c
@@ -3,8 +3,8 @@
 #include "eval.h"
 #include <stdlib.h>
 #include <string.h>
-
 #include <stdint.h>
+#include <gmp.h>
 
 int64_t gcd(int64_t a, int64_t b) {
     a = llabs(a);
@@ -29,6 +29,28 @@ Expr* builtin_gcd(Expr* res) {
     if (res->type != EXPR_FUNCTION) return NULL;
     size_t count = res->data.function.arg_count;
     if (count == 0) return expr_new_integer(0);
+
+    // Single pass: detect any bigint while confirming all args are integer-like
+    bool any_bigint = false, all_integer_like = true;
+    for (size_t i = 0; i < count; i++) {
+        Expr* arg = res->data.function.args[i];
+        if (!expr_is_integer_like(arg)) { all_integer_like = false; break; }
+        if (arg->type == EXPR_BIGINT) any_bigint = true;
+    }
+
+    if (all_integer_like && any_bigint) {
+        mpz_t running, tmp;
+        mpz_init_set_ui(running, 0);
+        for (size_t i = 0; i < count; i++) {
+            expr_to_mpz(res->data.function.args[i], tmp);
+            mpz_abs(tmp, tmp);
+            mpz_gcd(running, running, tmp);
+            mpz_clear(tmp);
+        }
+        Expr* result = expr_bigint_normalize(expr_new_bigint_from_mpz(running));
+        mpz_clear(running);
+        return result;
+    }
 
     int64_t running_n = 0;
     int64_t running_d = 1;
@@ -326,7 +348,12 @@ Expr* builtin_factorial(Expr* res) {
                 for (int64_t i = 2; i <= n; i++) f *= i;
                 return expr_new_integer(f);
             } else {
-                return expr_copy(res);
+                mpz_t result;
+                mpz_init(result);
+                mpz_fac_ui(result, (unsigned long)n);
+                Expr* r = expr_new_bigint_from_mpz(result);
+                mpz_clear(result);
+                return r;
             }
         } else if (d == 2 || d == -2) {
             if (d == -2) { n = -n; }

--- a/src/complex.c
+++ b/src/complex.c
@@ -103,6 +103,14 @@ Expr* builtin_abs(Expr* res) {
         return ret;
     }
     int64_t n, d;
+    if (arg->type == EXPR_BIGINT) {
+        mpz_t r;
+        mpz_init(r);
+        mpz_abs(r, arg->data.bigint);
+        Expr* result = expr_bigint_normalize(expr_new_bigint_from_mpz(r));
+        mpz_clear(r);
+        return result;
+    }
     if (arg->type == EXPR_INTEGER) {
         int64_t val = arg->data.integer;
         return expr_new_integer(val < 0 ? -val : val);

--- a/src/core.c
+++ b/src/core.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <gmp.h>
 #include "rat.h"
 #include "parfrac.h"
 
@@ -436,7 +437,7 @@ Expr* builtin_numberq(Expr* res) {
 
     Expr* arg = res->data.function.args[0];
 
-    if (arg->type == EXPR_INTEGER || arg->type == EXPR_REAL) {
+    if (arg->type == EXPR_INTEGER || arg->type == EXPR_REAL || arg->type == EXPR_BIGINT) {
         return expr_new_symbol("True");
     }
 
@@ -453,7 +454,7 @@ Expr* builtin_numberq(Expr* res) {
 }
 
 static bool is_numeric_quantity(Expr* e) {
-    if (e->type == EXPR_INTEGER || e->type == EXPR_REAL) return true;
+    if (e->type == EXPR_INTEGER || e->type == EXPR_REAL || e->type == EXPR_BIGINT) return true;
     if (e->type == EXPR_SYMBOL) {
         const char* name = e->data.symbol;
         if (strcmp(name, "Pi") == 0 || strcmp(name, "E") == 0 || strcmp(name, "I") == 0 ||
@@ -496,12 +497,12 @@ Expr* builtin_numericq(Expr* res) {
 
 Expr* builtin_integerq(Expr* res) {
     if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 1) {
-        return NULL; 
+        return NULL;
     }
 
     Expr* arg = res->data.function.args[0];
 
-    if (arg->type == EXPR_INTEGER) {
+    if (expr_is_integer_like(arg)) {
         return expr_new_symbol("True");
     }
 
@@ -528,7 +529,7 @@ Expr* builtin_information(Expr* res) {
 
 Expr* builtin_evenq(Expr* res) {
     if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 1) {
-        return NULL; 
+        return NULL;
     }
 
     Expr* arg = res->data.function.args[0];
@@ -539,12 +540,16 @@ Expr* builtin_evenq(Expr* res) {
         }
     }
 
+    if (arg->type == EXPR_BIGINT) {
+        return mpz_even_p(arg->data.bigint) ? expr_new_symbol("True") : expr_new_symbol("False");
+    }
+
     return expr_new_symbol("False");
 }
 
 Expr* builtin_oddq(Expr* res) {
     if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 1) {
-        return NULL; 
+        return NULL;
     }
 
     Expr* arg = res->data.function.args[0];
@@ -553,6 +558,10 @@ Expr* builtin_oddq(Expr* res) {
         if (arg->data.integer % 2 != 0) {
             return expr_new_symbol("True");
         }
+    }
+
+    if (arg->type == EXPR_BIGINT) {
+        return mpz_odd_p(arg->data.bigint) ? expr_new_symbol("True") : expr_new_symbol("False");
     }
 
     return expr_new_symbol("False");

--- a/src/eval.c
+++ b/src/eval.c
@@ -260,6 +260,7 @@ Expr* evaluate_step(Expr* e) {
         case EXPR_INTEGER:
         case EXPR_REAL:
         case EXPR_STRING:
+        case EXPR_BIGINT:
             return expr_copy(e);
             
         case EXPR_SYMBOL: {

--- a/src/expr.c
+++ b/src/expr.c
@@ -71,10 +71,62 @@ Expr* expr_new_function(Expr* head, Expr** args, size_t arg_count) {
     return e;
 }
 
-// Deallocate an expression. 
+// BigInt constructors
+Expr* expr_new_bigint_from_mpz(const mpz_t val) {
+    Expr* e = malloc(sizeof(Expr));
+    if (!e) return NULL;
+    e->type = EXPR_BIGINT;
+    mpz_init_set(e->data.bigint, val);
+    return e;
+}
+
+Expr* expr_new_bigint_from_int64(int64_t val) {
+    Expr* e = malloc(sizeof(Expr));
+    if (!e) return NULL;
+    e->type = EXPR_BIGINT;
+    mpz_init_set_si(e->data.bigint, val);
+    return e;
+}
+
+Expr* expr_new_bigint_from_str(const char* str) {
+    Expr* e = malloc(sizeof(Expr));
+    if (!e) return NULL;
+    e->type = EXPR_BIGINT;
+    if (mpz_init_set_str(e->data.bigint, str, 10) == -1) {
+        mpz_clear(e->data.bigint);
+        free(e);
+        return NULL;
+    }
+    return e;
+}
+
+void expr_to_mpz(const Expr* e, mpz_t out) {
+    if (e->type == EXPR_INTEGER) {
+        mpz_init_set_si(out, e->data.integer);
+    } else { // EXPR_BIGINT
+        mpz_init_set(out, e->data.bigint);
+    }
+}
+
+bool expr_is_integer_like(const Expr* e) {
+    return e && (e->type == EXPR_INTEGER || e->type == EXPR_BIGINT);
+}
+
+Expr* expr_bigint_normalize(Expr* e) {
+    if (e->type == EXPR_BIGINT && mpz_fits_slong_p(e->data.bigint)) {
+        long val = mpz_get_si(e->data.bigint);
+        Expr* result = expr_new_integer((int64_t)val);
+        mpz_clear(e->data.bigint);
+        free(e);
+        return result;
+    }
+    return e;
+}
+
+// Deallocate an expression.
 void expr_free(Expr* e) {
     if (!e) return;
-    
+
     switch (e->type) {
         case EXPR_SYMBOL:
         case EXPR_STRING:
@@ -88,6 +140,9 @@ void expr_free(Expr* e) {
                 }
             }
             if (e->data.function.args) free(e->data.function.args);
+            break;
+        case EXPR_BIGINT:
+            mpz_clear(e->data.bigint);
             break;
         default:
             break;
@@ -131,6 +186,9 @@ Expr* expr_copy(Expr* e) {
                 copy->data.function.args = NULL;
             }
             break;
+        case EXPR_BIGINT:
+            mpz_init_set(copy->data.bigint, e->data.bigint);
+            break;
         default:
             break;
     }
@@ -141,8 +199,21 @@ Expr* expr_copy(Expr* e) {
 bool expr_eq(const Expr* a, const Expr* b) {
     if (a == b) return true;
     if (!a || !b) return false;
-    if (a->type != b->type) return false;
-    
+    if (a->type != b->type) {
+        // Cross-type equality: EXPR_INTEGER vs EXPR_BIGINT
+        if ((a->type == EXPR_INTEGER && b->type == EXPR_BIGINT) ||
+            (a->type == EXPR_BIGINT && b->type == EXPR_INTEGER)) {
+            mpz_t va, vb;
+            expr_to_mpz(a, va);
+            expr_to_mpz(b, vb);
+            bool result = (mpz_cmp(va, vb) == 0);
+            mpz_clear(va);
+            mpz_clear(vb);
+            return result;
+        }
+        return false;
+    }
+
     switch (a->type) {
         case EXPR_INTEGER:
             return a->data.integer == b->data.integer;
@@ -161,12 +232,14 @@ bool expr_eq(const Expr* a, const Expr* b) {
             }
             return true;
         }
+        case EXPR_BIGINT:
+            return mpz_cmp(a->data.bigint, b->data.bigint) == 0;
     }
     return false;
 }
 
 static int get_canonical_rank(const Expr* e) {
-    if (e->type == EXPR_INTEGER || e->type == EXPR_REAL || is_rational((Expr*)e, NULL, NULL)) return 0;
+    if (e->type == EXPR_INTEGER || e->type == EXPR_BIGINT || e->type == EXPR_REAL || is_rational((Expr*)e, NULL, NULL)) return 0;
     if (is_complex((Expr*)e, NULL, NULL)) return 1;
     if (e->type == EXPR_STRING) return 2;
     if (e->type == EXPR_SYMBOL) return 3;
@@ -175,6 +248,7 @@ static int get_canonical_rank(const Expr* e) {
 
 static double get_numeric_value(const Expr* e) {
     if (e->type == EXPR_INTEGER) return (double)e->data.integer;
+    if (e->type == EXPR_BIGINT) return mpz_get_d(e->data.bigint);
     if (e->type == EXPR_REAL) return e->data.real;
     int64_t n, d;
     if (is_rational((Expr*)e, &n, &d)) return (double)n / d;
@@ -215,7 +289,7 @@ static Expr* get_main_factor(Expr* e) {
     }
     if (strcmp(head->data.symbol, "Times") == 0 && e->data.function.arg_count >= 1) {
         Expr* first = e->data.function.args[0];
-        if (first->type == EXPR_INTEGER || first->type == EXPR_REAL || is_rational(first, NULL, NULL)) {
+        if (first->type == EXPR_INTEGER || first->type == EXPR_REAL || first->type == EXPR_BIGINT || is_rational(first, NULL, NULL)) {
             if (e->data.function.arg_count == 2) return get_main_factor(e->data.function.args[1]);
             return e->data.function.args[1];
         }
@@ -249,6 +323,22 @@ int expr_compare(const Expr* a, const Expr* b) {
 
     switch (rank_a) {
         case 0: { // Number
+            // Fast path: plain int64 comparison without GMP overhead
+            if (a->type == EXPR_INTEGER && b->type == EXPR_INTEGER) {
+                if (a->data.integer < b->data.integer) return -1;
+                if (a->data.integer > b->data.integer) return 1;
+                return 0;
+            }
+            // Exact comparison when either operand is a BigInt
+            if (expr_is_integer_like(a) && expr_is_integer_like(b)) {
+                mpz_t ma, mb;
+                expr_to_mpz(a, ma);
+                expr_to_mpz(b, mb);
+                int cmp = mpz_cmp(ma, mb);
+                mpz_clear(ma);
+                mpz_clear(mb);
+                return cmp;
+            }
             double va = get_numeric_value(a);
             double vb = get_numeric_value(b);
             if (va < vb) return -1;
@@ -367,6 +457,16 @@ uint64_t expr_hash(const Expr* e) {
             h *= prime;
             for (size_t i = 0; i < e->data.function.arg_count; i++) {
                 h ^= expr_hash(e->data.function.args[i]);
+                h *= prime;
+            }
+            break;
+        }
+        case EXPR_BIGINT: {
+            h ^= (uint64_t)(mpz_sgn(e->data.bigint) + 2);
+            h *= prime;
+            size_t nlimbs = mpz_size(e->data.bigint);
+            for (size_t i = 0; i < nlimbs; i++) {
+                h ^= mpz_getlimbn(e->data.bigint, i);
                 h *= prime;
             }
             break;

--- a/src/expr.h
+++ b/src/expr.h
@@ -11,13 +11,15 @@
 #include <stdbool.h>
 #include <stdarg.h>
 #include <math.h>
+#include <gmp.h>
 
 typedef enum {
     EXPR_INTEGER,
     EXPR_REAL,
     EXPR_SYMBOL,
     EXPR_STRING,
-    EXPR_FUNCTION
+    EXPR_FUNCTION,
+    EXPR_BIGINT
 } ExprType;
 
 typedef struct Expr {
@@ -28,10 +30,11 @@ typedef struct Expr {
         char* symbol;
         char* string;
         struct {
-            struct Expr* head; 
+            struct Expr* head;
             struct Expr** args;
             size_t arg_count;
         } function;
+        mpz_t bigint;
     } data;
 } Expr;
 
@@ -47,5 +50,15 @@ Expr* expr_copy(Expr* e);
 bool expr_eq(const Expr* a, const Expr* b);
 int expr_compare(const Expr* a, const Expr* b);
 uint64_t expr_hash(const Expr* e);
+
+/* BigInt constructors */
+Expr* expr_new_bigint_from_mpz(const mpz_t val);
+Expr* expr_new_bigint_from_int64(int64_t val);
+Expr* expr_new_bigint_from_str(const char* str);
+
+/* Helpers used by arithmetic modules */
+void  expr_to_mpz(const Expr* e, mpz_t out);
+bool  expr_is_integer_like(const Expr* e);
+Expr* expr_bigint_normalize(Expr* e);
 
 #endif // EXPR_H

--- a/src/match.c
+++ b/src/match.c
@@ -1,4 +1,5 @@
 #include "match.h"
+#include <gmp.h>
 #include "part.h"
 #include "eval.h"
 #include "print.h"
@@ -339,6 +340,8 @@ bool match(Expr* expr, Expr* pattern, MatchEnv* env) {
                 matched_normally = (strcmp(expr->data.symbol, pattern->data.symbol) == 0); break;
             case EXPR_STRING:
                 matched_normally = (strcmp(expr->data.string, pattern->data.string) == 0); break;
+            case EXPR_BIGINT:
+                matched_normally = (mpz_cmp(expr->data.bigint, pattern->data.bigint) == 0); break;
             case EXPR_FUNCTION: {
                 size_t saved_env_count = env->count;
                 if (match(expr->data.function.head, pattern->data.function.head, env)) {

--- a/src/parse.c
+++ b/src/parse.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <gmp.h>
 
 // Private parser state
 typedef struct {
@@ -84,20 +85,42 @@ static Expr* parse_number(ParserState* s) {
             start++;
         }
 
-        uint64_t ullval = 0;
         const char* current = start;
         while (isdigit(*current)) {
-            ullval = ullval * 10 + (*current - '0');
             current++;
         }
-        
+
         if (current == start) return NULL;
+
+        // Collect digit string into buffer (with optional sign)
+        size_t digit_len = (size_t)(current - start);
+        size_t buf_len = digit_len + (negative ? 1 : 0) + 1;
+        char buf[256];
+        char* heap_buf = NULL;
+        char* num_str = buf;
+        if (buf_len > sizeof(buf)) {
+            heap_buf = malloc(buf_len);
+            num_str = heap_buf;
+        }
+        size_t idx = 0;
+        if (negative) num_str[idx++] = '-';
+        memcpy(num_str + idx, start, digit_len);
+        num_str[idx + digit_len] = '\0';
+
         s->pos = current;
 
-        int64_t val = (int64_t)ullval;
-        if (negative) val = -val;
-        
-        return expr_new_integer(val);
+        Expr* result;
+        if (digit_len > 19) {
+            // More digits than INT64_MAX (19 digits) — skip strtoll, go straight to bigint
+            result = expr_new_bigint_from_str(num_str);
+        } else {
+            errno = 0;
+            char* endptr;
+            long long llval = strtoll(num_str, &endptr, 10);
+            result = (errno == ERANGE) ? expr_new_bigint_from_str(num_str) : expr_new_integer((int64_t)llval);
+        }
+        if (heap_buf) free(heap_buf);
+        return result;
     }
 }
 

--- a/src/plus.c
+++ b/src/plus.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <gmp.h>
 
 static bool is_overflow(Expr* e) {
     return e->type == EXPR_FUNCTION && e->data.function.head->type == EXPR_SYMBOL &&
@@ -23,16 +24,16 @@ static void get_coeff_base(Expr* e, Expr** coeff, Expr** base, bool* allocated_b
         return;
     }
 
-    if (e->type == EXPR_INTEGER || e->type == EXPR_REAL || is_rational(e, NULL, NULL) || is_complex(e, NULL, NULL)) {
+    if (e->type == EXPR_INTEGER || e->type == EXPR_REAL || e->type == EXPR_BIGINT || is_rational(e, NULL, NULL) || is_complex(e, NULL, NULL)) {
         *coeff = expr_copy(e);
         *base = NULL;
         return;
     }
-    
+
     if (e->type == EXPR_FUNCTION && strcmp(e->data.function.head->data.symbol, "Times") == 0) {
         if (e->data.function.arg_count >= 2) {
             Expr* first = e->data.function.args[0];
-            if (first->type == EXPR_INTEGER || first->type == EXPR_REAL || is_rational(first, NULL, NULL) || is_complex(first, NULL, NULL)) {
+            if (first->type == EXPR_INTEGER || first->type == EXPR_REAL || first->type == EXPR_BIGINT || is_rational(first, NULL, NULL) || is_complex(first, NULL, NULL)) {
                 *coeff = expr_copy(first);
                 if (e->data.function.arg_count == 2) {
                     *base = e->data.function.args[1];
@@ -97,9 +98,31 @@ static Expr* add_numbers(Expr* a, Expr* b) {
         return expr_new_real(va + vb);
     }
 
+    if (a->type == EXPR_BIGINT || b->type == EXPR_BIGINT) {
+        mpz_t av, bv, r;
+        expr_to_mpz(a, av);
+        expr_to_mpz(b, bv);
+        mpz_init(r);
+        mpz_add(r, av, bv);
+        mpz_clear(av); mpz_clear(bv);
+        Expr* res = expr_bigint_normalize(expr_new_bigint_from_mpz(r));
+        mpz_clear(r);
+        return res;
+    }
+
     if (a->type == EXPR_INTEGER && b->type == EXPR_INTEGER) {
         __int128_t res = (__int128_t)a->data.integer + b->data.integer;
-        if (res > INT64_MAX || res < INT64_MIN) return expr_new_function(expr_new_symbol("Overflow"), NULL, 0);
+        if (res > INT64_MAX || res < INT64_MIN) {
+            mpz_t av, bv, r;
+            expr_to_mpz(a, av);
+            expr_to_mpz(b, bv);
+            mpz_init(r);
+            mpz_add(r, av, bv);
+            mpz_clear(av); mpz_clear(bv);
+            Expr* result = expr_bigint_normalize(expr_new_bigint_from_mpz(r));
+            mpz_clear(r);
+            return result;
+        }
         return expr_new_integer((int64_t)res);
     }
 

--- a/src/power.c
+++ b/src/power.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <gmp.h>
 
 static int64_t ipow(int64_t base, int64_t exp, bool* overflow) {
     if (exp < 0) return 0;
@@ -52,6 +53,18 @@ static void factor_out_kth_power(int64_t n, int64_t k, int64_t* out_m, int64_t* 
     }
     *out_m = m;
     *out_r = r;
+}
+
+static Expr* bigint_pow(const Expr* base, int64_t exp) {
+    if (exp < 0) return NULL;
+    mpz_t b, r;
+    expr_to_mpz(base, b);
+    mpz_init(r);
+    mpz_pow_ui(r, b, (unsigned long)exp);
+    mpz_clear(b);
+    Expr* result = expr_bigint_normalize(expr_new_bigint_from_mpz(r));
+    mpz_clear(r);
+    return result;
 }
 
 Expr* make_power(Expr* base, Expr* exp) {
@@ -180,19 +193,37 @@ Expr* builtin_power(Expr* res) {
         }
     }
 
+    if (base->type == EXPR_BIGINT && exp->type == EXPR_INTEGER) {
+        int64_t e = exp->data.integer;
+        if (e > 0) {
+            return bigint_pow(base, e);
+        }
+        if (e < 0) {
+            Expr* denom = bigint_pow(base, -e);
+            if (!denom) return NULL;
+            Expr* p_args[2] = { denom, expr_new_integer(-1) };
+            return expr_new_function(expr_new_symbol("Power"), p_args, 2);
+        }
+    }
+
     if (base->type == EXPR_INTEGER && exp->type == EXPR_INTEGER) {
         int64_t b = base->data.integer;
         int64_t e = exp->data.integer;
         if (e > 0) {
             bool overflow = false;
             int64_t res_val = ipow(b, e, &overflow);
-            if (overflow) return expr_new_function(expr_new_symbol("Overflow"), NULL, 0);
+            if (overflow) return bigint_pow(base, e);
             return expr_new_integer(res_val);
         }
         if (e < 0) {
             bool overflow = false;
             int64_t res_val = ipow(b, -e, &overflow);
-            if (overflow) return expr_new_function(expr_new_symbol("Overflow"), NULL, 0);
+            if (overflow) {
+                Expr* denom = bigint_pow(base, -e);
+                if (!denom) return NULL;
+                Expr* p_args[2] = { denom, expr_new_integer(-1) };
+                return expr_new_function(expr_new_symbol("Power"), p_args, 2);
+            }
             return make_rational(1, res_val);
         }
     }

--- a/src/print.c
+++ b/src/print.c
@@ -59,6 +59,12 @@ void expr_print_fullform(Expr* e) {
         case EXPR_SYMBOL: printf("%s", e->data.symbol); break;
         case EXPR_STRING: printf("\"%s\"", e->data.string); break;
         case EXPR_FUNCTION: print_function_fullform(e); break;
+        case EXPR_BIGINT: {
+            char* str = mpz_get_str(NULL, 10, e->data.bigint);
+            printf("%s", str);
+            free(str);
+            break;
+        }
     }
 }
 

--- a/src/times.c
+++ b/src/times.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <gmp.h>
 
 static bool is_overflow(Expr* e) {
     return e->type == EXPR_FUNCTION && e->data.function.head->type == EXPR_SYMBOL &&
@@ -22,9 +23,31 @@ static Expr* multiply_numbers(Expr* a, Expr* b) {
         if (is_rational(b, &n, &d)) vb = (double)n / d;
         return expr_new_real(va * vb);
     }
+    if (a->type == EXPR_BIGINT || b->type == EXPR_BIGINT) {
+        mpz_t av, bv, r;
+        expr_to_mpz(a, av);
+        expr_to_mpz(b, bv);
+        mpz_init(r);
+        mpz_mul(r, av, bv);
+        mpz_clear(av); mpz_clear(bv);
+        Expr* res = expr_bigint_normalize(expr_new_bigint_from_mpz(r));
+        mpz_clear(r);
+        return res;
+    }
+
     if (a->type == EXPR_INTEGER && b->type == EXPR_INTEGER) {
         __int128_t res = (__int128_t)a->data.integer * b->data.integer;
-        if (res > INT64_MAX || res < INT64_MIN) return expr_new_function(expr_new_symbol("Overflow"), NULL, 0);
+        if (res > INT64_MAX || res < INT64_MIN) {
+            mpz_t av, bv, r;
+            expr_to_mpz(a, av);
+            expr_to_mpz(b, bv);
+            mpz_init(r);
+            mpz_mul(r, av, bv);
+            mpz_clear(av); mpz_clear(bv);
+            Expr* result = expr_bigint_normalize(expr_new_bigint_from_mpz(r));
+            mpz_clear(r);
+            return result;
+        }
         return expr_new_integer((int64_t)res);
     }
     int64_t n1, d1, n2, d2;
@@ -67,7 +90,7 @@ Expr* builtin_times(Expr* res) {
             free(groups); return expr_new_function(expr_new_symbol("Overflow"), NULL, 0);
         }
 
-        if (arg->type == EXPR_INTEGER || arg->type == EXPR_REAL || is_rational(arg, NULL, NULL)) {
+        if (arg->type == EXPR_INTEGER || arg->type == EXPR_REAL || arg->type == EXPR_BIGINT || is_rational(arg, NULL, NULL)) {
             Expr* next = multiply_numbers(num_prod, arg); expr_free(num_prod); num_prod = next;
         } else if (is_complex(arg, NULL, NULL) || (arg->type == EXPR_SYMBOL && strcmp(arg->data.symbol, "I") == 0)) {
             Expr* c_arg;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,7 @@
+build/
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+*_tests
+*.o

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,3 +234,8 @@ target_include_directories(parfrac_tests PRIVATE ../src)
 add_executable(polymod_tests test_polymod.c ${COMMON_SRC})
 target_include_directories(polymod_tests PRIVATE ../src)
 target_include_directories(patterns_tests PRIVATE ../src)
+
+add_executable(bigint_tests test_bigint.c ${COMMON_SRC})
+target_include_directories(bigint_tests PRIVATE ../src /opt/homebrew/include)
+target_link_directories(bigint_tests PRIVATE /opt/homebrew/lib)
+target_link_libraries(bigint_tests gmp)

--- a/tests/test_bigint.c
+++ b/tests/test_bigint.c
@@ -1,0 +1,139 @@
+#include "core.h"
+#include "expr.h"
+#include "symtab.h"
+#include "eval.h"
+#include "test_utils.h"
+#include <stdio.h>
+#include <string.h>
+#include "print.h"
+#include "parse.h"
+#include <gmp.h>
+
+void test_large_literal_parsing(void) {
+    // A number beyond INT64_MAX should parse as EXPR_BIGINT
+    Expr* e = parse_expression("99999999999999999999");
+    assert(e != NULL);
+    assert(e->type == EXPR_BIGINT);
+    char* s = expr_to_string(e);
+    assert(strcmp(s, "99999999999999999999") == 0);
+    free(s);
+    expr_free(e);
+
+    // INT64_MAX should still parse as EXPR_INTEGER
+    Expr* e2 = parse_expression("9223372036854775807");
+    assert(e2 != NULL);
+    assert(e2->type == EXPR_INTEGER);
+    expr_free(e2);
+}
+
+void test_integer_overflow_promotion(void) {
+    // INT64_MAX + 1 should auto-promote to EXPR_BIGINT
+    assert_eval_eq("Plus[9223372036854775807, 1]", "9223372036854775808", 0);
+
+    // Verify the result type is bigint
+    Expr* e = parse_expression("Plus[9223372036854775807, 1]");
+    Expr* res = evaluate(e);
+    assert(res->type == EXPR_BIGINT);
+    expr_free(e);
+    expr_free(res);
+}
+
+void test_factorial_correctness(void) {
+    // 20! = 2432902008176640000 (fits in int64)
+    assert_eval_eq("Factorial[20]", "2432902008176640000", 0);
+
+    // 21! = 51090942171709440000 (overflows int64, should be bigint)
+    assert_eval_eq("Factorial[21]", "51090942171709440000", 0);
+
+    // 100! should be a large exact integer
+    Expr* e = parse_expression("Factorial[100]");
+    Expr* res = evaluate(e);
+    assert(res->type == EXPR_BIGINT);
+    char* s = expr_to_string(res);
+    // 100! has 158 digits
+    assert(strlen(s) == 158);
+    // Should start with "9332621544"
+    assert(strncmp(s, "9332621544", 10) == 0);
+    free(s);
+    expr_free(e);
+    expr_free(res);
+}
+
+void test_large_multiplication(void) {
+    // Large * large should give exact result
+    assert_eval_eq("Times[9999999999999999999, 9999999999999999999]",
+                    "99999999999999999980000000000000000001", 0);
+}
+
+void test_integerq_bigint(void) {
+    // IntegerQ on a factorial result (bigint)
+    assert_eval_eq("IntegerQ[Factorial[100]]", "True", 0);
+    // IntegerQ on a normal integer
+    assert_eval_eq("IntegerQ[42]", "True", 0);
+    // IntegerQ on a non-integer
+    assert_eval_eq("IntegerQ[3.14]", "False", 0);
+}
+
+void test_numberq_bigint(void) {
+    assert_eval_eq("NumberQ[Factorial[100]]", "True", 0);
+}
+
+void test_numericq_bigint(void) {
+    assert_eval_eq("NumericQ[Factorial[100]]", "True", 0);
+}
+
+void test_evenq_oddq_bigint(void) {
+    // 2^100 is even
+    assert_eval_eq("EvenQ[Power[2, 100]]", "True", 0);
+    assert_eval_eq("OddQ[Power[2, 100]]", "False", 0);
+
+    // 21! is even (since it contains factor 2)
+    assert_eval_eq("EvenQ[Factorial[21]]", "True", 0);
+
+    // 3^67 is odd
+    assert_eval_eq("OddQ[Power[3, 67]]", "True", 0);
+    assert_eval_eq("EvenQ[Power[3, 67]]", "False", 0);
+}
+
+void test_bigint_printing(void) {
+    // 2^100 = 1267650600228229401496703205376 (31 digits)
+    Expr* e = parse_expression("Power[2, 100]");
+    Expr* res = evaluate(e);
+    assert(res->type == EXPR_BIGINT);
+    char* s = expr_to_string(res);
+    assert(strlen(s) == 31);
+    assert(strncmp(s, "12676506002", 11) == 0);
+    free(s);
+    expr_free(e);
+    expr_free(res);
+}
+
+void test_power_large_exponent(void) {
+    // 2^100 should be exact 31-digit number
+    assert_eval_eq("Power[2, 100]", "1267650600228229401496703205376", 0);
+}
+
+void test_abs_bigint(void) {
+    // Abs of a negative bigint literal
+    assert_eval_eq("Abs[-99999999999999999999]", "99999999999999999999", 0);
+}
+
+int main(void) {
+    symtab_init();
+    core_init();
+
+    TEST(test_large_literal_parsing);
+    TEST(test_integer_overflow_promotion);
+    TEST(test_factorial_correctness);
+    TEST(test_large_multiplication);
+    TEST(test_integerq_bigint);
+    TEST(test_numberq_bigint);
+    TEST(test_numericq_bigint);
+    TEST(test_evenq_oddq_bigint);
+    TEST(test_bigint_printing);
+    TEST(test_power_large_exponent);
+    TEST(test_abs_bigint);
+
+    printf("\nAll bigint tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Replaces machine-precision integer overflow with exact arbitrary-precision arithmetic via [libgmp](https://gmplib.org/) (`mpz_t`). Integers that exceed int64 now auto-promote to BigInt instead of returning `Overflow[]`.

- **New `EXPR_BIGINT` type** in `src/expr.h/c` — backed by `mpz_t`; full support in `expr_free`, `expr_copy`, `expr_eq`, `expr_compare` (fast-path for plain int64, exact `mpz_cmp` for mixed), `expr_hash`
- **`Plus` / `Times`** — BigInt operand branch via `mpz_add`/`mpz_mul`; int64 overflow auto-promotes to BigInt
- **`Power`** — `bigint_pow` helper via `mpz_pow_ui`; int64 base overflow promotes
- **`Factorial`** — uses `mpz_fac_ui` for n > 20; `100!` is now an exact 158-digit integer
- **`GCD`** — single-pass bigint detection; uses `mpz_gcd` when any arg is BigInt
- **Parser** — large integer literals (> 19 digits) parsed directly as `EXPR_BIGINT`
- **Predicates** — `IntegerQ`, `NumberQ`, `NumericQ`, `EvenQ`, `OddQ`, `Abs` updated for `EXPR_BIGINT`; `eval.c` and `match.c` switch statements extended

## Examples

```mathematica
100!
(* 93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000 *)

Plus[9223372036854775807, 1]   (* was Overflow[], now: 9223372036854775808 *)
Power[2, 100]                  (* 1267650600228229401496703205376 *)
IntegerQ[Factorial[100]]       (* True *)
EvenQ[Power[2, 100]]           (* True *)
```

## Test plan

- [ ] Install GMP: `brew install gmp` (macOS) or `apt install libgmp-dev` (Linux)
- [ ] `make` in repo root
- [ ] `cd tests && cmake -S . -B build -DCMAKE_C_FLAGS="-I/opt/homebrew/include" -DCMAKE_EXE_LINKER_FLAGS="-L/opt/homebrew/lib -lgmp" && cmake --build build --target bigint_tests && ./build/bigint_tests`
- [ ] Smoke test: `echo "100!" | ./picocas` → exact 158-digit integer
- [ ] Verify `Plus[9223372036854775807, 1]` no longer returns `Overflow[]`