### PR TITLE
Add graph subsystem (Graph, generators, algorithms, GraphPlot) + notebook fixes

### DIFF
--- a/Mathilda_spec.md
+++ b/Mathilda_spec.md
@@ -51,6 +51,7 @@ Each category lives in [`docs/spec/builtins/`](docs/spec/builtins/):
 | Pattern matching (`MatchQ`, `Cases`, `DeleteCases`, `Position`, `Count`, ...) | [`builtins/pattern-matching.md`](docs/spec/builtins/pattern-matching.md) |
 | File I/O (`Get`, `Put`, `PutAppend`, `>>`, `>>>`) | [`builtins/file-io.md`](docs/spec/builtins/file-io.md) |
 | Graphics (`Graphics`, `Show`, `Plot`, `Point`, `Line`, `Rectangle`, `Circle`, `Disk`, `Polygon`, `Text`, ...) | [`builtins/graphics.md`](docs/spec/builtins/graphics.md) |
+| Graphs (`Graph`, `DirectedEdge`, `UndirectedEdge`, `GraphQ`, `VertexList`, `EdgeList`, `AdjacencyMatrix`, `FindShortestPath`, `GraphPlot`, ...) | [`builtins/graphs.md`](docs/spec/builtins/graphs.md) |
 
 ## Changelog
 
@@ -68,5 +69,6 @@ Detailed feature-addition and bug-fix notes, organized by week (Mon – Sun, key
 | 2026-06-08 → 2026-06-14 | [`changelog/2026-06-08.md`](docs/spec/changelog/2026-06-08.md) |
 | 2026-06-15 → 2026-06-21 | [`changelog/2026-06-15.md`](docs/spec/changelog/2026-06-15.md) |
 | 2026-06-22 → 2026-06-28 | [`changelog/2026-06-22.md`](docs/spec/changelog/2026-06-22.md) |
+| 2026-06-29 → 2026-07-05 | [`changelog/2026-06-29.md`](docs/spec/changelog/2026-06-29.md) |
 
 New entries land in the file for the current week (use the Monday-date of that week as the filename, format `YYYY-MM-DD.md`). When a change touches a built-in's documented behavior, the corresponding `docs/spec/builtins/*.md` file is updated as well; the changelog records the rationale and timing.

--- a/docs/spec/builtins/graphs.md
+++ b/docs/spec/builtins/graphs.md
@@ -1,0 +1,162 @@
+# Graphs
+
+A graph subsystem modeled on the Wolfram Language's, implemented in
+`src/graph/` (one builtin per translation unit, mirroring `src/linalg/`).
+Graphs are ordinary `Expr` trees — there is **no new `EXPR_*` tag** — of the
+canonical form
+
+```
+Graph[ List[v1, v2, ...], List[edge1, edge2, ...] ]
+```
+
+where each edge is `DirectedEdge[u, v]` or `UndirectedEdge[u, v]`. On
+construction, `Rule`/`u -> v` is accepted as shorthand for `DirectedEdge`, and
+`TwoWayRule`/`u <-> v` for `UndirectedEdge`. Vertices are arbitrary
+expressions. Because graphs are plain expressions, generic tools (`Part`,
+`Map`, `ReplaceAll`, …) work on them, and `AdjacencyMatrix[g]` returns a dense
+`List`-of-`List`s consumable directly by `Det`, `Tr`, and `Eigenvalues`.
+
+**MVP scope (locked):** simple graphs only — no parallel edges, no self-loops,
+no edge tags, no multigraphs, no hypergraphs, and no edge/vertex weights.
+`WeightedAdjacencyMatrix` and edge weights are a documented future extension.
+
+## Graph
+A graph value.
+- `Graph[v, e]`: a graph with vertex list `v` and edge list `e`.
+- `Graph[e]`: derives the vertex set from the edges, in first-appearance order
+  (directed by default).
+
+On construction the edge list is normalized and validated, producing the
+canonical `Graph[List[verts], List[edges]]`:
+- `u -> v` (`Rule`) and `DirectedEdge[u, v]` become `DirectedEdge[u, v]`.
+- `u <-> v` (`TwoWayRule`) and `UndirectedEdge[u, v]` become
+  `UndirectedEdge[u, v]`.
+
+Malformed input is left unevaluated: self-loops, parallel/duplicate edges,
+3-argument edges, or an edge endpoint absent from an explicit vertex list.
+(Anti-parallel directed edges `u -> v` and `v -> u` are distinct and allowed.)
+
+Printing: in standard output a graph shows a terse summary,
+`Graph[<n vertices, m edges>]`. `InputForm` and `FullForm` print the literal
+constructor, which round-trips through the parser.
+
+```
+Graph[{1,2,3,4}, {1->2, 2->3, 3->4, 4->1}]   (* Graph[<4 vertices, 4 edges>] *)
+InputForm[Graph[{1,2}, {1<->2}]]              (* Graph[{1, 2}, {1 <-> 2}]      *)
+```
+
+## GraphQ
+`GraphQ[g]` gives `True` if `g` is a valid graph, and `False` otherwise. A graph
+is valid when it is the canonical `Graph[List, List]` with every edge a
+2-argument `DirectedEdge`/`UndirectedEdge`, no self-loops, no parallel edges,
+and every endpoint present in the vertex list.
+
+```
+GraphQ[Graph[{1,2}, {1->2}]]   (* True  *)
+GraphQ[Graph[{1},   {1->1}]]   (* False -- self-loop *)
+GraphQ[5]                      (* False *)
+```
+
+## Query / representation
+
+All are thin readers over the canonical form and return unevaluated on a
+non-graph argument.
+
+- `VertexList[g]` — the vertices, in canonical order.
+- `EdgeList[g]` — the edges (canonical `Directed`/`UndirectedEdge` form).
+- `VertexCount[g]` / `EdgeCount[g]` — cardinalities.
+- `AdjacencyList[g]` — `{neighbors(v1), …}` in vertex order;
+  `AdjacencyList[g, v]` — neighbors of `v`. Directed edges contribute
+  successors (`v -> u` makes `u` a neighbor of `v`); undirected edges go both
+  ways.
+- `VertexDegree[g]` / `VertexDegree[g, v]` — total degree (incident edges).
+  `VertexInDegree` / `VertexOutDegree` give in-/out-degrees: a `DirectedEdge`
+  adds to the source's out-degree and target's in-degree; an `UndirectedEdge`
+  adds to both in- and out-degree of each endpoint.
+- `DirectedGraphQ[g]` — `True` iff `g` is a valid graph whose edges are all
+  directed.
+
+```
+VertexList[Graph[{1,2,3,4},{1->2,2->3,3->4,4->1}]]   (* {1, 2, 3, 4}        *)
+EdgeCount[Graph[{1,2,3,4},{1->2,2->3,3->4,4->1}]]    (* 4                   *)
+VertexDegree[Graph[{1,2,3},{1<->2,2<->3}]]           (* {1, 2, 1}           *)
+AdjacencyList[Graph[{1,2,3},{1<->2,2<->3}], 2]       (* {1, 3}              *)
+```
+
+## Matrix views (linear-algebra interop)
+
+- `AdjacencyMatrix[g]` — the dense 0/1 adjacency matrix (`n x n`, canonical
+  vertex order), symmetric for undirected graphs. It is an ordinary matrix, so
+  `Det`, `Tr`, `Eigenvalues`, etc. apply directly.
+- `IncidenceMatrix[g]` — the `|V| x |E|` incidence matrix; undirected edges mark
+  both endpoints with `1`, directed edges are oriented (`-1` tail, `+1` head).
+- `AdjacencyGraph[m]` — the inverse of `AdjacencyMatrix`: builds a graph on
+  vertices `1..n` from a 0/1 matrix (undirected if `m` is symmetric, else
+  directed). `AdjacencyGraph[AdjacencyMatrix[g]]` reproduces `g`'s edges.
+
+```
+AdjacencyMatrix[Graph[{1,2,3,4},{1->2,2->3,3->4,4->1}]]
+    (* {{0,1,0,0},{0,0,1,0},{0,0,0,1},{1,0,0,0}} *)
+Det[AdjacencyMatrix[Graph[{1,2,3,4},{1->2,2->3,3->4,4->1}]]]   (* -1 *)
+```
+
+*A future `WeightedAdjacencyMatrix` would carry edge weights instead of 0/1;
+not implemented in the MVP.*
+
+## Generators
+
+Each builds a canonical graph (vertices `1..n`, undirected edges) via the
+constructor path:
+
+- `CompleteGraph[n]` — `K_n`, all `n(n-1)/2` edges.
+- `CycleGraph[n]` — the cycle on `1..n`.
+- `PathGraph[n]` — the path `1-2-...-n`; `PathGraph[{v1,...}]` uses the given
+  vertices.
+- `RandomGraph[{n, m}]` — a random undirected graph with `n` vertices and `m`
+  distinct edges (uses the seeded system RNG, so `SeedRandom` makes it
+  reproducible). Returns unevaluated if `m` exceeds `n(n-1)/2`.
+
+```
+EdgeCount[CompleteGraph[5]]      (* 10                        *)
+EdgeList[CycleGraph[4]]          (* {1<->2, 2<->3, 3<->4, 4<->1} *)
+VertexDegree[PathGraph[5]]       (* {1, 2, 2, 2, 1}           *)
+```
+
+## Search & computation
+
+All are unweighted and build an integer-indexed adjacency on demand.
+
+- `FindShortestPath[g, s, t]` — a shortest path from `s` to `t` as a vertex
+  list (BFS; follows edge direction for directed graphs); `{}` if `t` is
+  unreachable.
+- `GraphDistance[g, s, t]` — the length of that path; `Infinity` if unreachable.
+- `ConnectedComponents[g]` / `WeaklyConnectedComponents[g]` — components of the
+  underlying undirected graph.
+- `StronglyConnectedComponents[g]` — components following edge directions
+  (Tarjan). For undirected graphs this coincides with the weak components.
+- `FindSpanningTree[g]` — a spanning tree/forest as a graph (`VertexCount - 1`
+  edges when connected); tree edges keep their original direction.
+- `ConnectedGraphQ[g]` — `True` iff `g` is a single connected component.
+- `VertexConnectivity[g]` — the minimum number of vertices whose removal
+  disconnects `g` (`n-1` for `K_n`, `0` if already disconnected). Exact
+  brute-force over vertex subsets, intended for small graphs.
+
+```
+FindShortestPath[Graph[{1,2,3,4},{1->2,2->3,3->4}], 1, 4]   (* {1, 2, 3, 4} *)
+GraphDistance[Graph[{1,2,3,4},{1->2,2->3,3->4}], 4, 1]      (* Infinity     *)
+StronglyConnectedComponents[Graph[{1,2,3},{1->2,2->3}]]     (* {{1},{2},{3}} *)
+VertexConnectivity[CycleGraph[5]]                           (* 2            *)
+```
+
+## Visualization
+
+- `GraphPlot[g]` — a `Graphics[...]` object drawing `g`: vertices are laid out
+  on a circle (one `Disk` and one `Text` label each), edges are `Line`s. It
+  renders through the standard graphics path (a window when `USE_GRAPHICS=1`,
+  the text placeholder otherwise). Directed edges are drawn as plain lines in
+  the MVP (no arrowheads yet); a force-directed layout is a future hook.
+
+```
+Head[GraphPlot[CycleGraph[8]]]                 (* Graphics *)
+Count[GraphPlot[CompleteGraph[6]], _Line, Infinity]   (* 15 edges *)
+```

--- a/docs/spec/changelog/2026-06-29.md
+++ b/docs/spec/changelog/2026-06-29.md
@@ -1,0 +1,138 @@
+# Changelog: week of 2026-06-29 (Mon) – 2026-07-05 (Sun)
+
+Feature additions and fixes recorded during this week.
+
+## Graph subsystem: scaffolding (2026-07-01)
+
+Stood up a new `src/graph/` subsystem — the foundation for making `Graph` a
+first-class symbol with construction, query, matrix-view, generator,
+algorithm, and visualization builtins. Mirrors the `src/linalg/` layout
+(one builtin per translation unit, a `graph.h` of `builtin_*` entry points,
+and a `graph_init()` registered from `core_init()`).
+
+Phase 0 (this note) is scaffolding only:
+
+- Interned the graph symbol block in `src/sym_names.{c,h}` (`SYM_Graph`,
+  `SYM_DirectedEdge`, `SYM_UndirectedEdge`, `SYM_TwoWayRule`, and every planned
+  builtin head). `SYM_Rule` and the graphics primitives are reused.
+- Added `src/graph/graph.h` and `src/graph/graph.c` with `graph_init()` and a
+  stub `builtin_graph` that leaves `Graph[...]` unevaluated (real
+  normalization arrives in Phase 1).
+- Registered `graph_init()` in `core_init()` (`src/core.c`), added
+  `src/graph/*.c` to the makefile `SRC` list, and `-I./src/graph` to `CFLAGS`.
+- `Graph` carries `ATTR_PROTECTED` and an Information docstring.
+
+Graphs are represented as ordinary `Expr` trees
+(`Graph[List[verts...], List[edges...]]`); no new `EXPR_*` tag and no changes
+under `src/external/`. See [`docs/spec/builtins/graphs.md`](../builtins/graphs.md).
+
+## Graph subsystem: construction, normalization & printing (2026-07-01)
+
+Phase 1 makes `Graph[...]` a real value.
+
+- **`Graph`** (`src/graph/construct.c`) — normalizes edge sugar
+  (`Rule`/`->` → `DirectedEdge`, `TwoWayRule`/`<->` → `UndirectedEdge`; existing
+  `DirectedEdge`/`UndirectedEdge` pass through), derives vertices in
+  first-appearance order for `Graph[edges]`, validates, and returns the
+  canonical `Graph[List, List]`. Malformed input (self-loops, parallel edges,
+  3-arg edges, unknown endpoints) is left unevaluated; anti-parallel directed
+  edges are allowed. Reaches a fixed point (returns `NULL` when already
+  canonical).
+- **`GraphQ`** (`src/graph/graphq.c`) — validity predicate over the shared
+  `graph_is_valid` helper (`src/graph/graph_util.c`).
+- **Parser** — added `<->` → `TwoWayRule[u, v]` (precedence 120, like `Rule`),
+  matched ahead of `<>`/`<=`/`<`.
+- **Printer** — `DirectedEdge`/`UndirectedEdge` print infix as `u -> v` /
+  `u <-> v` (round-trippable); a graph shows the terse summary
+  `Graph[<n vertices, m edges>]` in standard output, with `InputForm`/`FullForm`
+  printing the literal constructor.
+- Tests: `tests/test_graph.c` (edge-sugar normalization, vertex derivation,
+  summary printing, `GraphQ` truth table, malformed-input rejection, InputForm
+  round-trip). Both builtins carry `ATTR_PROTECTED` and docstrings.
+
+## Graph subsystem: query / representation builtins (2026-07-01)
+
+Phase 2 adds readers over the canonical form (all `ATTR_PROTECTED`, all with
+docstrings, one builtin per file in `src/graph/`):
+`VertexList`, `EdgeList`, `VertexCount`, `EdgeCount`, `AdjacencyList`
+(`[g]` and `[g,v]`), `VertexDegree`/`VertexInDegree`/`VertexOutDegree`
+(`[g]` and `[g,v]`), and `DirectedGraphQ`. Degree conventions: total degree
+counts incident edges; a directed edge adds to source out-degree and target
+in-degree, an undirected edge adds to both in- and out-degree of each endpoint.
+Adjacency uses successors for directed edges. Tests extended in
+`tests/test_graph.c` (directed cycle + undirected path).
+
+## Graph subsystem: matrix views (2026-07-01)
+
+Phase 3 bridges graphs to the dense-matrix world (all `ATTR_PROTECTED`, with
+docstrings): `AdjacencyMatrix` (0/1, symmetric for undirected — a plain matrix
+consumable by `Det`/`Tr`/`Eigenvalues`), `IncidenceMatrix` (`|V|x|E|`, oriented
+for directed edges), and `AdjacencyGraph` (inverse: builds a graph on `1..n`
+from a 0/1 matrix, undirected iff symmetric). `AdjacencyGraph[AdjacencyMatrix[g]]`
+round-trips `g`'s edges. Tests cover the circulant matrix of a directed 4-cycle,
+undirected symmetry, `Det`/`Tr` interop, and both round-trips.
+
+## Graph subsystem: generators (2026-07-01)
+
+Phase 4 adds standard constructors (`src/graph/generators.c`, all
+`ATTR_PROTECTED`, with docstrings): `CompleteGraph[n]`, `CycleGraph[n]`,
+`PathGraph[n]`/`PathGraph[{v...}]`, and `RandomGraph[{n,m}]`. Each assembles a
+`Graph[...]` and lets the evaluator canonicalize/validate it. `RandomGraph`
+samples `m` distinct edges via the seeded system RNG (evaluates `RandomSample`
+over the candidate edges), so it honors `SeedRandom`; it returns unevaluated if
+`m > n(n-1)/2`. Tests cover K5 counts/degrees, cycle/path structure, explicit-
+vertex paths, and seeded determinism.
+
+## Graph subsystem: search & computation algorithms (2026-07-01)
+
+Phase 5 adds the algorithmic core over a shared integer-indexed adjacency
+builder (`graph_build_adj`/`graph_adj_free` in `src/graph/graph_util.c`, with a
+component-counting helper; documented `expr_hash` upgrade path). All
+`ATTR_PROTECTED`, with docstrings:
+- `FindShortestPath[g,s,t]` (BFS path; `{}` if unreachable) and
+  `GraphDistance[g,s,t]` (length; `Infinity` if unreachable) — directed graphs
+  follow edge direction, undirected are symmetric.
+- `ConnectedComponents` / `WeaklyConnectedComponents` (underlying undirected)
+  and `StronglyConnectedComponents` (iterative Tarjan over directed adjacency).
+- `FindSpanningTree` (BFS spanning forest as a graph; `VertexCount-1` edges when
+  connected, original edge directions preserved).
+- `ConnectedGraphQ` and `VertexConnectivity` (exact brute-force minimum vertex
+  cut; `n-1` for complete graphs, `0` if disconnected).
+Tests cover directed vs undirected distances, unreachable targets, weak vs
+strong components, spanning-tree edge counts, and known connectivity values
+(path 1, cycle 2, K4 3, disconnected 0).
+
+## Graph subsystem: visualization (2026-07-01)
+
+Phase 6 adds `GraphPlot[g]` (`src/graph/graphplot.c`, `ATTR_PROTECTED`, with
+docstring): it emits a `Graphics[...]` expression using the existing primitives
+(`Line` per edge; `Disk` + `Text` per vertex) with a circular vertex layout, so
+the existing renderer draws it with no renderer changes (window when
+`USE_GRAPHICS=1`, text placeholder otherwise). Directed edges are plain lines in
+the MVP (arrowheads and a force-directed layout are future hooks). Builds under
+both `USE_GRAPHICS=0` and `=1` (no raylib dependency in the emitter). Tests
+assert `Head` is `Graphics` and count one `Line` per edge and one `Disk` per
+vertex for `CycleGraph`/`CompleteGraph`.
+
+This completes the graph subsystem MVP (Phases 0–6): construction, queries,
+matrix views, generators, algorithms, and visualization — 30 builtins across
+`src/graph/`, all with attributes, docstrings, and tests in
+`tests/test_graph.c`.
+
+## Notebook renderer: node-link diagram support (2026-07-01)
+
+Follow-up to Phase 6. The notebook's `Graphics`→Plotly serializer
+(`src/graphics/graphics_json.c`) previously handled only `Line` and `Polygon`,
+so `GraphPlot` output rendered as a bare line (vertex `Disk`s and `Text` labels
+were silently dropped, with no equal-aspect layout). Added:
+- `Disk`/`Point` → `mode:"markers"` scatter traces (vertices),
+- `Text[label,{x,y}]` → Plotly annotations (labels),
+- "diagram mode" (triggered when `Disk`/`Text` are present): a square canvas
+  with hidden axes and `yaxis.scaleanchor:"x"` so a circular vertex layout stays
+  circular,
+- sub-1e-12 coordinate snapping so floating-point dust (e.g. `sin(pi)`) doesn't
+  blow up an auto-ranged axis.
+Function `Plot[]` output is unchanged (no `Disk`/`Text`, so it keeps the
+standard axed layout). This is the renderer change the Phase 6 plan had
+incorrectly assumed unnecessary — it verified the primitive assumption against
+the Raylib backend (`render.c`) but not the notebook serializer.

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -20,16 +20,24 @@ fn build_menu(app: &tauri::App) -> tauri::Result<Menu<tauri::Wry>> {
         ],
     )?;
 
+    // Use the PREDEFINED clipboard/undo items so the standard shortcuts
+    // (Cmd+C/X/V/A, Cmd+Z) route through the macOS responder chain to the
+    // focused text editor. Binding custom items to those accelerators would
+    // hijack the keys app-wide and break copy/paste inside cells.
     let edit = Submenu::with_items(
         app,
         "Edit",
         true,
         &[
-            &MenuItem::with_id(app, "add-cell",     "Add Cell Below",   true, Some("CmdOrCtrl+B"))?,
+            &MenuItem::with_id(app, "add-cell", "Add Cell Below", true, Some("CmdOrCtrl+B"))?,
             &PredefinedMenuItem::separator(app)?,
-            &MenuItem::with_id(app, "copy-cells",   "Copy Cell(s)",     true, Some("CmdOrCtrl+C"))?,
-            &MenuItem::with_id(app, "paste-cells",  "Paste Cell(s)",    true, Some("CmdOrCtrl+V"))?,
-            &MenuItem::with_id(app, "delete-cells", "Delete Cell(s)",   true, Some("Backspace"))?,
+            &PredefinedMenuItem::undo(app, None)?,
+            &PredefinedMenuItem::redo(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::cut(app, None)?,
+            &PredefinedMenuItem::copy(app, None)?,
+            &PredefinedMenuItem::paste(app, None)?,
+            &PredefinedMenuItem::select_all(app, None)?,
         ],
     )?;
 

--- a/frontend/src/lib/Canvas.svelte
+++ b/frontend/src/lib/Canvas.svelte
@@ -24,8 +24,95 @@
 
   // ---------------------------------------------------------------------------
   // Active notebook — the most recently clicked card renders on top (z-index)
-
   let activeNbId: string | null = null;
+
+  // ---------------------------------------------------------------------------
+  // Rubber-band selection — drag on empty canvas to select multiple notebooks
+
+  let selStart: { sx: number; sy: number } | null = null;  // screen coords
+  let selCur:   { sx: number; sy: number } | null = null;
+
+  // Compute the selection rect in screen coords for rendering
+  $: selRect = selStart && selCur ? {
+    x: Math.min(selStart.sx, selCur.sx),
+    y: Math.min(selStart.sy, selCur.sy),
+    w: Math.abs(selCur.sx - selStart.sx),
+    h: Math.abs(selCur.sy - selStart.sy),
+  } : null;
+
+  function startSelection(e: PointerEvent) {
+    selStart = { sx: e.clientX, sy: e.clientY };
+    selCur   = { sx: e.clientX, sy: e.clientY };
+    canvasState.update(s => ({ ...s, selectedIds: [] }));
+  }
+
+  function updateSelection(e: PointerEvent) {
+    if (!selStart) return;
+    selCur = { sx: e.clientX, sy: e.clientY };
+  }
+
+  function finishSelection() {
+    if (!selStart || !selCur) { selStart = selCur = null; return; }
+    const rect = canvasEl?.getBoundingClientRect() ?? { left: 0, top: 0 };
+    // Convert screen rect to world rect
+    const toWorld = (sx: number, sy: number) => ({
+      wx: (sx - rect.left - panX) / zoom,
+      wy: (sy - rect.top  - panY) / zoom,
+    });
+    const a = toWorld(selStart.sx, selStart.sy);
+    const b = toWorld(selCur.sx,   selCur.sy);
+    const minWx = Math.min(a.wx, b.wx), maxWx = Math.max(a.wx, b.wx);
+    const minWy = Math.min(a.wy, b.wy), maxWy = Math.max(a.wy, b.wy);
+    // Select notebooks whose bounding box overlaps the selection rect
+    const ids = get(canvasState).notebooks
+      .filter(nb => {
+        const h = nb.height ?? 400;
+        return nb.x < maxWx && nb.x + nb.width > minWx &&
+               nb.y < maxWy && nb.y + h > minWy;
+      })
+      .map(nb => nb.id);
+    canvasState.update(s => ({ ...s, selectedIds: ids }));
+    selStart = selCur = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group drag — when a selected notebook is dragged, move all selected ones
+
+  let groupDragActive = false;
+  let groupDragStart: { cx: number; cy: number } | null = null;
+  let groupDragOrigins: Map<string, { x: number; y: number }> = new Map();
+
+  function startGroupDrag(e: PointerEvent, nbId: string) {
+    if (!$canvasState.selectedIds.includes(nbId)) return;
+    groupDragActive = true;
+    groupDragStart  = { cx: e.clientX, cy: e.clientY };
+    groupDragOrigins = new Map(
+      $canvasState.notebooks
+        .filter(nb => $canvasState.selectedIds.includes(nb.id))
+        .map(nb => [nb.id, { x: nb.x, y: nb.y }])
+    );
+    canvasEl?.setPointerCapture(e.pointerId);
+  }
+
+  function updateGroupDrag(e: PointerEvent) {
+    if (!groupDragActive || !groupDragStart) return;
+    const dx = (e.clientX - groupDragStart.cx) / zoom;
+    const dy = (e.clientY - groupDragStart.cy) / zoom;
+    canvasState.update(s => ({
+      ...s,
+      notebooks: s.notebooks.map(nb => {
+        const origin = groupDragOrigins.get(nb.id);
+        if (!origin) return nb;
+        return { ...nb, x: origin.x + dx, y: origin.y + dy };
+      }),
+    }));
+  }
+
+  function endGroupDrag() {
+    groupDragActive = false;
+    groupDragStart  = null;
+    groupDragOrigins.clear();
+  }
 
   // ---------------------------------------------------------------------------
   // Animated display values — lerped towards store "targets" each rAF tick.
@@ -129,17 +216,35 @@
 
   function onPointerDown(e: PointerEvent) {
     if (e.button !== 0) return;
-    // Don't capture when clicking interactive elements (buttons, inputs, etc.)
-    if ((e.target as HTMLElement).closest('.nb-card, button, input, a, [role="button"]')) return;
-    dragging   = true;
-    dragStartX = e.clientX;
-    dragStartY = e.clientY;
-    dragPanX0  = targetPanX;
-    dragPanY0  = targetPanY;
+    const overCard = (e.target as HTMLElement).closest('.nb-card');
+    // Interactive elements inside cards — don't interfere
+    if ((e.target as HTMLElement).closest('button, input, a, [role="button"]')) return;
+
+    if (overCard) {
+      // Clicking a card: if it's already selected, start group drag
+      const wrapper = (e.target as HTMLElement).closest('[data-nb-id]') as HTMLElement | null;
+      if (wrapper) {
+        const nbId = wrapper.getAttribute('data-nb-id');
+        if (nbId) {
+          activeNbId = nbId;
+          if ($canvasState.selectedIds.includes(nbId)) {
+            startGroupDrag(e, nbId);
+            return;
+          }
+        }
+      }
+      return; // let NotebookCard handle normal single drag
+    }
+
+    // Empty canvas — plain drag draws a rubber-band selection rect.
+    // Two-finger pan and pinch-zoom are handled by onWheel (no pointer drag needed for pan).
+    startSelection(e);
     canvasEl.setPointerCapture(e.pointerId);
   }
 
   function onPointerMove(e: PointerEvent) {
+    if (groupDragActive) { updateGroupDrag(e); return; }
+    if (selStart) { updateSelection(e); return; }
     if (!dragging) return;
     canvasState.update(s => ({
       ...s,
@@ -149,6 +254,8 @@
   }
 
   function onPointerUp(_e: PointerEvent) {
+    if (groupDragActive) { endGroupDrag(); return; }
+    if (selStart) { finishSelection(); return; }
     dragging = false;
   }
 
@@ -287,13 +394,36 @@
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           class="nb-card-wrapper"
+          data-nb-id={nb.id}
           style="left:{nb.x}px;top:{nb.y}px;width:{nb.width}px;z-index:{activeNbId===nb.id?10:1};"
           on:pointerdown|capture={() => activeNbId = nb.id}
         >
           <NotebookCard
             {nb}
             currentZoom={zoom}
+            isSelected={$canvasState.selectedIds.includes(nb.id)}
             on:focusNotebook={(e) => setFocused(e.detail.id)}
+            on:groupMoveEnd={() => groupDragOrigins.clear()}
+            on:groupMove={(e) => {
+              const { dx, dy, originX, originY, id } = e.detail;
+              // Lazy-init origins for all other selected notebooks on first move
+              if (groupDragOrigins.size === 0) {
+                const s = get(canvasState);
+                s.notebooks
+                  .filter(n => s.selectedIds.includes(n.id) && n.id !== id)
+                  .forEach(n => groupDragOrigins.set(n.id, { x: n.x, y: n.y }));
+              }
+              canvasState.update(s => ({
+                ...s,
+                notebooks: s.notebooks.map(n => {
+                  if (!s.selectedIds.includes(n.id)) return n;
+                  if (n.id === id) return { ...n, x: originX + dx, y: originY + dy };
+                  const origin = groupDragOrigins.get(n.id);
+                  if (!origin) return n;
+                  return { ...n, x: origin.x + dx, y: origin.y + dy };
+                }),
+              }));
+            }}
           />
         </div>
       {/each}
@@ -308,6 +438,14 @@
       <span class="hint-sep">·</span>
       <span>scroll pan · pinch zoom</span>
     </div>
+
+    <!-- Rubber-band selection rectangle -->
+    {#if selRect && selRect.w > 4 && selRect.h > 4}
+      <div
+        class="sel-rect"
+        style="left:{selRect.x}px;top:{selRect.y}px;width:{selRect.w}px;height:{selRect.h}px;"
+      ></div>
+    {/if}
   </div>
 
   <!-- Minimap: click a notebook rect to jump to it -->
@@ -345,6 +483,16 @@
 
   .nb-card-wrapper {
     position: absolute;
+  }
+
+  /* Rubber-band selection rectangle */
+  .sel-rect {
+    position: absolute;
+    pointer-events: none;
+    border: 1.5px dashed var(--accent, #89b4fa);
+    background: rgba(137, 180, 250, 0.08);
+    border-radius: 4px;
+    z-index: 9999;
   }
 
   /* Canvas hints must NOT scale with Cmd+/- — use px not rem */

--- a/frontend/src/lib/CellShell.svelte
+++ b/frontend/src/lib/CellShell.svelte
@@ -443,23 +443,37 @@
   .cell-horizontal {
     display: flex;
     flex-direction: row;
-    align-items: flex-start;
+    align-items: stretch;   /* make all children fill the full cell height */
   }
   .input-pane  { flex: 1; min-width: 0; overflow: hidden; }
   .output-pane { flex: 1; min-width: 0; border-left: 1px solid var(--border, rgba(255,255,255,0.06)); }
 
   /* Draggable divider between input and output panes */
   .split-handle {
-    flex: 0 0 5px;
-    width: 5px;
+    flex: 0 0 12px;
+    width: 12px;
     cursor: col-resize;
-    background: var(--border, rgba(255,255,255,0.06));
-    transition: background 0.1s;
+    background: transparent;
     position: relative;
-    z-index: 1;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
-  .split-handle:hover, .split-handle:active {
+  /* Thin visual bar centered in the handle */
+  .split-handle::before {
+    content: '';
+    display: block;
+    width: 2px;
+    height: 48px;
+    max-height: 80%;
+    border-radius: 2px;
+    background: rgba(255,255,255,0.18);
+    transition: background 0.15s, height 0.15s;
+  }
+  .split-handle:hover::before, .split-handle:active::before {
     background: var(--accent, #89b4fa);
+    height: 60px;
   }
 
   /* CodeMirror text colour — inherits from CSS var so light/dark both work */

--- a/frontend/src/lib/Minimap.svelte
+++ b/frontend/src/lib/Minimap.svelte
@@ -60,7 +60,7 @@
       y: toMapY(nb.y),
       w: Math.max(6, nb.width * scale),
       h: Math.max(4, h * scale),
-      color: PALETTE[i % PALETTE.length],
+      color: PALETTE[parseInt(nb.id.replace('nb-', ''), 10) % PALETTE.length] ?? PALETTE[i % PALETTE.length],
       label: nb.title.slice(0, 18),
     };
   });

--- a/frontend/src/lib/NotebookCard.svelte
+++ b/frontend/src/lib/NotebookCard.svelte
@@ -44,6 +44,7 @@
   export let nb: CanvasNotebook;
   export let currentZoom: number = 1.0;
   export let focused: boolean = false;  // true when rendered full-screen
+  export let isSelected: boolean = false;
 
   // Per-notebook accent colour from the deep-space palette
   const PALETTE = ['#89b4fa','#a6e3a1','#f38ba8','#fab387','#cba6f7','#94e2d5'];
@@ -174,15 +175,21 @@
     const dyScreen = e.clientY - dragStartY;
     if (Math.abs(dxScreen) > 4 || Math.abs(dyScreen) > 4) dragMoved = true;
     const effectiveZoom = currentZoom || 1;
-    const newX = dragNbX0 + dxScreen / effectiveZoom;
-    const newY = dragNbY0 + dyScreen / effectiveZoom;
-    canvasState.update(s => ({
-      ...s,
-      notebooks: s.notebooks.map(n => n.id === nb.id ? { ...n, x: newX, y: newY } : n),
-    }));
+    const dxWorld = dxScreen / effectiveZoom;
+    const dyWorld = dyScreen / effectiveZoom;
+    if (isSelected) {
+      // Move all selected notebooks by the same world-space delta
+      dispatch('groupMove', { dx: dxWorld, dy: dyWorld, originX: dragNbX0, originY: dragNbY0, id: nb.id });
+    } else {
+      canvasState.update(s => ({
+        ...s,
+        notebooks: s.notebooks.map(n => n.id === nb.id ? { ...n, x: dragNbX0 + dxWorld, y: dragNbY0 + dyWorld } : n),
+      }));
+    }
   }
 
   function onTitlePointerUp(_e: PointerEvent) {
+    if (dragging && isSelected) dispatch('groupMoveEnd', {});
     dragging = false;
   }
 
@@ -499,6 +506,7 @@
   class:mounted
   class:collapsed={nb.collapsed}
   class:focused-card={focused}
+  class:selected={isSelected}
   style="--accent: {accentColor}; --accent-glow: {accentColor}1a;"
   bind:this={cardEl}
   tabindex="-1"
@@ -713,6 +721,13 @@
   .nb-card.mounted {
     opacity: 1;
     transform: scale(1);
+  }
+
+  /* Multi-selected via rubber-band */
+  .nb-card.selected {
+    outline: 2px solid var(--accent, #89b4fa);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(137,180,250,0.18), 0 8px 32px rgba(0,0,0,0.45);
   }
 
   /* Full-screen focused mode — edge to edge, no card chrome */

--- a/frontend/src/lib/canvas.ts
+++ b/frontend/src/lib/canvas.ts
@@ -53,11 +53,12 @@ const _nb7 = makeCard('Special Functions',  750,1650);
 const _nb8 = makeCard('Applied Math',      1430,1650);
 
 export const canvasState = writable({
-  notebooks: [_nb1,_nb2,_nb3,_nb4,_nb5,_nb6,_nb7,_nb8] as CanvasNotebook[],
-  panX: 0,
-  panY: 0,
-  zoom:  1.0,
-  focusedId: null as string | null,
+  notebooks:    [_nb1,_nb2,_nb3,_nb4,_nb5,_nb6,_nb7,_nb8] as CanvasNotebook[],
+  panX:         0,
+  panY:         0,
+  zoom:         1.0,
+  focusedId:    null as string | null,
+  selectedIds:  [] as string[],   // IDs of notebooks selected by rubber-band
 });
 
 /** Pre-fill the starter notebooks with rich example cells. Call from onMount. */
@@ -320,10 +321,12 @@ export function loadLibraryData(json: string): string {
   });
   // Reset nextId past the highest id in the file to avoid collisions
   canvasState.set({
-    notebooks: notebooks.length > 0 ? notebooks : [makeCard('Notebook 1', 60, 60)],
-    panX: 0,
-    panY: 0,
-    zoom: 1.0,
+    notebooks:   notebooks.length > 0 ? notebooks : [makeCard('Notebook 1', 60, 60)],
+    panX:        0,
+    panY:        0,
+    zoom:        1.0,
+    focusedId:   null,
+    selectedIds: [],
   });
   return data.title ?? 'Untitled Library';
 }

--- a/graph-plan.md
+++ b/graph-plan.md
@@ -1,0 +1,468 @@
+# Graph Subsystem Implementation Plan
+
+> Making `Graph` a first-class symbol in Mathilda, with construction,
+> query/representation, search, computation, and visualization builtins.
+> Grounded in `graphs-research.md` (cross-system survey, 2026-07-01) and verified
+> against the current codebase (`src/linalg/`, `src/core.c`, `src/sym_names.c`,
+> `src/print.c`, `src/graphics/`, `makefile`).
+
+## Overview
+
+Add a new `src/graph/` subsystem — mirroring `src/linalg/` exactly (per-builtin
+`.c` files, a `graph.h` of `builtin_*` entry points, a `graph_init()` registered
+in `core_init()`) — that implements graphs as ordinary `Expr` trees:
+
+```
+Graph[ List[v1, v2, ...], List[edge1, edge2, ...] ]
+```
+
+Edges are `DirectedEdge[u,v]` / `UndirectedEdge[u,v]`, with `Rule`/`u->v` and
+`TwoWayRule`/`u<->v` accepted as parse-time sugar and normalized on construction.
+Vertices are arbitrary expressions. **No new `EXPR_*` tag** and **no changes to
+`src/external/`**.
+
+## Current State Analysis
+
+- **No graph subsystem exists.** No `Graph`, `DirectedEdge`, `VertexList`, etc.
+- **The mirror target is concrete.** `src/linalg/linalg.h:8-30` declares
+  `Expr* builtin_*(Expr*)` entry points + `void linalg_init(void)`;
+  `src/linalg/linalg.c:17-54` registers each with `symtab_add_builtin` +
+  `attributes |= ATTR_PROTECTED` + (should) a docstring. Per-builtin `.c` files
+  (`det.c`, `dot.c`, …) hold one builtin each.
+- **Init hub.** `core_init()` in `src/core.c` calls every subsystem `*_init()`;
+  the graphics block at `src/core.c:642-643` uses a local `void graphics_init(void);`
+  forward-declare + call. We follow the same idiom for `graph_init()`.
+- **Symbol interning.** `src/sym_names.c:1164` interns `SYM_Graphics` etc.;
+  `src/sym_names.h:569` externs them. `SYM_Rule` already exists
+  (`sym_names.h:396`).
+- **Matrices are dense List-of-Lists.** `get_tensor_dims` / `flatten_tensor`
+  (`src/linalg/linalg.h:34-35`) parse them; `Q`-predicates return
+  `expr_new_symbol(SYM_True/SYM_False)` (e.g. `src/linalg/negdef_q.c:187`). We
+  reuse this representation for `AdjacencyMatrix` so it interoperates with `Det`,
+  `Eigenvalues`, `Tr` immediately.
+- **Printer.** `src/print.c:475` renders `SYM_Rule` as `" -> "`. We add
+  `DirectedEdge`→`" -> "`, `UndirectedEdge`→`" <-> "`, and a terse `Graph[...]`
+  summary form.
+- **Visualization precedent.** `src/graphics/plot.c:803 builtin_plot` builds a
+  `Graphics[...]` expression from primitives (`Point`, `Line`, `Circle`, `Text`)
+  and returns it for `render.c` to draw. `GraphPlot` emits the same primitives —
+  **no renderer changes needed.**
+- **⚠ Makefile is not recursive.** `makefile:125` enumerates each source subdir
+  in `SRC`. `src/graph/*.c` **must** be added there or new files are silently
+  ignored.
+
+## Desired End State
+
+A user in the REPL can:
+
+```
+g = Graph[{1,2,3,4}, {1->2, 2->3, 3->4, 4->1}]   (* prints as a terse summary *)
+GraphQ[g]                    -> True
+VertexList[g]                -> {1, 2, 3, 4}
+EdgeList[g]                  -> {1 -> 2, 2 -> 3, 3 -> 4, 4 -> 1}
+VertexCount[g]               -> 4
+EdgeCount[g]                 -> 4
+VertexDegree[g, 1]           -> 2
+AdjacencyMatrix[g]           -> {{0,1,0,0},{0,0,1,0},{0,0,0,1},{1,0,0,0}}
+Eigenvalues[AdjacencyMatrix[g]]   (* reuses linalg unchanged *)
+FindShortestPath[g, 1, 4]    -> {1, 2, 3, 4}
+GraphDistance[g, 1, 4]       -> 3
+ConnectedComponents[g]       -> {{1, 2, 3, 4}}
+CompleteGraph[4]             -> Graph[...]
+GraphPlot[g]                 -> Graphics[...]  (renders when USE_GRAPHICS=1)
+```
+
+Verified by: clean `-std=c99 -Wall -Wextra` build, a new `tests/graph_tests.c`
+suite passing, valgrind-clean under `valgrind --leak-check=full`, and docs in
+sync.
+
+### Key Discoveries
+- `src/linalg/linalg.c:17-54` — exact registration idiom to copy.
+- `src/core.c:642-643` — forward-declare-and-call idiom for a new `*_init()`.
+- `src/sym_names.c:1164` / `sym_names.h:569` — where to intern/extern new symbols.
+- `makefile:125` — the `SRC` wildcard line that must gain `$(SRC_DIR)/graph/*.c`.
+- `src/print.c:475` — where edge/arrow printing plugs in.
+- `src/graphics/plot.c:803` — `Graphics[...]`-emitting builtin precedent for `GraphPlot`.
+
+## Locked Decisions (resolving graphs-research.md §4.4 / §6)
+
+1. **Multigraphs & loops: forbidden in MVP** (Maxima minimal-viable point).
+   `GraphQ` rejects parallel edges and self-loops. The 3-arg edge form
+   `DirectedEdge[u,v,tag]` is **reserved** for a future `EdgeTaggedGraph`; not
+   implemented now.
+2. **`AdjacencyMatrix` returns a dense linalg List-of-Lists** (0/1, symmetric for
+   undirected). `WeightedAdjacencyMatrix` is a **later** addition, not MVP.
+3. **Internal storage: canonical edge `List`, adjacency derived on demand.** A
+   shared `graph_util.c` builds an integer-indexed adjacency structure (vertex →
+   index via linear `expr_eq` scan for MVP; `expr_hash` map is the documented
+   upgrade path) that all algorithms consume. Graphs stay plain, inspectable
+   `Expr` trees (not opaque atoms).
+4. **Printer: terse summary by default** — `Graph[<|V| vertices, |E| edges|>]`
+   style — with `InputForm[g]` printing the round-trippable literal constructor.
+5. **Hypergraphs: out of scope** (research found only negative results). Not
+   implemented.
+
+## What We're NOT Doing
+
+- No multigraphs, no loops, no `EdgeTaggedGraph`, no hypergraphs.
+- No `WeightedAdjacencyMatrix` / edge weights / vertex weights in MVP (Phase 3
+  leaves a documented hook).
+- No opaque/atomic graph object; no `AtomQ[g] == True`.
+- No changes to `src/external/`, the evaluator core, or the graphics renderer.
+- No new sparse-array type; matrices reuse dense List-of-Lists.
+- No `ChromaticNumber`/coloring or `FindMaximumFlow` in the first pass — deferred
+  to Phase 6 as stretch (see phase notes).
+
+## Implementation Approach
+
+Six incremental phases, each independently buildable, testable, and
+valgrind-clean. Phases 0–2 establish the type and its representation; Phase 3
+adds matrix interop; Phase 4 adds generators; Phase 5 is the algorithm core
+(built on one shared adjacency helper so every algorithm shares vertex-indexing
+and BFS/DFS scaffolding); Phase 6 is visualization. Each builtin gets a
+docstring, attributes, a `docs/spec/builtins/graphs.md` entry, and a changelog
+note in `docs/spec/changelog/2026-06-29.md`.
+
+---
+
+## Phase 0: Scaffolding
+
+### Overview
+Stand up the empty subsystem so a trivial `Graph` builtin registers and the build
+picks up `src/graph/`.
+
+### Changes Required
+
+#### 1. Symbol interning
+**Files**: `src/sym_names.h`, `src/sym_names.c`
+Add externs + `intern_symbol` calls (next to the `SYM_Graphics` block):
+`SYM_Graph`, `SYM_DirectedEdge`, `SYM_UndirectedEdge`, `SYM_TwoWayRule`,
+`SYM_GraphQ`, `SYM_VertexList`, `SYM_EdgeList`, and the remaining builtin heads.
+(`SYM_Rule` already exists.)
+
+#### 2. Subsystem header + init
+**Files**: `src/graph/graph.h` (new), `src/graph/graph.c` (new)
+Mirror `src/linalg/linalg.h`: `#include "expr.h"`, declare every
+`Expr* builtin_*(Expr* res);` and `void graph_init(void);`. `graph.c` holds
+`graph_init()` (registrations + attributes + docstrings) and, for Phase 0, a
+stub `builtin_graph` that just returns `NULL`.
+
+```c
+/* src/graph/graph.c */
+#include "graph.h"
+#include "symtab.h"
+#include "attr.h"
+void graph_init(void) {
+    symtab_add_builtin("Graph", builtin_graph);
+    symtab_get_def("Graph")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("Graph",
+        "Graph[v,e] represents a graph with vertices v and edges e.");
+}
+```
+
+#### 3. Register in core_init
+**File**: `src/core.c` (near line 642, next to `graphics_init`)
+```c
+void graph_init(void); graph_init();
+```
+
+#### 4. Makefile
+**File**: `makefile:125` — append to the `SRC` wildcard list:
+```
+$(wildcard $(SRC_DIR)/graph/*.c)
+```
+
+#### 5. Docs skeleton
+**Files**: `docs/spec/builtins/graphs.md` (new), `Mathilda_spec.md` (add a table
+row linking to it), `docs/spec/changelog/2026-06-29.md` (create with the
+`# Changelog: week of ...` heading if absent; add a "Graph subsystem: scaffolding"
+note).
+
+### Success Criteria
+
+#### Automated
+- [x] Clean build: `make -j$(nproc)` with `-std=c99 -Wall -Wextra`, no warnings.
+- [x] `echo '?Graph' | ./Mathilda` prints the docstring. (Verified via `Information[Graph]` over the REPL's non-TTY JSON protocol.)
+- [x] `src/graph/*.c` objects appear in the build (grep the link line / `ls src/graph/*.o`).
+
+#### Manual
+- [x] `Graph[{1,2},{1->2}]` returns unevaluated (stub) without crashing. (Confirmed in the notebook: returns the unevaluated `Graph[...]`, no crash.)
+
+**Pause for confirmation before Phase 1.**
+
+---
+
+## Phase 1: Construction, Normalization & Printing
+
+### Overview
+Make `Graph[...]` a real value: normalize edge sugar, validate, canonicalize, and
+print. Add `GraphQ`.
+
+### Changes Required
+
+#### 1. `builtin_graph` — normalize & canonicalize
+**File**: `src/graph/construct.c` (new)
+- Accept `Graph[edges]` (derive vertex set from edges, **directed by default** per
+  Wolfram) and `Graph[verts, edges]`.
+- Normalize each edge: `Rule[u,v]`/`u->v` → `DirectedEdge[u,v]`;
+  `TwoWayRule[u,v]`/`u<->v` → `UndirectedEdge[u,v]`; pass through existing
+  `DirectedEdge`/`UndirectedEdge`.
+- Reject (return `NULL`, leave unevaluated) on: 3-arg edges, self-loops, parallel
+  edges, or an edge endpoint not in an explicit vertex list.
+- Produce canonical `Graph[List[verts], List[normalized edges]]` with vertices in
+  first-appearance order. Ownership: build new tree, NULL-out reused sub-exprs
+  before the evaluator frees `res` (SPEC §4).
+
+#### 2. `builtin_graph_q` — GraphQ predicate
+**File**: `src/graph/graphq.c` (new)
+Returns `SYM_True` iff the arg is a canonical `Graph[List, List]` with all edges
+`DirectedEdge`/`UndirectedEdge`, no loops, no duplicates; else `SYM_False`.
+Shared validator `graph_is_valid(Expr*)` lives in `graph_util.c` and is reused by
+every algorithm as a guard.
+
+#### 3. Printer
+**File**: `src/print.c` (near line 475)
+- `DirectedEdge` → `" -> "`, `UndirectedEdge` → `" <-> "` (infix, precedence like
+  `Rule`).
+- `Graph[List v, List e]` → terse `Graph[<n vertices, m edges>]` in standard
+  output; `InputForm`/`FullForm` print the literal constructor (round-trippable).
+
+### Success Criteria
+
+#### Automated
+- [x] `tests/graph_tests.c` (new, wired into CMake like other `*_tests`) covers:
+  normalization of all four edge sugars, vertex derivation, loop/duplicate
+  rejection, `GraphQ` True/False cases. (`tests/test_graph.c`, all pass.)
+- [x] `GraphQ[Graph[{1,2},{1->2}]]` → `True`; `GraphQ[Graph[{1},{1->1}]]` →
+  `False` (loop); `GraphQ[5]` → `False`.
+- [x] `InputForm[Graph[{1,2},{1<->2}]]` round-trips through the parser to an
+  equal expression.
+- [~] valgrind-clean — valgrind unavailable on this Mac (Darwin ARM64);
+  substituting AddressSanitizer on the graph suite.
+
+#### Manual
+- [x] REPL: `Graph[{1,2,3},{1->2,2->3}]` prints the terse summary. (Verified:
+  `Graph[<3 vertices, 2 edges>]`.)
+
+---
+
+## Phase 2: Query / Representation Builtins
+
+### Overview
+Extract structure back out of a graph.
+
+### Changes Required
+**Files** (one `.c` each in `src/graph/`): `vertexlist.c`, `edgelist.c`,
+`counts.c` (`VertexCount`, `EdgeCount`), `adjlist.c` (`AdjacencyList`),
+`degree.c` (`VertexDegree`, plus `VertexInDegree`/`VertexOutDegree` for directed),
+`directedq.c` (`DirectedGraphQ`).
+
+All are thin readers over the canonical form, guarded by `graph_is_valid`. For
+directed graphs, degree/adjacency respect edge direction; for undirected,
+symmetric.
+
+### Success Criteria
+
+#### Automated
+- [x] `VertexList`/`EdgeList` return the canonical lists in order.
+- [x] `VertexCount`/`EdgeCount` return correct integers.
+- [x] `VertexDegree[g,v]`, in/out-degree correct for a known directed example.
+- [x] `DirectedGraphQ` distinguishes directed vs undirected.
+- [x] Tests pass (valgrind->ASan; see final).
+
+#### Manual
+- [x] Spot-check `AdjacencyList` on a small mixed example matches hand computation.
+
+**Pause for confirmation.**
+
+---
+
+## Phase 3: Matrix Views (linalg interop)
+
+### Overview
+Bridge graphs to the existing dense-matrix world.
+
+### Changes Required
+**Files**: `src/graph/adjmat.c` (`AdjacencyMatrix`), `src/graph/incmat.c`
+(`IncidenceMatrix`), `src/graph/adjgraph.c` (`AdjacencyGraph` — inverse of
+`AdjacencyMatrix`, round-trips a 0/1 matrix back to a `Graph`).
+
+- `AdjacencyMatrix[g]` → dense List-of-Lists of 0/1 (counts always 1 since no
+  multiedges); **symmetric** for undirected. Result is a normal matrix consumable
+  by `Det`, `Tr`, `Eigenvalues` with zero linalg changes.
+- Leave a clearly-commented hook for a future `WeightedAdjacencyMatrix` (not
+  implemented — see Locked Decision 2).
+
+### Success Criteria
+
+#### Automated
+- [x] `AdjacencyMatrix` of a directed 4-cycle equals the known circulant 0/1 matrix.
+- [x] `Det`/`Tr`[AdjacencyMatrix[g]] run unchanged (linalg interop).
+- [x] `AdjacencyGraph[AdjacencyMatrix[g]]` reproduces `g`'s edges (round-trip).
+- [x] Tests pass (valgrind->ASan; see final).
+
+#### Manual
+- [x] Undirected graph yields a symmetric matrix; directed does not.
+
+**Pause for confirmation.**
+
+---
+
+## Phase 4: Graph Generators
+
+### Overview
+Standard constructors.
+
+### Changes Required
+**Files**: `src/graph/generators.c` (or one file each): `CompleteGraph[n]`,
+`CycleGraph[n]`, `PathGraph[n]` / `PathGraph[{v...}]`, `RandomGraph[{n,m}]`
+(reuse the existing RNG used by `random_init` / `RandomInteger`). Each builds a
+canonical `Graph` via the Phase 1 constructor path (so validation/canonicalization
+is shared, not duplicated).
+
+### Success Criteria
+
+#### Automated
+- [x] `VertexCount[CompleteGraph[5]]` → 5, `EdgeCount` → 10 (undirected K5).
+- [x] `CycleGraph[n]`/`PathGraph[n]` have correct counts and degrees.
+- [x] `RandomGraph[{n,m}]` yields exactly `m` distinct non-loop edges; deterministic
+  under `SeedRandom`.
+- [x] Tests pass (valgrind->ASan; see final).
+
+#### Manual
+- [ ] `GraphPlot` (Phase 6) of `CompleteGraph[6]` looks correct.
+
+**Pause for confirmation.**
+
+---
+
+## Phase 5: Search & Computation Algorithms
+
+### Overview
+The algorithmic core. All algorithms share one internal adjacency builder in
+`graph_util.c`.
+
+### Changes Required
+
+#### 1. Shared adjacency scaffolding
+**File**: `src/graph/graph_util.c` (extend)
+`graph_to_adj(Expr* g, ...)` → integer-indexed CSR-ish adjacency (vertex list +
+per-vertex neighbor index arrays), plus index↔vertex maps. Vertex→index via
+linear `expr_eq` scan for MVP (documented `expr_hash` upgrade path). Provide
+internal `bfs`/`dfs` helpers used by multiple algorithms. Careful manual memory
+management; freed by the caller.
+
+#### 2. Algorithms (one `.c` each)
+- `shortestpath.c` — `FindShortestPath[g,s,t]` (returns the **path** as a vertex
+  list; BFS for unweighted) and `GraphDistance[g,s,t]` (returns the **length**).
+  Keep Wolfram's path-vs-length naming split.
+- `components.c` — `ConnectedComponents`, `WeaklyConnectedComponents`,
+  `StronglyConnectedComponents` (Tarjan/Kosaraju for directed).
+- `spanningtree.c` — `FindSpanningTree` (BFS/DFS tree for unweighted MST).
+- `connectivity.c` — `VertexConnectivity` (and `ConnectedGraphQ`).
+
+**Stretch (same phase, if time permits, else defer):** `FindMaximumFlow`
+(Edmonds–Karp), matching (`FindIndependentEdgeSet`), `ChromaticNumber`/greedy
+coloring. Explicitly optional; not required for phase completion.
+
+### Success Criteria
+
+#### Automated
+- [x] `FindShortestPath` returns a valid shortest path; `GraphDistance` returns
+  its length, on directed and undirected examples with known answers.
+- [x] Unreachable target: `GraphDistance` → `Infinity`, `FindShortestPath` → `{}`.
+- [x] `ConnectedComponents` partitions vertices correctly; strong vs weak differ
+  on a known directed example.
+- [x] `FindSpanningTree` has `VertexCount - 1` edges on a connected graph.
+- [x] Tests pass on all algorithm paths incl. the adjacency builder (valgrind->ASan; see final).
+
+#### Manual
+- [x] Cross-checked known small/medium examples (cycles, complete graphs, paths).
+
+**Pause for confirmation.**
+
+---
+
+## Phase 6: Visualization (`GraphPlot`)
+
+### Overview
+Render a graph by emitting a `Graphics[...]` expression — reusing the existing
+graphics primitives and renderer with **no renderer changes**.
+
+### Changes Required
+**File**: `src/graph/graphplot.c`
+- `GraphPlot[g]` computes 2-D vertex coordinates (MVP: circular layout — vertices
+  evenly on a circle; documented hook for a force-directed spring layout later),
+  then builds a `Graphics[{ Line[{p_u,p_v}] per edge, Disk[p_v]/Point per vertex,
+  Text[label] per vertex }]` exactly as `src/graphics/plot.c:803 builtin_plot`
+  builds its `Graphics` tree. Return that expression; `render.c` draws it when
+  `USE_GRAPHICS=1`, or the text placeholder otherwise (graceful-degrade policy).
+- Directed edges: draw with an arrowhead primitive if available, else a plain line
+  with a documented limitation.
+
+### Success Criteria
+
+#### Automated
+- [x] `Head[GraphPlot[g]]` → `Graphics`.
+- [x] The emitted `Graphics` contains one Line per edge and one Disk per vertex
+  (asserted via Count[...,_Line/_Disk,Infinity]).
+- [x] Builds and tests pass with both `USE_GRAPHICS=0` and `=1` (emitter has no raylib dep).
+- [x] Memory-clean under ASan (valgrind unavailable on Darwin ARM64).
+
+#### Manual
+- [ ] `GraphPlot[CompleteGraph[6]]` and `GraphPlot[CycleGraph[8]]` render a
+  recognizable figure with `USE_GRAPHICS=1` (raylib installed; awaiting your visual check).
+
+**Pause for confirmation.**
+
+---
+
+## Testing Strategy
+
+### Unit tests (`tests/graph_tests.c`, wired into CMake alongside existing suites)
+- Construction/normalization: all four edge sugars, vertex derivation, directed
+  default, loop/duplicate/3-arg rejection.
+- `GraphQ` / `DirectedGraphQ` truth tables.
+- Query builtins vs hand-computed small examples.
+- `AdjacencyMatrix` symmetry (undirected) and round-trip via `AdjacencyGraph`.
+- Generators: exact vertex/edge counts and degrees.
+- Algorithms: shortest path/distance (incl. unreachable), components (weak vs
+  strong), spanning tree edge count.
+- `GraphPlot` structural assertions under both graphics settings.
+
+### Integration
+- `AdjacencyMatrix` feeding `Eigenvalues`/`Det`/`Tr` unchanged.
+- `InputForm` round-trip through the parser.
+
+### Manual
+1. REPL walk-through of the Desired End State examples.
+2. Visual check of `GraphPlot` on `CompleteGraph`/`CycleGraph` with graphics on.
+3. `valgrind --leak-check=full ./Mathilda` over a scripted graph session.
+
+## Performance Considerations
+- MVP vertex→index is a linear `expr_eq` scan (O(V) per lookup, O(V·E) build) —
+  fine for pico-CAS sizes; documented `expr_hash`-map upgrade path (codebase
+  already has `expr_hash`) for larger graphs.
+- Adjacency derived on demand per algorithm call; acceptable for the MVP, cache
+  later if profiling warrants.
+- BFS/DFS are shared in `graph_util.c` to avoid per-algorithm duplication.
+
+## Documentation & Workflow Obligations (CLAUDE.md / SPEC.md §10)
+- Every builtin: `symtab_set_docstring`, attributes in `graph_init()`, an entry
+  in `docs/spec/builtins/graphs.md`, a note in
+  `docs/spec/changelog/2026-06-29.md` (Monday of the current ISO week).
+- New internal symbols in `src/sym_names.c` (+ externs in `sym_names.h`).
+- Add the `graphs.md` row to `Mathilda_spec.md` and a changelog-table row for the
+  weekly file.
+- SPEC §4 ownership contract on every builtin; valgrind each phase.
+- Commit as Michael Sollami; no AI/Claude attribution (global CLAUDE.md).
+
+## References
+- Research: `graphs-research.md` (esp. §4 recommended design, §4.4 decisions).
+- Mirror pattern: `src/linalg/linalg.h:8-30`, `src/linalg/linalg.c:17-54`.
+- Init hub: `src/core.c:642-643`.
+- Symbols: `src/sym_names.c:1164`, `src/sym_names.h:569`.
+- Build: `makefile:125` (`SRC` wildcard — must add `src/graph/*.c`).
+- Printer: `src/print.c:475`.
+- Visualization precedent: `src/graphics/plot.c:803`.
+- Contributor workflow / standards: `CLAUDE.md`, `SPEC.md`.

--- a/graphs-research.md
+++ b/graphs-research.md
@@ -1,0 +1,355 @@
+# Graphs, Hypergraphs & Networks — Cross-System Research
+
+*Research report to inform adding a graph-theory subsystem to Mathilda (a pico
+Mathematica clone in C99). Compiled 2026-07-01. All external claims below
+survived 3-vote adversarial verification (25/25 confirmed, 0 refuted).*
+
+---
+
+## 1. Executive Summary
+
+Across every surveyed system a graph is fundamentally **an adjacency structure
+over a vertex set plus an edge collection**, but the systems split into two
+design camps:
+
+1. **Atomic / opaque graph objects** with rich attribute properties — Wolfram's
+   `Graph` head (`AtomQ` returns `True`), SageMath's backend-selectable
+   `DiGraph`.
+2. **Explicitly exposed data structures** — NetworkX's dict-of-dicts-of-dicts,
+   Maxima's Lisp adjacency lists, igraph's edge-list-plus-metadata.
+
+Directed / undirected / mixed / weighted variants are universally handled either
+through **constructor flags** (SageMath `loops`/`multiedges`/`weighted`; Wolfram
+`DirectedEdges->False`) or **distinct classes** (NetworkX
+`Graph`/`DiGraph`/`MultiGraph`/`MultiDiGraph`). Undirected edges are consistently
+modeled as **two opposing directed edges**, yielding symmetric adjacency
+matrices.
+
+**Multigraph (parallel-edge) support is the key design differentiator.** Wolfram
+needs `EdgeTaggedGraph` with unique per-edge tags because a plain `Graph` cannot
+distinguish parallel edges; NetworkX adds a fourth dict level keyed by edge key;
+Maxima supports neither multi-edges nor loops.
+
+The expected algorithm surface is **broad and largely uniform** across systems
+(shortest paths incl. named Dijkstra / Bellman-Ford / all-pairs, connectivity /
+strong components, max flow, matching, coloring, MST) — signaling that a CAS
+graph subsystem is expected to expose **distinct named algorithms**, not a single
+generic dispatcher.
+
+**For Mathilda:** the idiomatic representation is a `Graph[vertexList, edgeList]`
+head where edges are `DirectedEdge[u,v]` / `UndirectedEdge[u,v]` (or
+`Rule` / `TwoWayRule`), implemented as a new `src/graph/` subsystem mirroring
+`src/linalg/` (per-builtin `.c` files, a `graph.h` of `builtin_*` entry points, a
+`graph_init()` registered in `core_init()`), reusing the existing `Expr` tagged
+union and List-of-Rules convention, with **no changes** to `src/external/`.
+
+---
+
+## 2. Per-System Findings
+
+### 2.1 Wolfram Language (Mathilda's primary model)
+
+**Representation — atomic, canonical, attribute-carrying.** A Wolfram `Graph` is
+an *atomic raw object* (`AtomQ` → `True`), always normalized to a canonical
+standard form `Graph[vertices, edges, ...]`. It carries vertex properties
+(`VertexLabels`, `VertexCoordinates`, `VertexWeight`, `VertexStyle`) and edge
+properties (`EdgeLabels`, `EdgeStyle`, `EdgeWeight`). Constructed via `Graph`,
+`CompleteGraph`, `RandomGraph`, `AdjacencyGraph`, `GraphData`.
+`[confidence: high · 3-0]`
+
+**Edge syntax.** `Graph[{e1,...}]` builds from edges; `Graph[{v1,...},{e1,...}]`
+adds explicit vertices.
+- Directed: `u -> v` / `DirectedEdge[u,v]` / `Rule[u,v]`
+- Undirected: `u <-> v` / `UndirectedEdge[u,v]` / `TwoWayRule[u,v]`
+
+By default a **directed** graph is generated from a list of rules;
+`DirectedEdges->False` reinterprets them as undirected. **Mixed graphs** (a
+collection of both directed and undirected edges) are supported. `[3-0]`
+
+**Multiple interchangeable views of one graph.** Matrix forms
+(`AdjacencyMatrix`, `IncidenceMatrix`, `KirchhoffMatrix`,
+`WeightedAdjacencyMatrix`) and list forms (`VertexList`, `EdgeList`,
+`AdjacencyList`, `IncidenceList`, `EdgeRules`) coexist, and `AdjacencyGraph[amat]`
+round-trips a matrix back to a graph. `[3-0]`
+
+**Adjacency matrix semantics.** Entry `a_ij` is the *number* of directed edges
+from vertex `i` to vertex `j`. An undirected edge = two opposing directed edges
+⇒ **symmetric** matrix; directed graphs may be unsymmetric; multigraph
+multiplicities appear as integer counts `> 1`. Wolfram returns a `SparseArray`
+convertible via `Normal`. `AdjacencyMatrix` ignores weights —
+`WeightedAdjacencyMatrix` handles those. `[3-0]`
+
+**Weights & parallel edges.** `VertexWeight` / `EdgeWeight` accept any numeric or
+symbolic expression. **Parallel edges are indistinguishable in a plain `Graph`**;
+`EdgeTaggedGraph` assigns unique (auto-generated integer or user-supplied) tags,
+making parallel edges individually identifiable and annotatable. This is the
+central multigraph-identity decision. `[3-0]`
+
+**Algorithms (core, current API).** `FindShortestPath` (returns the *path*),
+`GraphDistance` (returns the *length*), `ConnectedComponents`,
+`FindMaximumFlow`, `BreadthFirstScan`, `GraphUnion`. Note the useful naming split
+between path-returning and length-returning functions. `[3-0]`
+
+**Legacy `Combinatorica`.** As of Wolfram v10, most `Combinatorica` functionality
+is built into the core system — the package is **obsolete**. Historically it
+offered both a generic `ShortestPath` dispatcher (with an `Algorithm` option) and
+distinct named implementations (`Dijkstra`, `BellmanFord`,
+`AllPairsShortestPath`), plus `NetworkFlow`, `ResidualFlowGraph`,
+`BipartiteMatching`, `MaximalMatching`, `StableMarriage`. This shows a generic
+entry point and named algorithms can coexist. `[3-0]`
+
+### 2.2 NetworkX (canonical exposed adjacency structure)
+
+**Dict-of-dicts-of-dicts.** Graphs are an explicit nested dictionary: outer keyed
+by node, inner by neighbor, innermost = the edge-attribute dict. `G[u][v]`
+returns the edge attribute dictionary itself. Chosen over lists (for fast sparse
+lookup) and sets (so data can be attached to an edge); edges are found/removed in
+two dict look-ups. `[3-0]`
+
+**Four classes via `Di` + `Multi` prefixes:** `Graph`, `DiGraph`, `MultiGraph`,
+`MultiDiGraph`. `DiGraph` keeps **separate successor (`G.succ`) and predecessor
+(`G.pred`)** structures (giving O(1) in-degree). `MultiGraph`/`MultiDiGraph` add a
+**fourth dict level keyed by an edge key**. This is the class-per-variant
+alternative to Wolfram's single-head-with-flags design. `[3-0]`
+
+### 2.3 Maxima `graphs` package (minimal-viable design point)
+
+Graphs are represented internally by **adjacency lists implemented as Lisp
+structures**; edges/arcs are lists of length 2; vertices are integer ids. It
+supports **simple undirected graphs and digraphs only** — explicitly **no
+multiple edges, no loops, no hypergraphs**. A digraph may hold both `u->v` and
+`v->u` without those counting as duplicates.
+
+Algorithm suite: `shortest_path`, `shortest_weighted_path`,
+`connected_components`, `strong_components`, `vertex_connectivity`,
+`min_vertex_cut`, `max_flow`, `max_matching`, `chromatic_number`,
+`minimum_spanning_tree`. `[3-0]`
+
+This (**integer-id vertices + length-2 edge lists + simple-graph-only**) is the
+closest analog to what a pico-CAS would ship first.
+
+### 2.4 SageMath (mature, backend-selectable)
+
+`DiGraph` defaults to **simple** (no loops, no multiedges) and **unweighted**,
+tuned by separate `loops` / `multiedges` / `weighted` flags. Construction
+**auto-detects** many input formats: integer vertex count, edge list,
+dict-of-lists (out-neighbors), dict-of-dicts with labels, square adjacency
+matrix, nonsquare incidence matrix, `[V, f]` rule form with a boolean adjacency
+function, `dig6` string, and conversion from NetworkX/igraph. `[3-0]`
+
+**Selectable backends** at construction: `'dense'`, `'sparse'` (default), and
+`'static_sparse'`. `static_sparse` is faster, smaller in memory, and
+**immutable** — so such graphs can be used as dictionary keys (`immutable=True`
+is shorthand for it). Relevant to Mathilda later, since an immutable hashable
+graph aligns with Mathilda's immutable-`Expr` convention. `[3-0]`
+
+### 2.5 igraph (C library — closest architectural analog, partial coverage)
+
+*(Extracted but not in the top-25 verified set; treat as strong-but-unverified.)*
+igraph models a graph as **an edge list plus a metadata table** — a multiset of
+integer-labeled vertex-ID pairs (ordered if directed, unordered if undirected)
+rather than an adjacency matrix. In C it uses typed containers
+(`igraph_vector_int_t` for vertex/edge ids), hand-rolled because C lacks
+generics. It can export multiple views: adjacency matrix, adjacency list, edge
+list, incidence list. This is the most directly transferable C99 design.
+
+### 2.6 Hypergraphs (a gap — mostly negative results)
+
+- **Maxima:** no hypergraph support.
+- **SageMath:** `IncidenceStructure(ground_set, blocks)` models a hypergraph as
+  an incidence structure / set system (verified as a source but not top-ranked).
+- **Wolfram:** `HypergraphPlot` and the Wolfram Physics hypergraph model exist
+  but were **not captured in any verified claim**.
+- **HyperNetX** (PNNL) represents a hypergraph as a set system with an incidence
+  store (source fetched, not top-ranked).
+
+The natural Mathilda representation for a hypergraph edge is a **`List` of
+vertices** (arbitrary arity) rather than a 2-element `DirectedEdge`/
+`UndirectedEdge`, e.g. `Hypergraph[{v...}, {{a,b,c}, {c,d}, ...}]`.
+
+---
+
+## 3. Comparison Table
+
+| System | Core structure | Directed/undirected | Weighted | Multigraph | Hypergraph | Vertex ids |
+|--------|----------------|---------------------|----------|------------|------------|------------|
+| **Wolfram** | Atomic `Graph[v,e,...]`, sparse-array views | flags (`DirectedEdges`), mixed OK | `EdgeWeight`/`VertexWeight` (numeric or symbolic) | via `EdgeTaggedGraph` tags | `HypergraphPlot` / Physics model (not verified) | any expression |
+| **NetworkX** | dict-of-dicts-of-dicts | 4 classes (`Di`/`Multi`) | edge-attr dict | 4th dict level (edge key) | separate lib (HyperNetX) | any hashable |
+| **Maxima** | Lisp adjacency lists | separate graph/digraph | weighted path fns | **none** | **none** | integers |
+| **SageMath** | selectable dense/sparse/static_sparse backend | flags + classes | `weighted` flag | `multiedges` flag | `IncidenceStructure` | any |
+| **igraph (C)** | edge list + metadata table | flag | attributes | supported | no | integers |
+
+---
+
+## 4. Recommended Mathilda Design
+
+### 4.1 Expression representation
+
+Reuse the existing `Expr` tagged union and the List-of-Rules convention. **No new
+`EXPR_*` tag is needed** — a graph is a normal `EXPR_FUNCTION`:
+
+```
+Graph[ List[v1, v2, ...], List[edge1, edge2, ...] ]
+```
+
+with edge heads:
+- `DirectedEdge[u, v]`   (accept `Rule[u,v]` / `u -> v` as sugar → normalize)
+- `UndirectedEdge[u, v]` (accept `TwoWayRule[u,v]` / `u <-> v` as sugar)
+- optional tag slot `DirectedEdge[u, v, tag]` for multigraphs (EdgeTaggedGraph
+  style) — decide up front (see §4.4).
+
+Vertices are arbitrary expressions (symbols, integers), matching Wolfram and
+keeping uniformity with the rest of the system.
+
+**Canonical form + `GraphQ`.** Following Wolfram, normalize any constructor input
+to `Graph[List[verts], List[edges]]` inside `builtin_graph`, and gate structural
+pattern-matching behind a `GraphQ` predicate rather than exposing internals.
+Mathilda graphs stay plainly-inspectable `Expr` trees (unlike Wolfram's opaque
+atom), which is simpler for a pico-CAS; hashability/immutability already come for
+free from the immutable-`Expr` convention.
+
+### 4.2 Subsystem structure (mirror `src/linalg/`)
+
+Concrete pattern observed in the codebase:
+
+- **`src/graph/graph.h`** — `#include "expr.h"`, declare each `Expr*
+  builtin_*(Expr* res);` entry point and `void graph_init(void);` (mirrors
+  `src/linalg/linalg.h:1-33`).
+- **One `.c` per builtin** (e.g. `construct.c`, `adjmat.c`, `shortestpath.c`,
+  `components.c`), plus a `graph.c` holding `graph_init()` and shared helpers —
+  exactly the `src/linalg/` layout.
+- **`graph_init()`** registers each builtin and sets attributes, following
+  `src/linalg/linalg.c:17-54`:
+  ```c
+  symtab_add_builtin("Graph", builtin_graph);
+  symtab_get_def("Graph")->attributes |= ATTR_PROTECTED;
+  symtab_set_docstring("Graph", "Graph[v,e] represents a graph ...");
+  ```
+- **Register in `core_init()`** — add `graph_init();` alongside the other
+  `*_init()` calls in `src/core.c` (see the block at `src/core.c:532-551`).
+- **Intern internal symbols in `sym_names.c`** — `DirectedEdge`,
+  `UndirectedEdge`, `Graph`, `EdgeTaggedGraph`, matching the
+  `SYM_Graphics = intern_symbol("Graphics")` pattern at `src/sym_names.c:1164`.
+- **⚠ Makefile is NOT recursive.** `makefile:125` lists every source subdir
+  explicitly in the `SRC` wildcard. A new subsystem **must add**
+  `$(wildcard $(SRC_DIR)/graph/*.c)` there — new files under `src/graph/` will
+  otherwise be silently ignored.
+
+### 4.3 Builtin surface (MVP → later)
+
+**Construction:** `Graph`, `CompleteGraph`, `CycleGraph`, `PathGraph`,
+`AdjacencyGraph` (inverse of `AdjacencyMatrix`), `RandomGraph`.
+
+**Query/representation:** `GraphQ`, `VertexList`, `EdgeList`, `VertexCount`,
+`EdgeCount`, `AdjacencyList`, `AdjacencyMatrix`, `IncidenceMatrix`,
+`WeightedAdjacencyMatrix`, `DirectedGraphQ`, `VertexDegree`.
+
+**Algorithms (named, per cross-system convention):** `FindShortestPath` (path)
+and `GraphDistance` (length) — keep Wolfram's split; `ConnectedComponents`,
+`StronglyConnectedComponents` / `WeaklyConnectedComponents`, `FindMaximumFlow`,
+`FindSpanningTree` (MST), `VertexConnectivity`, graph coloring / `ChromaticNumber`,
+matching. Expose distinct named functions; a generic dispatcher with an
+`Algorithm` option is optional (Combinatorica precedent).
+
+### 4.4 Key up-front decisions
+
+1. **Multigraphs:** bake an optional tag slot into the edge
+   (`DirectedEdge[u,v,tag]`, EdgeTaggedGraph-style) **now**, or forbid multi-edges
+   (Maxima-style) and add tags later? Recommendation: **forbid multi-edges/loops
+   in the MVP** (Maxima's minimal-viable point), reserve the 3-arg edge form for a
+   later `EdgeTaggedGraph`.
+2. **AdjacencyMatrix return type:** reuse the existing linalg **dense
+   List-of-Lists** matrix (interoperates immediately with `Det`, `Eigenvalues`,
+   `Tr`) for the MVP; add a sparse representation later as Wolfram does. Split
+   unweighted `AdjacencyMatrix` (0/1 or counts) from `WeightedAdjacencyMatrix`.
+3. **Internal storage:** simplest MVP stores the canonical edge `List` and derives
+   adjacency on demand; a hash-map (the codebase already has `expr_hash`) from
+   vertex → neighbor is the NetworkX-style upgrade path. igraph's edge-list +
+   integer-id-vector model is the closest C99 precedent if performance matters.
+4. **Printer:** teach `print.c` to render `DirectedEdge[u,v]` as `u -> v`,
+   `UndirectedEdge[u,v]` as `u <-> v`, and `Graph[...]` either as a terse
+   summary (`Graph[<n vertices, m edges>]`, Wolfram-atom style) or as the literal
+   constructor for round-trippable `InputForm`.
+
+### 4.5 Documentation & workflow obligations (per `CLAUDE.md` / `SPEC.md`)
+
+Each new builtin needs: a `symtab_set_docstring`, appropriate attributes in
+`graph_init()`, an entry in the relevant `docs/spec/builtins/` category file, and
+a note in the current week's `docs/spec/changelog/<Monday>.md`. Add a
+`docs/spec/builtins/graphs.md` category and reference it from `Mathilda_spec.md`.
+Run `valgrind --leak-check=full` — the builtin ownership contract (§4 of SPEC)
+applies: return a new `Expr*` on success (evaluator frees `res`), `NULL` when the
+graph can't be evaluated, NULL-out reused sub-expressions before the wrapper is
+freed.
+
+---
+
+## 5. Caveats & Coverage Gaps
+
+- **Uneven system coverage.** Verified claims are dominated by Wolfram (the most
+  directly relevant model), with solid primary-source coverage of NetworkX,
+  Maxima, and SageMath. **Maple, GAP, and Magma produced no surviving verified
+  claims.** **igraph** was characterized (edge-list + typed C vectors) but its
+  claims did not make the top-25 verified set — treat §2.5 as strong-but-unverified.
+- **Hypergraphs are essentially unaddressed.** The only verified hypergraph
+  finding is negative (Maxima has none). Wolfram's `HypergraphPlot` / Physics
+  hypergraph model was requested but not captured in a verified claim.
+- **Vendor self-reporting.** All Wolfram claims cite Wolfram's own reference docs
+  — authoritative for API facts, self-reported for design rationale.
+- **`Combinatorica` is explicitly obsolete** (superseded in Wolfram v10); its
+  algorithm inventory reflects legacy naming, not the current API.
+- **Version sensitivity.** NetworkX (v3.6.1) and SageMath docs are current but
+  version-specific.
+- **Mathilda integration guidance is a recommendation, not an observed
+  implementation** — inferred from inspecting `src/linalg/`, `src/core.c`,
+  `sym_names.c`, and `makefile`. No graph subsystem exists yet. (The codebase
+  facts cited in §4.2 — makefile non-recursion, the `*_init()` pattern, the
+  `symtab_add_builtin` + attribute idiom — were verified directly against the
+  repo.)
+
+---
+
+## 6. Open Questions
+
+1. **Maple / GAP / Magma / igraph internals:** data structures, construction/query
+   APIs, and algorithm suites. igraph is the closest architectural analog to a C99
+   CAS and deserves a dedicated follow-up crawl of `igraph.org/c/doc/`.
+2. **Wolfram hypergraphs:** how `HypergraphPlot`, the Wolfram Physics hypergraph
+   model, and any `Hypergraph` object actually represent hyperedges — and whether
+   any surveyed non-Wolfram system ships a first-class hypergraph structure.
+3. **Multigraph policy for Mathilda:** tag slot from day one vs. deferred
+   simple-graph-only (see §4.4.1).
+4. **AdjacencyMatrix representation:** reuse linalg dense List-of-Lists vs. a
+   SparseArray-style form; and how to split `AdjacencyMatrix` vs.
+   `WeightedAdjacencyMatrix` (see §4.4.2).
+
+---
+
+## 7. Sources
+
+**Primary (vendor / authoritative):**
+- Wolfram — Graphs & Networks guide: <https://reference.wolfram.com/language/guide/GraphsAndNetworks.html>
+- Wolfram — Graph Construction & Representation: <https://reference.wolfram.com/language/guide/GraphConstructionAndRepresentation.html>
+- Wolfram — `Graph`: <https://reference.wolfram.com/language/ref/Graph.html>
+- Wolfram — `AdjacencyMatrix`: <https://reference.wolfram.com/language/ref/AdjacencyMatrix.html>
+- Wolfram — `EdgeTaggedGraph`: <https://reference.wolfram.com/language/ref/EdgeTaggedGraph.html>
+- Wolfram — `IncidenceGraph`: <https://reference.wolfram.com/language/ref/IncidenceGraph.html>
+- Wolfram (legacy) — Combinatorica Graph Algorithms: <https://reference.wolfram.com/language/Combinatorica/guide/GraphAlgorithms.html>
+- NetworkX — Introduction / data structures: <https://networkx.org/documentation/stable/reference/introduction.html>
+- Maxima — `graphs` package manual: <https://maxima.sourceforge.io/docs/manual/Package-graphs.html>
+- SageMath — `DiGraph`: <https://doc.sagemath.org/html/en/reference/graphs/sage/graphs/digraph.html>
+- SageMath — `IncidenceStructure` (hypergraphs): <https://doc.sagemath.org/html/en/reference/graphs/sage/combinat/designs/incidence_structures.html>
+- igraph C — Basic interface: <https://igraph.org/c/doc/igraph-Basic.html>
+- igraph C — Data structures: <https://igraph.org/c/doc/igraph-Data-structures.html>
+- igraph (Python) — `Graph` API: <https://python.igraph.org/en/main/api/igraph.Graph.html>
+- Graphviz — Cgraph library: <https://www.graphviz.org/pdf/cgraph.pdf>
+- IGraph/M documentation: <https://szhorvat.net/mathematica/IGDocumentation/>
+- HyperNetX — hypergraph class: <https://github.com/pnnl/HyperNetX/blob/master/hypernetx/classes/hypergraph.py>
+
+**Secondary / reference:**
+- SageMath Wiki — Graph Theory Software Survey: <https://wiki.sagemath.org/graph_survey>
+- Wikipedia — Adjacency list: <https://en.wikipedia.org/wiki/Adjacency_list>
+- GeeksforGeeks — adjacency list vs. matrix: <https://www.geeksforgeeks.org/dsa/comparison-between-adjacency-list-and-adjacency-matrix-representation-of-graph/>
+
+*Research stats: 5 search angles · 22 sources fetched · 108 claims extracted ·
+25 verified (25 confirmed, 0 refuted) · 104 agent calls.*

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ else
 endif
 
 CC = gcc
-CFLAGS = -O3 -std=c99 -Wall -Wextra -g -I./src -I./src/list -I./src/linalg -I./src/numbertheory -I./src/poly -I./src/simp -I./src/calculus -I./src/sum -I./src/product -I./src/special_functions -I./src/numerical_calculus -I./src/numerical_roots -I./src/graphics -I/usr/local/include
+CFLAGS = -O3 -std=c99 -Wall -Wextra -g -I./src -I./src/list -I./src/linalg -I./src/numbertheory -I./src/poly -I./src/simp -I./src/calculus -I./src/sum -I./src/product -I./src/special_functions -I./src/numerical_calculus -I./src/numerical_roots -I./src/graphics -I./src/graph -I/usr/local/include
 
 # Readline is available on macOS and Linux but not on Windows (MinGW).
 # Build with USE_READLINE=0 to disable it explicitly (e.g. for cross-builds
@@ -122,7 +122,7 @@ ifeq ($(USE_GRAPHICS), 1)
 endif
 
 SRC_DIR = src
-SRC = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/list/*.c) $(wildcard $(SRC_DIR)/linalg/*.c) $(wildcard $(SRC_DIR)/numbertheory/*.c) $(wildcard $(SRC_DIR)/poly/*.c) $(wildcard $(SRC_DIR)/simp/*.c) $(wildcard $(SRC_DIR)/calculus/*.c) $(wildcard $(SRC_DIR)/sum/*.c) $(wildcard $(SRC_DIR)/product/*.c) $(wildcard $(SRC_DIR)/special_functions/*.c) $(wildcard $(SRC_DIR)/numerical_calculus/*.c) $(wildcard $(SRC_DIR)/numerical_roots/*.c) $(wildcard $(SRC_DIR)/graphics/*.c)
+SRC = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/list/*.c) $(wildcard $(SRC_DIR)/linalg/*.c) $(wildcard $(SRC_DIR)/numbertheory/*.c) $(wildcard $(SRC_DIR)/poly/*.c) $(wildcard $(SRC_DIR)/simp/*.c) $(wildcard $(SRC_DIR)/calculus/*.c) $(wildcard $(SRC_DIR)/sum/*.c) $(wildcard $(SRC_DIR)/product/*.c) $(wildcard $(SRC_DIR)/special_functions/*.c) $(wildcard $(SRC_DIR)/numerical_calculus/*.c) $(wildcard $(SRC_DIR)/numerical_roots/*.c) $(wildcard $(SRC_DIR)/graphics/*.c) $(wildcard $(SRC_DIR)/graph/*.c)
 ifneq ($(USE_GRAPHICS), 1)
 SRC := $(filter-out $(SRC_DIR)/graphics/render.c $(SRC_DIR)/graphics/hershey_font.c, $(SRC))
 endif

--- a/src/core.c
+++ b/src/core.c
@@ -641,6 +641,8 @@ void core_init(void) {
     zero_test_init();
     void graphics_init(void);
     graphics_init();
+    void graph_init(void);
+    graph_init();
 
     /* Options/SetOptions/OptionValue + the default-options registry. Runs last
      * so every option-name symbol used by the registry is already interned. */

--- a/src/graph/adjgraph.c
+++ b/src/graph/adjgraph.c
@@ -1,0 +1,76 @@
+/* adjgraph.c - AdjacencyGraph[m]: build a graph from a 0/1 adjacency matrix.
+ *
+ * The inverse of AdjacencyMatrix. Vertices are the integers 1..n. A symmetric
+ * matrix yields an undirected graph (one UndirectedEdge per i<j with m[i][j]=1);
+ * an asymmetric matrix yields a directed graph (a DirectedEdge for each off-
+ * diagonal m[i][j]=1). Diagonal entries (self-loops) are ignored. The result is
+ * returned as a Graph[...] expression and canonicalized/validated by the
+ * evaluator (builtin_graph).
+ *
+ * Round-trips with AdjacencyMatrix when the source graph's vertices are 1..n.
+ *
+ * Memory (SPEC section 4): returns a freshly-allocated Graph; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* Integer value of matrix entry, or -1 if not a plain integer. */
+static int entry_int(const Expr* row, size_t j) {
+    const Expr* e = row->data.function.args[j];
+    if (e->type != EXPR_INTEGER) return -1;
+    return (int)e->data.integer;
+}
+
+Expr* builtin_adjacency_graph(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* m = res->data.function.args[0];
+    if (!graph_is_list(m)) return NULL;
+
+    size_t n = m->data.function.arg_count;
+    /* Validate: n x n, entries 0/1. */
+    for (size_t i = 0; i < n; i++) {
+        const Expr* row = m->data.function.args[i];
+        if (!graph_is_list(row) || row->data.function.arg_count != n) return NULL;
+        for (size_t j = 0; j < n; j++) {
+            int v = entry_int(row, j);
+            if (v != 0 && v != 1) return NULL;
+        }
+    }
+
+    /* Symmetry test. */
+    int symmetric = 1;
+    for (size_t i = 0; i < n && symmetric; i++)
+        for (size_t j = 0; j < n; j++)
+            if (entry_int(m->data.function.args[i], j)
+                != entry_int(m->data.function.args[j], i)) { symmetric = 0; break; }
+
+    /* Vertices 1..n. */
+    Expr** verts = (n > 0) ? calloc(n, sizeof(Expr*)) : NULL;
+    for (size_t i = 0; i < n; i++) verts[i] = expr_new_integer((int64_t)i + 1);
+    Expr* vlist = expr_new_function(expr_new_symbol(SYM_List), verts, n);
+    free(verts);
+
+    /* Edges. Upper-bound count then trim via arg_count. */
+    Expr** edges = (n > 0) ? calloc(n * n, sizeof(Expr*)) : NULL;
+    size_t ne = 0;
+    for (size_t i = 0; i < n; i++) {
+        for (size_t j = 0; j < n; j++) {
+            if (i == j) continue;                    /* ignore self-loops */
+            if (entry_int(m->data.function.args[i], j) != 1) continue;
+            if (symmetric && j < i) continue;        /* one undirected edge per pair */
+            Expr* ea[2] = { expr_new_integer((int64_t)i + 1),
+                            expr_new_integer((int64_t)j + 1) };
+            edges[ne++] = expr_new_function(
+                expr_new_symbol(symmetric ? SYM_UndirectedEdge : SYM_DirectedEdge),
+                ea, 2);
+        }
+    }
+    Expr* elist = expr_new_function(expr_new_symbol(SYM_List), edges, ne);
+    free(edges);
+
+    Expr* gargs[2] = { vlist, elist };
+    return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+}

--- a/src/graph/adjlist.c
+++ b/src/graph/adjlist.c
@@ -1,0 +1,71 @@
+/* adjlist.c - AdjacencyList[g] and AdjacencyList[g, v].
+ *
+ * Neighbors of v: successors for directed edges (v -> u yields u), and both
+ * endpoints for undirected edges. This matches the row convention of
+ * AdjacencyMatrix (a 1 in row v, column u means v is adjacent to u). Neighbors
+ * are returned in first-appearance order, de-duplicated.
+ *
+ * AdjacencyList[g]     -> {neighbors(v1), neighbors(v2), ...} in vertex order.
+ * AdjacencyList[g, v]  -> neighbors(v).
+ *
+ * Memory (SPEC section 4): returns freshly-allocated lists; evaluator frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* Build List of neighbors of `v` (deduplicated, first-appearance order). */
+static Expr* neighbors_of(const Expr* g, const Expr* v) {
+    const Expr* edges = g->data.function.args[1];
+    size_t ne = edges->data.function.arg_count;
+    Expr** nbr = (ne > 0) ? calloc(ne * 2, sizeof(Expr*)) : NULL;
+    size_t n = 0;
+
+    for (size_t i = 0; i < ne; i++) {
+        const Expr* e = edges->data.function.args[i];
+        const char* kind = graph_edge_kind(e);
+        const Expr* a = e->data.function.args[0];
+        const Expr* b = e->data.function.args[1];
+        const Expr* add = NULL;
+        if (kind == SYM_UndirectedEdge) {
+            if (expr_eq(a, v)) add = b;
+            else if (expr_eq(b, v)) add = a;
+        } else {
+            if (expr_eq(a, v)) add = b;   /* successor only */
+        }
+        if (add) {
+            int seen = 0;
+            for (size_t j = 0; j < n; j++)
+                if (expr_eq(nbr[j], add)) { seen = 1; break; }
+            if (!seen) nbr[n++] = expr_copy((Expr*)add);
+        }
+    }
+    Expr* list = expr_new_function(expr_new_symbol(SYM_List), nbr, n);
+    free(nbr);
+    return list;
+}
+
+Expr* builtin_adjacency_list(Expr* res) {
+    size_t argc = res->data.function.arg_count;
+    if (argc < 1 || argc > 2) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+    const Expr* verts = g->data.function.args[0];
+
+    if (argc == 2) {
+        const Expr* v = res->data.function.args[1];
+        if (graph_vertex_index(verts, v) < 0) return NULL;
+        return neighbors_of(g, v);
+    }
+
+    size_t nv = verts->data.function.arg_count;
+    Expr** rows = (nv > 0) ? calloc(nv, sizeof(Expr*)) : NULL;
+    if (nv > 0 && !rows) return NULL;
+    for (size_t i = 0; i < nv; i++)
+        rows[i] = neighbors_of(g, verts->data.function.args[i]);
+    Expr* list = expr_new_function(expr_new_symbol(SYM_List), rows, nv);
+    free(rows);
+    return list;
+}

--- a/src/graph/adjmat.c
+++ b/src/graph/adjmat.c
@@ -1,0 +1,53 @@
+/* adjmat.c - AdjacencyMatrix[g]: dense 0/1 adjacency matrix.
+ *
+ * Returns an n x n dense List-of-Lists (n = |V|, in canonical vertex order),
+ * consumable directly by Det, Tr, and Eigenvalues with no linalg changes.
+ * A DirectedEdge[a,b] sets M[a][b] = 1; an UndirectedEdge sets both M[a][b] and
+ * M[b][a], so undirected graphs yield a symmetric matrix. Entries are always
+ * 0/1 since parallel edges are forbidden.
+ *
+ * Future hook: a WeightedAdjacencyMatrix would fill entries with edge weights
+ * instead of 1 (Locked Decision 2); not implemented in the MVP.
+ *
+ * Memory (SPEC section 4): returns a freshly-allocated matrix; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+Expr* builtin_adjacency_matrix(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+
+    const Expr* verts = g->data.function.args[0];
+    const Expr* edges = g->data.function.args[1];
+    size_t n = verts->data.function.arg_count;
+
+    int* grid = (n > 0) ? calloc(n * n, sizeof(int)) : NULL;
+    if (n > 0 && !grid) return NULL;
+
+    for (size_t k = 0; k < edges->data.function.arg_count; k++) {
+        const Expr* e = edges->data.function.args[k];
+        const char* kind = graph_edge_kind(e);
+        int ia = graph_vertex_index(verts, e->data.function.args[0]);
+        int ib = graph_vertex_index(verts, e->data.function.args[1]);
+        grid[(size_t)ia * n + (size_t)ib] = 1;
+        if (kind == SYM_UndirectedEdge) grid[(size_t)ib * n + (size_t)ia] = 1;
+    }
+
+    Expr** rows = (n > 0) ? calloc(n, sizeof(Expr*)) : NULL;
+    for (size_t i = 0; i < n; i++) {
+        Expr** row = calloc(n, sizeof(Expr*));
+        for (size_t j = 0; j < n; j++)
+            row[j] = expr_new_integer(grid[i * n + j]);
+        rows[i] = expr_new_function(expr_new_symbol(SYM_List), row, n);
+        free(row);
+    }
+    Expr* mat = expr_new_function(expr_new_symbol(SYM_List), rows, n);
+    free(rows);
+    free(grid);
+    return mat;
+}

--- a/src/graph/components.c
+++ b/src/graph/components.c
@@ -1,0 +1,140 @@
+/* components.c - connected-component builtins.
+ *
+ *   ConnectedComponents[g]          weak components (underlying undirected)
+ *   WeaklyConnectedComponents[g]    same as ConnectedComponents
+ *   StronglyConnectedComponents[g]  strong components (Tarjan) over directed
+ *                                   adjacency; for undirected graphs this
+ *                                   coincides with the weak components.
+ *
+ * Each returns a List of Lists of vertices, components in first-appearance
+ * order, vertices within a component in canonical index order.
+ *
+ * Memory (SPEC section 4): returns freshly-allocated lists; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* Build the result List from a component-id labeling comp[0..n-1] with `k`
+ * components. Components appear in order of their first vertex; vertices within
+ * each keep index order. */
+static Expr* components_to_list(const GraphAdj* a, const int* comp, int k) {
+    int n = a->n;
+    /* First-appearance order of component ids. */
+    int* order = calloc((size_t)(k > 0 ? k : 1), sizeof(int));
+    int* pos   = malloc((size_t)(k > 0 ? k : 1) * sizeof(int));
+    for (int i = 0; i < k; i++) pos[i] = -1;
+    int seen = 0;
+    for (int i = 0; i < n; i++)
+        if (pos[comp[i]] < 0) { pos[comp[i]] = seen; order[seen++] = comp[i]; }
+
+    Expr** groups = calloc((size_t)(k > 0 ? k : 1), sizeof(Expr*));
+    for (int gi = 0; gi < k; gi++) {
+        int cid = order[gi];
+        int cnt = 0;
+        for (int i = 0; i < n; i++) if (comp[i] == cid) cnt++;
+        Expr** members = (cnt > 0) ? calloc((size_t)cnt, sizeof(Expr*)) : NULL;
+        int m = 0;
+        for (int i = 0; i < n; i++)
+            if (comp[i] == cid) members[m++] = expr_copy(a->verts->data.function.args[i]);
+        groups[gi] = expr_new_function(expr_new_symbol(SYM_List), members, (size_t)cnt);
+        free(members);
+    }
+    Expr* out = expr_new_function(expr_new_symbol(SYM_List), groups, (size_t)k);
+    free(groups); free(order); free(pos);
+    return out;
+}
+
+/* Weak/underlying-undirected labeling via DFS over out+in. */
+static Expr* weak_components(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    GraphAdj* a = graph_build_adj(res->data.function.args[0]);
+    if (!a) return NULL;
+    int n = a->n;
+    int* comp = malloc((size_t)(n > 0 ? n : 1) * sizeof(int));
+    for (int i = 0; i < n; i++) comp[i] = -1;
+    int* stack = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    int k = 0;
+    for (int s = 0; s < n; s++) {
+        if (comp[s] >= 0) continue;
+        int top = 0; stack[top++] = s; comp[s] = k;
+        while (top > 0) {
+            int u = stack[--top];
+            for (int j = 0; j < a->outdeg[u]; j++) { int w = a->out[u][j]; if (comp[w] < 0) { comp[w] = k; stack[top++] = w; } }
+            for (int j = 0; j < a->indeg[u];  j++) { int w = a->in[u][j];  if (comp[w] < 0) { comp[w] = k; stack[top++] = w; } }
+        }
+        k++;
+    }
+    Expr* out = components_to_list(a, comp, k);
+    free(comp); free(stack); graph_adj_free(a);
+    return out;
+}
+
+Expr* builtin_connected_components(Expr* res)          { return weak_components(res); }
+Expr* builtin_weakly_connected_components(Expr* res)   { return weak_components(res); }
+
+/* ---- Tarjan strongly-connected components --------------------------------- */
+typedef struct {
+    const GraphAdj* a;
+    int* index; int* low; char* onstack; int* stack; int sp;
+    int* comp; int counter; int k;
+} Tarjan;
+
+/* Iterative Tarjan to avoid deep recursion on large graphs. */
+static void tarjan_run(Tarjan* t) {
+    int n = t->a->n;
+    int* it = calloc((size_t)(n > 0 ? n : 1), sizeof(int)); /* per-node child cursor */
+    int* callstk = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    for (int s = 0; s < n; s++) {
+        if (t->index[s] >= 0) continue;
+        int csp = 0; callstk[csp++] = s;
+        t->index[s] = t->low[s] = t->counter++;
+        t->stack[t->sp++] = s; t->onstack[s] = 1;
+        while (csp > 0) {
+            int u = callstk[csp - 1];
+            if (it[u] < t->a->outdeg[u]) {
+                int w = t->a->out[u][it[u]++];
+                if (t->index[w] < 0) {
+                    t->index[w] = t->low[w] = t->counter++;
+                    t->stack[t->sp++] = w; t->onstack[w] = 1;
+                    callstk[csp++] = w;
+                } else if (t->onstack[w]) {
+                    if (t->index[w] < t->low[u]) t->low[u] = t->index[w];
+                }
+            } else {
+                /* Done with u: if root of an SCC, pop it. */
+                if (t->low[u] == t->index[u]) {
+                    int w;
+                    do { w = t->stack[--t->sp]; t->onstack[w] = 0; t->comp[w] = t->k; } while (w != u);
+                    t->k++;
+                }
+                csp--;
+                if (csp > 0) { int p = callstk[csp - 1]; if (t->low[u] < t->low[p]) t->low[p] = t->low[u]; }
+            }
+        }
+    }
+    free(it); free(callstk);
+}
+
+Expr* builtin_strongly_connected_components(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    GraphAdj* a = graph_build_adj(res->data.function.args[0]);
+    if (!a) return NULL;
+    int n = a->n;
+    Tarjan t;
+    t.a = a;
+    t.index = malloc((size_t)(n > 0 ? n : 1) * sizeof(int));
+    t.low   = malloc((size_t)(n > 0 ? n : 1) * sizeof(int));
+    t.onstack = calloc((size_t)(n > 0 ? n : 1), sizeof(char));
+    t.stack = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    t.comp  = malloc((size_t)(n > 0 ? n : 1) * sizeof(int));
+    t.sp = 0; t.counter = 0; t.k = 0;
+    for (int i = 0; i < n; i++) { t.index[i] = -1; t.low[i] = -1; t.comp[i] = -1; }
+    tarjan_run(&t);
+    Expr* out = components_to_list(a, t.comp, t.k);
+    free(t.index); free(t.low); free(t.onstack); free(t.stack); free(t.comp);
+    graph_adj_free(a);
+    return out;
+}

--- a/src/graph/connectivity.c
+++ b/src/graph/connectivity.c
@@ -1,0 +1,75 @@
+/* connectivity.c - ConnectedGraphQ[g] and VertexConnectivity[g].
+ *
+ * Both operate on the underlying undirected graph.
+ *   ConnectedGraphQ[g]    True iff g has >= 1 vertex and forms a single
+ *                         connected component.
+ *   VertexConnectivity[g] the least number of vertices whose removal
+ *                         disconnects g (n-1 for a complete graph, 0 if already
+ *                         disconnected or trivial). Computed by brute-force
+ *                         search over vertex subsets -- exact, intended for the
+ *                         small graphs of a pico-CAS.
+ *
+ * Memory (SPEC section 4): returns freshly-allocated results; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+Expr* builtin_connected_graph_q(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    GraphAdj* a = graph_build_adj(res->data.function.args[0]);
+    if (!a) return NULL;
+    int comps = graph_count_components(a, NULL, NULL);
+    int connected = (a->n >= 1 && comps == 1);
+    graph_adj_free(a);
+    return expr_new_symbol(connected ? SYM_True : SYM_False);
+}
+
+/* Does some size-k subset of vertices disconnect the graph? Enumerates all
+ * C(n,k) subsets via an index array; sets `removed` for each. */
+static int some_cut_of_size(const GraphAdj* a, int k, char* removed) {
+    int n = a->n;
+    int* idx = calloc((size_t)(k > 0 ? k : 1), sizeof(int));
+    for (int i = 0; i < k; i++) idx[i] = i;
+    int found = 0;
+    while (!found) {
+        for (int i = 0; i < n; i++) removed[i] = 0;
+        for (int i = 0; i < k; i++) removed[idx[i]] = 1;
+        int active = 0;
+        int comps = graph_count_components(a, removed, &active);
+        if (active >= 2 && comps >= 2) { found = 1; break; }
+        /* Advance the combination (rightmost index that can move). */
+        int p = k - 1;
+        while (p >= 0 && idx[p] == n - k + p) p--;
+        if (p < 0) break;
+        idx[p]++;
+        for (int i = p + 1; i < k; i++) idx[i] = idx[i - 1] + 1;
+    }
+    free(idx);
+    return found;
+}
+
+Expr* builtin_vertex_connectivity(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    GraphAdj* a = graph_build_adj(res->data.function.args[0]);
+    if (!a) return NULL;
+    int n = a->n;
+
+    int kappa;
+    if (n <= 1) {
+        kappa = 0;
+    } else if (graph_count_components(a, NULL, NULL) > 1) {
+        kappa = 0;                       /* already disconnected */
+    } else {
+        char* removed = calloc((size_t)n, sizeof(char));
+        kappa = n - 1;                   /* complete-graph fallback */
+        for (int k = 1; k <= n - 2; k++) {
+            if (some_cut_of_size(a, k, removed)) { kappa = k; break; }
+        }
+        free(removed);
+    }
+    graph_adj_free(a);
+    return expr_new_integer(kappa);
+}

--- a/src/graph/construct.c
+++ b/src/graph/construct.c
@@ -1,0 +1,137 @@
+/* construct.c - builtin_graph: normalize, derive, validate, canonicalize.
+ *
+ * Accepts:
+ *   Graph[edges]          -- vertices derived from the edges (directed default)
+ *   Graph[verts, edges]   -- explicit vertex list
+ *
+ * Edge sugar is normalized on construction:
+ *   Rule[u,v]        / u -> v    ->  DirectedEdge[u, v]
+ *   TwoWayRule[u,v]  / u <-> v   ->  UndirectedEdge[u, v]
+ *   DirectedEdge[u,v] / UndirectedEdge[u,v]   pass through unchanged
+ *
+ * The result is the canonical Graph[List[verts], List[edges]] with vertices in
+ * first-appearance order (when derived). Malformed input -- 3-arg edges,
+ * self-loops, parallel edges, or an edge endpoint absent from an explicit
+ * vertex list -- leaves Graph[...] unevaluated (returns NULL).
+ *
+ * Memory (SPEC section 4): the canonical tree is built entirely from expr_copy
+ * of the argument's parts, so `res` is never cannibalized. On success the
+ * evaluator frees `res`; on NULL it retains it. The "already canonical" case
+ * returns NULL so evaluation reaches a fixed point.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* head symbol of a function node, or NULL. */
+static const char* fn_head(const Expr* e) {
+    if (!e || e->type != EXPR_FUNCTION || !e->data.function.head
+        || e->data.function.head->type != EXPR_SYMBOL)
+        return NULL;
+    return e->data.function.head->data.symbol;
+}
+
+/* Build a fresh normalized edge (with copied endpoints) from any accepted edge
+ * form, or NULL if `e` is not a recognizable 2-argument edge. Does not reject
+ * self-loops -- the caller does, via graph_is_valid. */
+static Expr* normalize_edge(const Expr* e) {
+    const char* h = fn_head(e);
+    if (!h || e->data.function.arg_count != 2) return NULL;
+
+    const char* out_head;
+    if (h == SYM_Rule || h == SYM_DirectedEdge)              out_head = SYM_DirectedEdge;
+    else if (h == SYM_TwoWayRule || h == SYM_UndirectedEdge) out_head = SYM_UndirectedEdge;
+    else return NULL;
+
+    Expr* args[2];
+    args[0] = expr_copy(e->data.function.args[0]);
+    args[1] = expr_copy(e->data.function.args[1]);
+    return expr_new_function(expr_new_symbol(out_head), args, 2);
+}
+
+/* Assemble the canonical Graph from `res`, or NULL if the shape is wrong or the
+ * result would be invalid. */
+static Expr* try_build_canonical(Expr* res) {
+    size_t argc = res->data.function.arg_count;
+    const Expr* verts_in = NULL;
+    const Expr* edges_in = NULL;
+
+    if (argc == 1) {
+        edges_in = res->data.function.args[0];
+    } else if (argc == 2) {
+        verts_in = res->data.function.args[0];
+        edges_in = res->data.function.args[1];
+    } else {
+        return NULL;
+    }
+    if (!graph_is_list(edges_in)) return NULL;
+    if (verts_in && !graph_is_list(verts_in)) return NULL;
+
+    size_t ne = edges_in->data.function.arg_count;
+
+    /* 1. Normalize every edge. */
+    Expr** edges = (ne > 0) ? calloc(ne, sizeof(Expr*)) : NULL;
+    if (ne > 0 && !edges) return NULL;
+    for (size_t i = 0; i < ne; i++) {
+        edges[i] = normalize_edge(edges_in->data.function.args[i]);
+        if (!edges[i]) {
+            for (size_t j = 0; j < i; j++) expr_free(edges[j]);
+            free(edges);
+            return NULL;
+        }
+    }
+
+    /* 2. Build the vertex list: copy the explicit one, or derive it from the
+     *    normalized edges in first-appearance order. */
+    Expr** verts = NULL;
+    size_t nv = 0;
+    if (verts_in) {
+        nv = verts_in->data.function.arg_count;
+        verts = (nv > 0) ? calloc(nv, sizeof(Expr*)) : NULL;
+        if (nv > 0 && !verts) goto fail_edges;
+        for (size_t i = 0; i < nv; i++)
+            verts[i] = expr_copy(verts_in->data.function.args[i]);
+    } else {
+        /* At most 2 distinct new vertices per edge. */
+        verts = (ne > 0) ? calloc(ne * 2, sizeof(Expr*)) : NULL;
+        if (ne > 0 && !verts) goto fail_edges;
+        for (size_t i = 0; i < ne; i++) {
+            for (int k = 0; k < 2; k++) {
+                Expr* ep = edges[i]->data.function.args[k];
+                int seen = 0;
+                for (size_t j = 0; j < nv; j++)
+                    if (expr_eq(verts[j], ep)) { seen = 1; break; }
+                if (!seen) verts[nv++] = expr_copy(ep);
+            }
+        }
+    }
+
+    /* 3. Assemble candidate Graph[List verts, List edges] (moves ownership). */
+    Expr* vlist = expr_new_function(expr_new_symbol(SYM_List), verts, nv);
+    Expr* elist = expr_new_function(expr_new_symbol(SYM_List), edges, ne);
+    free(verts);
+    free(edges);
+    Expr* gargs[2] = { vlist, elist };
+    Expr* g = expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+
+    /* 4. Validate (self-loops, parallel edges, endpoint membership). */
+    if (!graph_is_valid(g)) { expr_free(g); return NULL; }
+    return g;
+
+fail_edges:
+    for (size_t i = 0; i < ne; i++) expr_free(edges[i]);
+    free(edges);
+    return NULL;
+}
+
+Expr* builtin_graph(Expr* res) {
+    Expr* canonical = try_build_canonical(res);
+    if (!canonical) return NULL;                 /* malformed: leave unevaluated */
+    if (expr_eq(canonical, res)) {               /* already canonical: fixed point */
+        expr_free(canonical);
+        return NULL;
+    }
+    return canonical;
+}

--- a/src/graph/counts.c
+++ b/src/graph/counts.c
@@ -1,0 +1,20 @@
+/* counts.c - VertexCount[g] and EdgeCount[g]: cardinalities as integers.
+ * Thin readers over the canonical form; NULL (unevaluated) if g is not a graph.
+ * Memory (SPEC section 4): returns a fresh integer; the evaluator frees res. */
+
+#include "graph.h"
+#include "expr.h"
+
+Expr* builtin_vertex_count(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+    return expr_new_integer((int64_t)g->data.function.args[0]->data.function.arg_count);
+}
+
+Expr* builtin_edge_count(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+    return expr_new_integer((int64_t)g->data.function.args[1]->data.function.arg_count);
+}

--- a/src/graph/degree.c
+++ b/src/graph/degree.c
@@ -1,0 +1,74 @@
+/* degree.c - VertexDegree, VertexInDegree, VertexOutDegree.
+ *
+ * Each accepts VertexDegree[g] (a list of degrees, one per vertex in canonical
+ * order) or VertexDegree[g, v] (the degree of a single vertex).
+ *
+ * Conventions (documented in docs/spec/builtins/graphs.md):
+ *   - A DirectedEdge[a,b] adds 1 to out(a) and 1 to in(b); total degree of a
+ *     vertex is in + out, so for a purely directed graph total = in + out.
+ *   - An UndirectedEdge[a,b] is incident to both a and b, adding 1 to each of
+ *     their in-, out-, and total degrees (so in = out = total for a purely
+ *     undirected graph).
+ * There are no self-loops, so no endpoint is double-counted within one edge.
+ *
+ * Memory (SPEC section 4): returns freshly-allocated integers/lists; the
+ * evaluator frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+enum { DEG_TOTAL, DEG_IN, DEG_OUT };
+
+/* Degree of vertex `v` in graph `g` under the given mode. */
+static int64_t degree_of(const Expr* g, const Expr* v, int mode) {
+    const Expr* edges = g->data.function.args[1];
+    int64_t in = 0, out = 0, tot = 0;
+    for (size_t i = 0; i < edges->data.function.arg_count; i++) {
+        const Expr* e = edges->data.function.args[i];
+        const char* kind = graph_edge_kind(e);
+        const Expr* a = e->data.function.args[0];
+        const Expr* b = e->data.function.args[1];
+        int va = expr_eq(a, v);
+        int vb = expr_eq(b, v);
+        if (kind == SYM_UndirectedEdge) {
+            /* Incident once: contributes to in, out, and total alike. */
+            if (va || vb) { in++; out++; tot++; }
+        } else { /* directed: total counts each incident edge once */
+            if (va) { out++; tot++; }
+            if (vb) { in++;  tot++; }
+        }
+    }
+    if (mode == DEG_IN)  return in;
+    if (mode == DEG_OUT) return out;
+    return tot;
+}
+
+static Expr* degree_dispatch(Expr* res, int mode) {
+    size_t argc = res->data.function.arg_count;
+    if (argc < 1 || argc > 2) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+    const Expr* verts = g->data.function.args[0];
+
+    if (argc == 2) {
+        const Expr* v = res->data.function.args[1];
+        if (graph_vertex_index(verts, v) < 0) return NULL;   /* v not a vertex */
+        return expr_new_integer(degree_of(g, v, mode));
+    }
+
+    size_t nv = verts->data.function.arg_count;
+    Expr** out = (nv > 0) ? calloc(nv, sizeof(Expr*)) : NULL;
+    if (nv > 0 && !out) return NULL;
+    for (size_t i = 0; i < nv; i++)
+        out[i] = expr_new_integer(degree_of(g, verts->data.function.args[i], mode));
+    Expr* list = expr_new_function(expr_new_symbol(SYM_List), out, nv);
+    free(out);
+    return list;
+}
+
+Expr* builtin_vertex_degree(Expr* res)     { return degree_dispatch(res, DEG_TOTAL); }
+Expr* builtin_vertex_in_degree(Expr* res)  { return degree_dispatch(res, DEG_IN);    }
+Expr* builtin_vertex_out_degree(Expr* res) { return degree_dispatch(res, DEG_OUT);   }

--- a/src/graph/directedq.c
+++ b/src/graph/directedq.c
@@ -1,0 +1,20 @@
+/* directedq.c - DirectedGraphQ[g]: True iff g is a valid graph whose edges are
+ * all DirectedEdge (vacuously True for an edgeless graph). False otherwise.
+ * Memory (SPEC section 4): returns a fresh symbol; the evaluator frees res. */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+
+Expr* builtin_directed_graph_q(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return expr_new_symbol(SYM_False);
+
+    const Expr* edges = g->data.function.args[1];
+    for (size_t i = 0; i < edges->data.function.arg_count; i++) {
+        if (graph_edge_kind(edges->data.function.args[i]) != SYM_DirectedEdge)
+            return expr_new_symbol(SYM_False);
+    }
+    return expr_new_symbol(SYM_True);
+}

--- a/src/graph/edgelist.c
+++ b/src/graph/edgelist.c
@@ -1,0 +1,13 @@
+/* edgelist.c - EdgeList[g]: the graph's edges (canonical Directed/UndirectedEdge
+ * form), in order. NULL (unevaluated) if g is not a graph.
+ * Memory (SPEC section 4): returns a fresh copy; the evaluator frees res. */
+
+#include "graph.h"
+#include "expr.h"
+
+Expr* builtin_edge_list(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+    return expr_copy(g->data.function.args[1]);
+}

--- a/src/graph/generators.c
+++ b/src/graph/generators.c
@@ -1,0 +1,134 @@
+/* generators.c - standard graph constructors.
+ *
+ *   CompleteGraph[n]          - undirected K_n (all n(n-1)/2 edges)
+ *   CycleGraph[n]             - undirected cycle on 1..n
+ *   PathGraph[n]              - undirected path 1-2-...-n
+ *   PathGraph[{v1,...,vk}]    - undirected path over the given vertices
+ *   RandomGraph[{n, m}]       - undirected graph with n vertices, m random edges
+ *
+ * Each assembles a Graph[List verts, List edges] expression and returns it; the
+ * evaluator canonicalizes and validates it via builtin_graph. Vertices are the
+ * integers 1..n (except the explicit PathGraph[{...}] form). RandomGraph reuses
+ * the system RNG by evaluating RandomSample over the candidate edges, so it
+ * honors SeedRandom.
+ *
+ * Memory (SPEC section 4): returns freshly-allocated trees; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "eval.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* Small integer argument as a nonnegative long, or -1 if not a suitable int. */
+static long as_count(const Expr* e) {
+    if (!e || e->type != EXPR_INTEGER || e->data.integer < 0) return -1;
+    return (long)e->data.integer;
+}
+
+static Expr* undirected_edge(long a, long b) {
+    Expr* ea[2] = { expr_new_integer(a), expr_new_integer(b) };
+    return expr_new_function(expr_new_symbol(SYM_UndirectedEdge), ea, 2);
+}
+
+/* Wrap vertex/edge C-arrays into a Graph[...] (moves ownership). */
+static Expr* make_graph(Expr** verts, size_t nv, Expr** edges, size_t ne) {
+    Expr* vlist = expr_new_function(expr_new_symbol(SYM_List), verts, nv);
+    Expr* elist = expr_new_function(expr_new_symbol(SYM_List), edges, ne);
+    Expr* gargs[2] = { vlist, elist };
+    return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+}
+
+static Expr** int_vertices(long n) {
+    Expr** v = (n > 0) ? calloc((size_t)n, sizeof(Expr*)) : NULL;
+    for (long i = 0; i < n; i++) v[i] = expr_new_integer(i + 1);
+    return v;
+}
+
+Expr* builtin_complete_graph(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    long n = as_count(res->data.function.args[0]);
+    if (n < 0) return NULL;
+    size_t ne = (size_t)n * (size_t)(n - 1) / 2;
+    Expr** edges = (ne > 0) ? calloc(ne, sizeof(Expr*)) : NULL;
+    size_t k = 0;
+    for (long i = 1; i <= n; i++)
+        for (long j = i + 1; j <= n; j++)
+            edges[k++] = undirected_edge(i, j);
+    return make_graph(int_vertices(n), (size_t)n, edges, ne);
+}
+
+Expr* builtin_cycle_graph(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    long n = as_count(res->data.function.args[0]);
+    if (n < 0) return NULL;
+    /* Path edges 1-2-...-n, plus the wrap edge n-1 when n >= 3 (for n <= 2 the
+     * wrap edge would duplicate an existing one). */
+    size_t ne = (n >= 3) ? (size_t)n : (n >= 2 ? 1u : 0u);
+    Expr** edges = (ne > 0) ? calloc(ne, sizeof(Expr*)) : NULL;
+    size_t k = 0;
+    for (long i = 1; i < n; i++) edges[k++] = undirected_edge(i, i + 1);
+    if (n >= 3) edges[k++] = undirected_edge(n, 1);
+    return make_graph(int_vertices(n), (size_t)n, edges, ne);
+}
+
+Expr* builtin_path_graph(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* arg = res->data.function.args[0];
+
+    if (graph_is_list(arg)) {
+        /* PathGraph[{v1,...,vk}] over explicit vertices. */
+        size_t nv = arg->data.function.arg_count;
+        Expr** verts = (nv > 0) ? calloc(nv, sizeof(Expr*)) : NULL;
+        for (size_t i = 0; i < nv; i++) verts[i] = expr_copy(arg->data.function.args[i]);
+        size_t ne = (nv > 0) ? nv - 1 : 0;
+        Expr** edges = (ne > 0) ? calloc(ne, sizeof(Expr*)) : NULL;
+        for (size_t i = 0; i + 1 < nv; i++) {
+            Expr* ea[2] = { expr_copy(arg->data.function.args[i]),
+                            expr_copy(arg->data.function.args[i + 1]) };
+            edges[i] = expr_new_function(expr_new_symbol(SYM_UndirectedEdge), ea, 2);
+        }
+        return make_graph(verts, nv, edges, ne);
+    }
+
+    long n = as_count(arg);
+    if (n < 0) return NULL;
+    size_t ne = (n > 0) ? (size_t)n - 1 : 0;
+    Expr** edges = (ne > 0) ? calloc(ne, sizeof(Expr*)) : NULL;
+    for (long i = 1; i < n; i++) edges[i - 1] = undirected_edge(i, i + 1);
+    return make_graph(int_vertices(n), (size_t)n, edges, ne);
+}
+
+Expr* builtin_random_graph(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* spec = res->data.function.args[0];
+    if (!graph_is_list(spec) || spec->data.function.arg_count != 2) return NULL;
+    long n = as_count(spec->data.function.args[0]);
+    long m = as_count(spec->data.function.args[1]);
+    if (n < 0 || m < 0) return NULL;
+    long maxe = n * (n - 1) / 2;
+    if (m > maxe) return NULL;   /* more edges than a simple graph allows */
+
+    /* All candidate undirected edges. */
+    size_t ncand = (size_t)maxe;
+    Expr** cand = (ncand > 0) ? calloc(ncand, sizeof(Expr*)) : NULL;
+    size_t k = 0;
+    for (long i = 1; i <= n; i++)
+        for (long j = i + 1; j <= n; j++)
+            cand[k++] = undirected_edge(i, j);
+    Expr* cand_list = expr_new_function(expr_new_symbol(SYM_List), cand, ncand);
+    free(cand);
+
+    /* Sample m of them without replacement, via the seeded system RNG. */
+    Expr* sample_args[2] = { cand_list, expr_new_integer(m) };
+    Expr* sample_call = expr_new_function(expr_new_symbol("RandomSample"),
+                                          sample_args, 2);
+    Expr* sampled = evaluate(sample_call);   /* consumes sample_call */
+    if (!graph_is_list(sampled)) { expr_free(sampled); return NULL; }
+
+    Expr* gargs[2] = { expr_new_function(expr_new_symbol(SYM_List),
+                                         int_vertices(n), (size_t)n),
+                       sampled };
+    return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+}

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -1,0 +1,178 @@
+/* graph_init - the graph-subsystem module entry point.
+ *
+ * Registers the per-builtin symbols, attributes, and docstrings. Each builtin
+ * lives in its own translation unit inside src/graph/ (construct.c, graphq.c,
+ * ...), mirroring the src/linalg/ layout. graph_init() is called from
+ * core_init() in src/core.c.
+ *
+ * Phase 1 registers Graph (construction/normalization, in construct.c) and
+ * GraphQ (in graphq.c). Queries, matrix views, generators, algorithms, and
+ * visualization arrive in later phases, each adding its registrations here.
+ * The builtin implementations themselves live one-per-file in src/graph/.
+ */
+
+#include "graph.h"
+#include "symtab.h"
+#include "attr.h"
+
+void graph_init(void) {
+    /* Graph -- construction, normalization, canonicalization (construct.c). */
+    symtab_add_builtin("Graph", builtin_graph);
+    symtab_get_def("Graph")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("Graph",
+        "Graph[v, e] represents a graph with vertices v and edges e. "
+        "Graph[e] derives the vertices from the edge list. Edges are "
+        "DirectedEdge[u,v] or UndirectedEdge[u,v]; u->v and u<->v are accepted "
+        "as shorthand. Simple graphs only: no self-loops or parallel edges.");
+
+    /* GraphQ -- validity predicate (graphq.c). */
+    symtab_add_builtin("GraphQ", builtin_graph_q);
+    symtab_get_def("GraphQ")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("GraphQ",
+        "GraphQ[g] gives True if g is a valid graph, and False otherwise.");
+
+    /* ---- Phase 2: query / representation builtins ------------------------- */
+    symtab_add_builtin("VertexList", builtin_vertex_list);
+    symtab_get_def("VertexList")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("VertexList",
+        "VertexList[g] gives the list of vertices of the graph g.");
+
+    symtab_add_builtin("EdgeList", builtin_edge_list);
+    symtab_get_def("EdgeList")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("EdgeList",
+        "EdgeList[g] gives the list of edges of the graph g.");
+
+    symtab_add_builtin("VertexCount", builtin_vertex_count);
+    symtab_get_def("VertexCount")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("VertexCount",
+        "VertexCount[g] gives the number of vertices in the graph g.");
+
+    symtab_add_builtin("EdgeCount", builtin_edge_count);
+    symtab_get_def("EdgeCount")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("EdgeCount",
+        "EdgeCount[g] gives the number of edges in the graph g.");
+
+    symtab_add_builtin("AdjacencyList", builtin_adjacency_list);
+    symtab_get_def("AdjacencyList")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("AdjacencyList",
+        "AdjacencyList[g] gives the adjacency list of g; AdjacencyList[g,v] "
+        "gives the vertices adjacent to v (successors for directed edges).");
+
+    symtab_add_builtin("VertexDegree", builtin_vertex_degree);
+    symtab_get_def("VertexDegree")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("VertexDegree",
+        "VertexDegree[g] gives the list of vertex degrees; VertexDegree[g,v] "
+        "gives the degree of vertex v.");
+
+    symtab_add_builtin("VertexInDegree", builtin_vertex_in_degree);
+    symtab_get_def("VertexInDegree")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("VertexInDegree",
+        "VertexInDegree[g] / VertexInDegree[g,v] gives in-degrees "
+        "(incoming directed edges; undirected edges count for both).");
+
+    symtab_add_builtin("VertexOutDegree", builtin_vertex_out_degree);
+    symtab_get_def("VertexOutDegree")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("VertexOutDegree",
+        "VertexOutDegree[g] / VertexOutDegree[g,v] gives out-degrees "
+        "(outgoing directed edges; undirected edges count for both).");
+
+    symtab_add_builtin("DirectedGraphQ", builtin_directed_graph_q);
+    symtab_get_def("DirectedGraphQ")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("DirectedGraphQ",
+        "DirectedGraphQ[g] gives True if all edges of g are directed.");
+
+    /* ---- Phase 3: matrix views (linalg interop) -------------------------- */
+    symtab_add_builtin("AdjacencyMatrix", builtin_adjacency_matrix);
+    symtab_get_def("AdjacencyMatrix")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("AdjacencyMatrix",
+        "AdjacencyMatrix[g] gives the 0/1 adjacency matrix of g (symmetric for "
+        "undirected graphs).");
+
+    symtab_add_builtin("IncidenceMatrix", builtin_incidence_matrix);
+    symtab_get_def("IncidenceMatrix")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("IncidenceMatrix",
+        "IncidenceMatrix[g] gives the vertex-edge incidence matrix of g "
+        "(oriented: -1 tail, +1 head for directed edges).");
+
+    symtab_add_builtin("AdjacencyGraph", builtin_adjacency_graph);
+    symtab_get_def("AdjacencyGraph")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("AdjacencyGraph",
+        "AdjacencyGraph[m] builds a graph on vertices 1..n from a 0/1 adjacency "
+        "matrix m (undirected if m is symmetric, else directed).");
+
+    /* ---- Phase 4: graph generators --------------------------------------- */
+    symtab_add_builtin("CompleteGraph", builtin_complete_graph);
+    symtab_get_def("CompleteGraph")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("CompleteGraph",
+        "CompleteGraph[n] gives the complete graph K_n on n vertices.");
+
+    symtab_add_builtin("CycleGraph", builtin_cycle_graph);
+    symtab_get_def("CycleGraph")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("CycleGraph",
+        "CycleGraph[n] gives the cycle graph on n vertices.");
+
+    symtab_add_builtin("PathGraph", builtin_path_graph);
+    symtab_get_def("PathGraph")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("PathGraph",
+        "PathGraph[n] gives the path on n vertices; PathGraph[{v1,...}] the "
+        "path over the given vertices.");
+
+    symtab_add_builtin("RandomGraph", builtin_random_graph);
+    symtab_get_def("RandomGraph")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("RandomGraph",
+        "RandomGraph[{n, m}] gives a random undirected graph with n vertices "
+        "and m edges.");
+
+    /* ---- Phase 5: search & computation algorithms ------------------------ */
+    symtab_add_builtin("FindShortestPath", builtin_find_shortest_path);
+    symtab_get_def("FindShortestPath")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("FindShortestPath",
+        "FindShortestPath[g,s,t] gives a shortest path from s to t as a list of "
+        "vertices ({} if none).");
+
+    symtab_add_builtin("GraphDistance", builtin_graph_distance);
+    symtab_get_def("GraphDistance")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("GraphDistance",
+        "GraphDistance[g,s,t] gives the length of a shortest path from s to t "
+        "(Infinity if unreachable).");
+
+    symtab_add_builtin("ConnectedComponents", builtin_connected_components);
+    symtab_get_def("ConnectedComponents")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("ConnectedComponents",
+        "ConnectedComponents[g] gives the connected components of g (weak, on "
+        "the underlying undirected graph).");
+
+    symtab_add_builtin("WeaklyConnectedComponents", builtin_weakly_connected_components);
+    symtab_get_def("WeaklyConnectedComponents")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("WeaklyConnectedComponents",
+        "WeaklyConnectedComponents[g] gives the weakly connected components of g.");
+
+    symtab_add_builtin("StronglyConnectedComponents", builtin_strongly_connected_components);
+    symtab_get_def("StronglyConnectedComponents")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("StronglyConnectedComponents",
+        "StronglyConnectedComponents[g] gives the strongly connected components "
+        "of g (following edge directions).");
+
+    symtab_add_builtin("FindSpanningTree", builtin_find_spanning_tree);
+    symtab_get_def("FindSpanningTree")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("FindSpanningTree",
+        "FindSpanningTree[g] gives a spanning tree (forest) of g as a graph.");
+
+    symtab_add_builtin("ConnectedGraphQ", builtin_connected_graph_q);
+    symtab_get_def("ConnectedGraphQ")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("ConnectedGraphQ",
+        "ConnectedGraphQ[g] gives True if g is connected.");
+
+    symtab_add_builtin("VertexConnectivity", builtin_vertex_connectivity);
+    symtab_get_def("VertexConnectivity")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("VertexConnectivity",
+        "VertexConnectivity[g] gives the minimum number of vertices whose "
+        "removal disconnects g.");
+
+    /* ---- Phase 6: visualization ------------------------------------------ */
+    symtab_add_builtin("GraphPlot", builtin_graph_plot);
+    symtab_get_def("GraphPlot")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("GraphPlot",
+        "GraphPlot[g] gives a Graphics object drawing the graph g with a "
+        "circular vertex layout.");
+}

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -1,0 +1,116 @@
+#ifndef GRAPH_H
+#define GRAPH_H
+
+#include "expr.h"
+
+/* Graph subsystem entry points, registered by graph_init().
+ *
+ * Graphs are represented as ordinary Expr trees -- no new EXPR_* tag:
+ *
+ *     Graph[ List[v1, v2, ...], List[edge1, edge2, ...] ]
+ *
+ * where each edge is DirectedEdge[u, v] or UndirectedEdge[u, v]. Rule/->
+ * and TwoWayRule/<-> are accepted as parse-time sugar and normalized on
+ * construction. Vertices are arbitrary expressions.
+ *
+ * This mirrors the src/linalg/ layout: one builtin per translation unit,
+ * with the builtin_* prototypes declared here and registered in graph.c.
+ * The set of prototypes grows phase by phase as builtins land.
+ *
+ * Ownership follows the SPEC §4 contract: a builtin takes ownership of its
+ * argument `res`, returns a new Expr* on success (the evaluator frees res),
+ * or NULL to leave the expression unevaluated (the evaluator retains res).
+ */
+
+/* Graph[...] construction: normalizes edge sugar (Rule/TwoWayRule ->
+ * Directed/UndirectedEdge), derives vertices when omitted, validates, and
+ * returns the canonical Graph[List[verts], List[edges]]. Returns NULL to
+ * leave malformed input (self-loops, parallel edges, 3-arg edges, unknown
+ * edge endpoints) unevaluated, and also NULL when the argument is already
+ * canonical (so evaluation reaches a fixed point). */
+Expr* builtin_graph(Expr* res);
+
+/* GraphQ[g]: True iff g is a canonical, valid graph; False otherwise. */
+Expr* builtin_graph_q(Expr* res);
+
+/* Module initializer: registers builtins, attributes, and docstrings.
+ * Called from core_init() in src/core.c. */
+void graph_init(void);
+
+/* ---- Shared helpers (src/graph/graph_util.c) ------------------------------
+ * Used across the subsystem (constructor, predicates, printer, and later the
+ * query/matrix/algorithm builtins). All are read-only over their arguments. */
+
+/* True iff e is a List[...] function node. */
+int graph_is_list(const Expr* e);
+
+/* If e is a normalized 2-argument edge, returns the interned edge-head pointer
+ * (SYM_DirectedEdge or SYM_UndirectedEdge); otherwise NULL. */
+const char* graph_edge_kind(const Expr* e);
+
+/* True iff g is a canonical, valid graph: Graph[List verts, List edges] where
+ * every edge is a 2-arg DirectedEdge/UndirectedEdge, there are no self-loops,
+ * no parallel/duplicate edges, and every edge endpoint appears in verts. */
+int graph_is_valid(const Expr* g);
+
+/* Index of vertex v within List `verts` (linear expr_eq scan), or -1. */
+int graph_vertex_index(const Expr* verts, const Expr* v);
+
+/* ---- Phase 2: query / representation builtins ----------------------------- */
+Expr* builtin_vertex_list(Expr* res);      /* VertexList[g]                    */
+Expr* builtin_edge_list(Expr* res);        /* EdgeList[g]                      */
+Expr* builtin_vertex_count(Expr* res);     /* VertexCount[g]                   */
+Expr* builtin_edge_count(Expr* res);       /* EdgeCount[g]                     */
+Expr* builtin_adjacency_list(Expr* res);   /* AdjacencyList[g] / [g,v]         */
+Expr* builtin_vertex_degree(Expr* res);    /* VertexDegree[g] / [g,v]          */
+Expr* builtin_vertex_in_degree(Expr* res); /* VertexInDegree[g] / [g,v]        */
+Expr* builtin_vertex_out_degree(Expr* res);/* VertexOutDegree[g] / [g,v]       */
+Expr* builtin_directed_graph_q(Expr* res); /* DirectedGraphQ[g]                */
+
+/* ---- Phase 3: matrix views (linalg interop) ------------------------------- */
+Expr* builtin_adjacency_matrix(Expr* res); /* AdjacencyMatrix[g]               */
+Expr* builtin_incidence_matrix(Expr* res); /* IncidenceMatrix[g]               */
+Expr* builtin_adjacency_graph(Expr* res);  /* AdjacencyGraph[m]                */
+
+/* ---- Phase 4: graph generators -------------------------------------------- */
+Expr* builtin_complete_graph(Expr* res);   /* CompleteGraph[n]                 */
+Expr* builtin_cycle_graph(Expr* res);      /* CycleGraph[n]                    */
+Expr* builtin_path_graph(Expr* res);       /* PathGraph[n] / PathGraph[{...}]  */
+Expr* builtin_random_graph(Expr* res);     /* RandomGraph[{n, m}]              */
+
+/* ---- Phase 5: shared adjacency scaffolding (graph_util.c) ------------------
+ * Integer-indexed adjacency derived from a validated graph. Vertex i is
+ * verts[i] (canonical order). `out`/`in` hold successor/predecessor indices;
+ * an UndirectedEdge{a,b} contributes symmetrically to both, so the underlying
+ * undirected neighborhood of v is out[v] together with in[v]. Built on demand
+ * per algorithm call (linear expr_eq indexing; documented upgrade path is an
+ * expr_hash map). The caller owns the result and frees it with graph_adj_free. */
+typedef struct GraphAdj {
+    int   n;              /* number of vertices                                */
+    const Expr* verts;    /* borrowed: the vertex List of the source graph     */
+    int*  outdeg; int** out;   /* successors:   out[i][0..outdeg[i]-1]         */
+    int*  indeg;  int** in;    /* predecessors: in[i][0..indeg[i]-1]           */
+} GraphAdj;
+
+GraphAdj* graph_build_adj(const Expr* g);   /* NULL if g is not a valid graph  */
+void      graph_adj_free(GraphAdj* a);
+
+/* Count connected components of the underlying undirected graph, considering
+ * only vertices with removed[i]==0 (removed may be NULL = none removed). Writes
+ * the number of active vertices to *active_out when non-NULL. */
+int graph_count_components(const GraphAdj* a, const char* removed, int* active_out);
+
+/* ---- Phase 5: search & computation builtins ------------------------------- */
+Expr* builtin_find_shortest_path(Expr* res); /* FindShortestPath[g,s,t]        */
+Expr* builtin_graph_distance(Expr* res);     /* GraphDistance[g,s,t]           */
+Expr* builtin_connected_components(Expr* res);          /* ConnectedComponents  */
+Expr* builtin_weakly_connected_components(Expr* res);   /* Weakly...            */
+Expr* builtin_strongly_connected_components(Expr* res); /* Strongly...          */
+Expr* builtin_find_spanning_tree(Expr* res);            /* FindSpanningTree     */
+Expr* builtin_connected_graph_q(Expr* res);             /* ConnectedGraphQ      */
+Expr* builtin_vertex_connectivity(Expr* res);           /* VertexConnectivity   */
+
+/* ---- Phase 6: visualization ----------------------------------------------- */
+Expr* builtin_graph_plot(Expr* res);        /* GraphPlot[g] -> Graphics[...]   */
+
+#endif /* GRAPH_H */

--- a/src/graph/graph_util.c
+++ b/src/graph/graph_util.c
@@ -1,0 +1,187 @@
+/* graph_util.c - shared, read-only helpers for the graph subsystem.
+ *
+ * Graphs are ordinary Expr trees; these helpers inspect the canonical form
+ *
+ *     Graph[ List[v1, ...], List[edge1, ...] ]
+ *
+ * where each edge is a 2-argument DirectedEdge[u, v] or UndirectedEdge[u, v].
+ * Nothing here allocates or mutates; ownership contracts live in the callers.
+ *
+ * The MVP vertex-membership test is a linear expr_eq scan (O(V) per lookup).
+ * That is fine for pico-CAS graph sizes; an expr_hash-based index is the
+ * documented upgrade path when profiling warrants it.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* True iff e is a function node whose head is the interned symbol `sym`. */
+static int head_is_sym(const Expr* e, const char* sym) {
+    return e && e->type == EXPR_FUNCTION
+        && e->data.function.head
+        && e->data.function.head->type == EXPR_SYMBOL
+        && e->data.function.head->data.symbol == sym;
+}
+
+int graph_is_list(const Expr* e) {
+    return head_is_sym(e, SYM_List);
+}
+
+const char* graph_edge_kind(const Expr* e) {
+    if (!e || e->type != EXPR_FUNCTION || e->data.function.arg_count != 2)
+        return NULL;
+    if (head_is_sym(e, SYM_DirectedEdge))   return SYM_DirectedEdge;
+    if (head_is_sym(e, SYM_UndirectedEdge)) return SYM_UndirectedEdge;
+    return NULL;
+}
+
+/* True iff `v` is structurally equal to some element of List `list`. */
+static int vertex_in_list(const Expr* list, const Expr* v) {
+    for (size_t i = 0; i < list->data.function.arg_count; i++) {
+        if (expr_eq(list->data.function.args[i], v)) return 1;
+    }
+    return 0;
+}
+
+int graph_vertex_index(const Expr* verts, const Expr* v) {
+    if (!graph_is_list(verts)) return -1;
+    for (size_t i = 0; i < verts->data.function.arg_count; i++) {
+        if (expr_eq(verts->data.function.args[i], v)) return (int)i;
+    }
+    return -1;
+}
+
+/* ---- Phase 5: adjacency scaffolding --------------------------------------- */
+
+void graph_adj_free(GraphAdj* a) {
+    if (!a) return;
+    for (int i = 0; i < a->n; i++) { free(a->out[i]); free(a->in[i]); }
+    free(a->out); free(a->in);
+    free(a->outdeg); free(a->indeg);
+    free(a);
+}
+
+GraphAdj* graph_build_adj(const Expr* g) {
+    if (!graph_is_valid(g)) return NULL;
+    const Expr* verts = g->data.function.args[0];
+    const Expr* edges = g->data.function.args[1];
+    int n = (int)verts->data.function.arg_count;
+    size_t ne = edges->data.function.arg_count;
+
+    GraphAdj* a = calloc(1, sizeof(GraphAdj));
+    if (!a) return NULL;
+    a->n = n;
+    a->verts = verts;
+    a->outdeg = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    a->indeg  = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    a->out    = calloc((size_t)(n > 0 ? n : 1), sizeof(int*));
+    a->in     = calloc((size_t)(n > 0 ? n : 1), sizeof(int*));
+
+    /* Pass 1: count degrees. */
+    for (size_t k = 0; k < ne; k++) {
+        const Expr* e = edges->data.function.args[k];
+        const char* kind = graph_edge_kind(e);
+        int ia = graph_vertex_index(verts, e->data.function.args[0]);
+        int ib = graph_vertex_index(verts, e->data.function.args[1]);
+        a->outdeg[ia]++; a->indeg[ib]++;
+        if (kind == SYM_UndirectedEdge) { a->outdeg[ib]++; a->indeg[ia]++; }
+    }
+    for (int i = 0; i < n; i++) {
+        a->out[i] = (a->outdeg[i] > 0) ? calloc((size_t)a->outdeg[i], sizeof(int)) : NULL;
+        a->in[i]  = (a->indeg[i]  > 0) ? calloc((size_t)a->indeg[i],  sizeof(int)) : NULL;
+    }
+
+    /* Pass 2: fill (reuse degree counters as write cursors). */
+    int* oc = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    int* ic = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    for (size_t k = 0; k < ne; k++) {
+        const Expr* e = edges->data.function.args[k];
+        const char* kind = graph_edge_kind(e);
+        int ia = graph_vertex_index(verts, e->data.function.args[0]);
+        int ib = graph_vertex_index(verts, e->data.function.args[1]);
+        a->out[ia][oc[ia]++] = ib;  a->in[ib][ic[ib]++] = ia;
+        if (kind == SYM_UndirectedEdge) {
+            a->out[ib][oc[ib]++] = ia;  a->in[ia][ic[ia]++] = ib;
+        }
+    }
+    free(oc); free(ic);
+    return a;
+}
+
+int graph_count_components(const GraphAdj* a, const char* removed, int* active_out) {
+    int n = a->n;
+    char* seen = calloc((size_t)(n > 0 ? n : 1), sizeof(char));
+    int* stack = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    int comps = 0, active = 0;
+
+    for (int s = 0; s < n; s++) {
+        if (removed && removed[s]) continue;
+        active++;
+        if (seen[s]) continue;
+        /* New component: DFS over underlying undirected neighbors (out + in). */
+        comps++;
+        int top = 0; stack[top++] = s; seen[s] = 1;
+        while (top > 0) {
+            int u = stack[--top];
+            for (int j = 0; j < a->outdeg[u]; j++) {
+                int w = a->out[u][j];
+                if ((removed && removed[w]) || seen[w]) continue;
+                seen[w] = 1; stack[top++] = w;
+            }
+            for (int j = 0; j < a->indeg[u]; j++) {
+                int w = a->in[u][j];
+                if ((removed && removed[w]) || seen[w]) continue;
+                seen[w] = 1; stack[top++] = w;
+            }
+        }
+    }
+    free(seen); free(stack);
+    if (active_out) *active_out = active;
+    return comps;
+}
+
+/* Two normalized edges are "parallel" (duplicates) when they connect the same
+ * endpoints in a way the graph cannot distinguish:
+ *   - directed:   same head and same ordered (u, v);
+ *   - undirected: same head and the same unordered pair {u, v}.
+ * Directed a->b and b->a are distinct; that is allowed. */
+static int edges_parallel(const Expr* e1, const Expr* e2) {
+    const char* k1 = graph_edge_kind(e1);
+    const char* k2 = graph_edge_kind(e2);
+    if (!k1 || k1 != k2) return 0;
+    const Expr* a1 = e1->data.function.args[0];
+    const Expr* b1 = e1->data.function.args[1];
+    const Expr* a2 = e2->data.function.args[0];
+    const Expr* b2 = e2->data.function.args[1];
+    if (expr_eq(a1, a2) && expr_eq(b1, b2)) return 1;
+    if (k1 == SYM_UndirectedEdge && expr_eq(a1, b2) && expr_eq(b1, a2)) return 1;
+    return 0;
+}
+
+int graph_is_valid(const Expr* g) {
+    if (!head_is_sym(g, SYM_Graph) || g->data.function.arg_count != 2)
+        return 0;
+
+    const Expr* verts = g->data.function.args[0];
+    const Expr* edges = g->data.function.args[1];
+    if (!graph_is_list(verts) || !graph_is_list(edges)) return 0;
+
+    size_t ne = edges->data.function.arg_count;
+    for (size_t i = 0; i < ne; i++) {
+        const Expr* edge = edges->data.function.args[i];
+        if (!graph_edge_kind(edge)) return 0;              /* un-normalized/3-arg */
+
+        const Expr* u = edge->data.function.args[0];
+        const Expr* v = edge->data.function.args[1];
+        if (expr_eq(u, v)) return 0;                        /* self-loop */
+        if (!vertex_in_list(verts, u)) return 0;            /* endpoint not a vertex */
+        if (!vertex_in_list(verts, v)) return 0;
+
+        for (size_t j = 0; j < i; j++) {
+            if (edges_parallel(edge, edges->data.function.args[j])) return 0;
+        }
+    }
+    return 1;
+}

--- a/src/graph/graphplot.c
+++ b/src/graph/graphplot.c
@@ -1,0 +1,81 @@
+/* graphplot.c - GraphPlot[g]: render a graph as a Graphics[...] expression.
+ *
+ * Emits the same primitives the plotting engine uses (Line, Disk, Text), so the
+ * existing renderer draws it with no renderer changes (and the text placeholder
+ * is used when USE_GRAPHICS=0). Vertices are laid out on a circle (MVP layout;
+ * a force-directed spring layout is the documented future hook). Each edge is a
+ * Line between its endpoints, each vertex a Disk plus a Text label.
+ *
+ * Directed edges are drawn as plain lines in the MVP (no arrowheads yet).
+ *
+ * Memory (SPEC section 4): returns a freshly-allocated Graphics tree; the
+ * evaluator frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <math.h>
+#include <stdlib.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#define NODE_RADIUS 0.08
+
+static Expr* point2(double x, double y) {
+    Expr* xy[2] = { expr_new_real(x), expr_new_real(y) };
+    return expr_new_function(expr_new_symbol(SYM_List), xy, 2);
+}
+
+Expr* builtin_graph_plot(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+
+    const Expr* verts = g->data.function.args[0];
+    const Expr* edges = g->data.function.args[1];
+    int n = (int)verts->data.function.arg_count;
+    size_t ne = edges->data.function.arg_count;
+
+    /* Circular layout coordinates. */
+    double* x = (n > 0) ? calloc((size_t)n, sizeof(double)) : NULL;
+    double* y = (n > 0) ? calloc((size_t)n, sizeof(double)) : NULL;
+    for (int i = 0; i < n; i++) {
+        if (n == 1) { x[i] = 0.0; y[i] = 0.0; }
+        else {
+            double t = 2.0 * M_PI * (double)i / (double)n;
+            x[i] = cos(t); y[i] = sin(t);
+        }
+    }
+
+    /* Primitives: one Line per edge, then one Disk + one Text per vertex. */
+    size_t total = ne + (size_t)n * 2;
+    Expr** prims = (total > 0) ? calloc(total, sizeof(Expr*)) : NULL;
+    size_t p = 0;
+
+    for (size_t k = 0; k < ne; k++) {
+        const Expr* e = edges->data.function.args[k];
+        int iu = graph_vertex_index(verts, e->data.function.args[0]);
+        int iv = graph_vertex_index(verts, e->data.function.args[1]);
+        Expr* pts[2] = { point2(x[iu], y[iu]), point2(x[iv], y[iv]) };
+        Expr* seg = expr_new_function(expr_new_symbol(SYM_List), pts, 2);
+        Expr* la[1] = { seg };
+        prims[p++] = expr_new_function(expr_new_symbol(SYM_Line), la, 1);
+    }
+    for (int i = 0; i < n; i++) {
+        Expr* da[2] = { point2(x[i], y[i]), expr_new_real(NODE_RADIUS) };
+        prims[p++] = expr_new_function(expr_new_symbol(SYM_Disk), da, 2);
+    }
+    for (int i = 0; i < n; i++) {
+        Expr* ta[2] = { expr_copy(verts->data.function.args[i]), point2(x[i], y[i]) };
+        prims[p++] = expr_new_function(expr_new_symbol(SYM_Text), ta, 2);
+    }
+
+    free(x); free(y);
+    Expr* prim_list = expr_new_function(expr_new_symbol(SYM_List), prims, total);
+    free(prims);
+    Expr* ga[1] = { prim_list };
+    return expr_new_function(expr_new_symbol(SYM_Graphics), ga, 1);
+}

--- a/src/graph/graphq.c
+++ b/src/graph/graphq.c
@@ -1,0 +1,19 @@
+/* graphq.c - GraphQ[g]: is g a valid graph?
+ *
+ * A thin wrapper over graph_is_valid (graph_util.c): returns the symbol True
+ * when the (already-evaluated) argument is a canonical, valid graph, and False
+ * otherwise. Non-unary calls are left unevaluated (NULL).
+ *
+ * Memory (SPEC section 4): returns a freshly-allocated symbol; the evaluator
+ * frees `res`.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+
+Expr* builtin_graph_q(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* arg = res->data.function.args[0];
+    return expr_new_symbol(graph_is_valid(arg) ? SYM_True : SYM_False);
+}

--- a/src/graph/incmat.c
+++ b/src/graph/incmat.c
@@ -1,0 +1,54 @@
+/* incmat.c - IncidenceMatrix[g]: |V| x |E| incidence matrix.
+ *
+ * Column j corresponds to edge j (canonical order), row i to vertex i.
+ *   - UndirectedEdge{a,b}: entries (a,j) and (b,j) are 1.
+ *   - DirectedEdge[a,b]:   (a,j) = -1 (tail), (b,j) = 1 (head)  [oriented].
+ *
+ * Memory (SPEC section 4): returns a freshly-allocated matrix; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+Expr* builtin_incidence_matrix(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+
+    const Expr* verts = g->data.function.args[0];
+    const Expr* edges = g->data.function.args[1];
+    size_t n = verts->data.function.arg_count;
+    size_t m = edges->data.function.arg_count;
+
+    int* grid = (n > 0 && m > 0) ? calloc(n * m, sizeof(int)) : NULL;
+    if (n > 0 && m > 0 && !grid) return NULL;
+
+    for (size_t j = 0; j < m; j++) {
+        const Expr* e = edges->data.function.args[j];
+        const char* kind = graph_edge_kind(e);
+        int ia = graph_vertex_index(verts, e->data.function.args[0]);
+        int ib = graph_vertex_index(verts, e->data.function.args[1]);
+        if (kind == SYM_UndirectedEdge) {
+            grid[(size_t)ia * m + j] = 1;
+            grid[(size_t)ib * m + j] = 1;
+        } else {
+            grid[(size_t)ia * m + j] = -1;   /* tail */
+            grid[(size_t)ib * m + j] = 1;    /* head */
+        }
+    }
+
+    Expr** rows = (n > 0) ? calloc(n, sizeof(Expr*)) : NULL;
+    for (size_t i = 0; i < n; i++) {
+        Expr** row = (m > 0) ? calloc(m, sizeof(Expr*)) : NULL;
+        for (size_t j = 0; j < m; j++)
+            row[j] = expr_new_integer(grid[i * m + j]);
+        rows[i] = expr_new_function(expr_new_symbol(SYM_List), row, m);
+        free(row);
+    }
+    Expr* mat = expr_new_function(expr_new_symbol(SYM_List), rows, n);
+    free(rows);
+    free(grid);
+    return mat;
+}

--- a/src/graph/shortestpath.c
+++ b/src/graph/shortestpath.c
@@ -1,0 +1,86 @@
+/* shortestpath.c - FindShortestPath[g,s,t] and GraphDistance[g,s,t].
+ *
+ * Unweighted breadth-first search over the successor adjacency (out[]): for a
+ * directed graph this follows edge direction; for an undirected graph out[] is
+ * symmetric, so it is an ordinary shortest path. Wolfram's naming split is
+ * kept: FindShortestPath returns the vertex path, GraphDistance the length.
+ *
+ * Unreachable target: FindShortestPath -> {} (empty list), GraphDistance ->
+ * Infinity.
+ *
+ * Memory (SPEC section 4): returns freshly-allocated results; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* BFS from src over out[]; fills parent[] (-1 = root/unvisited) and dist[]
+ * (-1 = unreached). Caller allocates parent/dist of length a->n. */
+static void bfs(const GraphAdj* a, int src, int* parent, int* dist) {
+    for (int i = 0; i < a->n; i++) { parent[i] = -1; dist[i] = -1; }
+    int* q = calloc((size_t)(a->n > 0 ? a->n : 1), sizeof(int));
+    int head = 0, tail = 0;
+    dist[src] = 0; q[tail++] = src;
+    while (head < tail) {
+        int u = q[head++];
+        for (int j = 0; j < a->outdeg[u]; j++) {
+            int w = a->out[u][j];
+            if (dist[w] < 0) { dist[w] = dist[u] + 1; parent[w] = u; q[tail++] = w; }
+        }
+    }
+    free(q);
+}
+
+/* Resolve g, s, t to a GraphAdj and endpoint indices. Returns adj (caller frees)
+ * or NULL; on success sets *is,*it. */
+static GraphAdj* resolve(Expr* res, int* is, int* it) {
+    if (res->data.function.arg_count != 3) return NULL;
+    const Expr* g = res->data.function.args[0];
+    GraphAdj* a = graph_build_adj(g);
+    if (!a) return NULL;
+    *is = graph_vertex_index(a->verts, res->data.function.args[1]);
+    *it = graph_vertex_index(a->verts, res->data.function.args[2]);
+    if (*is < 0 || *it < 0) { graph_adj_free(a); return NULL; }
+    return a;
+}
+
+Expr* builtin_find_shortest_path(Expr* res) {
+    int is, it;
+    GraphAdj* a = resolve(res, &is, &it);
+    if (!a) return NULL;
+
+    int* parent = calloc((size_t)a->n, sizeof(int));
+    int* dist   = calloc((size_t)a->n, sizeof(int));
+    bfs(a, is, parent, dist);
+
+    Expr* out;
+    if (dist[it] < 0) {
+        out = expr_new_function(expr_new_symbol(SYM_List), NULL, 0);  /* {} */
+    } else {
+        int len = dist[it] + 1;
+        Expr** path = calloc((size_t)len, sizeof(Expr*));
+        int v = it;
+        for (int k = len - 1; k >= 0; k--) { path[k] = expr_copy(a->verts->data.function.args[v]); v = parent[v]; }
+        out = expr_new_function(expr_new_symbol(SYM_List), path, (size_t)len);
+        free(path);
+    }
+    free(parent); free(dist); graph_adj_free(a);
+    return out;
+}
+
+Expr* builtin_graph_distance(Expr* res) {
+    int is, it;
+    GraphAdj* a = resolve(res, &is, &it);
+    if (!a) return NULL;
+
+    int* parent = calloc((size_t)a->n, sizeof(int));
+    int* dist   = calloc((size_t)a->n, sizeof(int));
+    bfs(a, is, parent, dist);
+
+    Expr* out = (dist[it] < 0) ? expr_new_symbol(SYM_Infinity)
+                               : expr_new_integer(dist[it]);
+    free(parent); free(dist); graph_adj_free(a);
+    return out;
+}

--- a/src/graph/spanningtree.c
+++ b/src/graph/spanningtree.c
@@ -1,0 +1,75 @@
+/* spanningtree.c - FindSpanningTree[g].
+ *
+ * A BFS spanning forest of the underlying undirected graph: for each component,
+ * the tree edges chosen by BFS are collected in their original form (preserving
+ * DirectedEdge/UndirectedEdge and orientation). Returns Graph[verts, treeEdges];
+ * for a connected graph the tree has VertexCount - 1 edges.
+ *
+ * Memory (SPEC section 4): returns a freshly-allocated Graph; frees res.
+ */
+
+#include "graph.h"
+#include "expr.h"
+#include "sym_names.h"
+#include <stdlib.h>
+
+/* Copy the original edge of g connecting vertex indices iu and iv (either
+ * orientation / kind), or NULL if none. */
+static Expr* original_edge_copy(const Expr* g, int iu, int iv) {
+    const Expr* verts = g->data.function.args[0];
+    const Expr* edges = g->data.function.args[1];
+    for (size_t k = 0; k < edges->data.function.arg_count; k++) {
+        const Expr* e = edges->data.function.args[k];
+        int a = graph_vertex_index(verts, e->data.function.args[0]);
+        int b = graph_vertex_index(verts, e->data.function.args[1]);
+        if ((a == iu && b == iv) || (a == iv && b == iu)) return expr_copy((Expr*)e);
+    }
+    return NULL;
+}
+
+Expr* builtin_find_spanning_tree(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    GraphAdj* a = graph_build_adj(g);
+    if (!a) return NULL;
+    int n = a->n;
+
+    char* seen = calloc((size_t)(n > 0 ? n : 1), sizeof(char));
+    int* q = calloc((size_t)(n > 0 ? n : 1), sizeof(int));
+    Expr** tree = (n > 0) ? calloc((size_t)n, sizeof(Expr*)) : NULL;  /* <= n-1 edges */
+    size_t te = 0;
+
+    for (int s = 0; s < n; s++) {
+        if (seen[s]) continue;
+        int head = 0, tail = 0;
+        seen[s] = 1; q[tail++] = s;
+        while (head < tail) {
+            int u = q[head++];
+            /* Underlying undirected neighbors: out then in. */
+            for (int pass = 0; pass < 2; pass++) {
+                int deg = pass ? a->indeg[u] : a->outdeg[u];
+                int* nb = pass ? a->in[u]   : a->out[u];
+                for (int j = 0; j < deg; j++) {
+                    int w = nb[j];
+                    if (seen[w]) continue;
+                    seen[w] = 1; q[tail++] = w;
+                    Expr* e = original_edge_copy(g, u, w);
+                    if (e) tree[te++] = e;
+                }
+            }
+        }
+    }
+
+    Expr* elist = expr_new_function(expr_new_symbol(SYM_List), tree, te);
+    free(tree);
+    /* Fresh copy of the vertex list. */
+    size_t nv = (size_t)n;
+    Expr** vcopy = (nv > 0) ? calloc(nv, sizeof(Expr*)) : NULL;
+    for (size_t i = 0; i < nv; i++) vcopy[i] = expr_copy(a->verts->data.function.args[i]);
+    Expr* vlist = expr_new_function(expr_new_symbol(SYM_List), vcopy, nv);
+    free(vcopy);
+
+    free(seen); free(q); graph_adj_free(a);
+    Expr* gargs[2] = { vlist, elist };
+    return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+}

--- a/src/graph/vertexlist.c
+++ b/src/graph/vertexlist.c
@@ -1,0 +1,13 @@
+/* vertexlist.c - VertexList[g]: the graph's vertices, in canonical order.
+ * Thin reader over the canonical form; NULL (unevaluated) if g is not a graph.
+ * Memory (SPEC section 4): returns a fresh copy; the evaluator frees res. */
+
+#include "graph.h"
+#include "expr.h"
+
+Expr* builtin_vertex_list(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;
+    const Expr* g = res->data.function.args[0];
+    if (!graph_is_valid(g)) return NULL;
+    return expr_copy(g->data.function.args[0]);
+}

--- a/src/graphics/graphics_json.c
+++ b/src/graphics/graphics_json.c
@@ -21,6 +21,13 @@
  *     $PlotResample[...]
  *   ]
  *
+ * GraphPlot[] instead emits node-link diagrams built from Line (edges),
+ * Disk (vertices), and Text (labels). When Disk or Text primitives are
+ * present the converter switches to "diagram mode": vertices become marker
+ * points, labels become annotations, and the layout uses an equal-aspect
+ * (scaleanchor) square with hidden axes -- so a graph draws as a graph, not
+ * as an XY function plot.
+ *
  * Output JSON (Plotly format):
  *
  *   {
@@ -29,13 +36,7 @@
  *        "line":{"color":"rgba(51,102,204,1.0)","width":1.5}},
  *       ...
  *     ],
- *     "layout": {
- *       "xaxis":{"showgrid":true,"zeroline":true},
- *       "yaxis":{"showgrid":true,"zeroline":true},
- *       "margin":{"l":50,"r":20,"t":20,"b":50},
- *       "height":350,
- *       "plot_bgcolor":"#fff","paper_bgcolor":"#fff"
- *     }
+ *     "layout": { ... }
  *   }
  */
 
@@ -83,9 +84,12 @@ static int buf_cat(Buf* b, const char* s) {
     return 1;
 }
 
-/* Append a double value — use %g to keep it compact. */
+/* Append a double value — use %g to keep it compact. Snap sub-noise
+ * magnitudes to 0 so floating-point dust (e.g. sin(pi) ~ 1e-16) does not
+ * blow up an auto-ranged axis. */
 static int buf_catd(Buf* b, double v) {
     char tmp[64];
+    if (fabs(v) < 1e-12) v = 0.0;
     snprintf(tmp, sizeof(tmp), "%.7g", v);
     return buf_cat(b, tmp);
 }
@@ -109,6 +113,38 @@ static int expr_to_double(const Expr* e, double* out) {
     if (e->type == EXPR_INTEGER) { *out = (double)e->data.integer;    return 1; }
     if (e->type == EXPR_BIGINT)  { *out = mpz_get_d(e->data.bigint);  return 1; }
     return 0;
+}
+
+/* Read a coordinate pair List[x, y] into x/y. */
+static int get_xy(const Expr* pair, double* x, double* y) {
+    if (!head_is(pair, SYM_List) || pair->data.function.arg_count < 2) return 0;
+    return expr_to_double(pair->data.function.args[0], x)
+        && expr_to_double(pair->data.function.args[1], y);
+}
+
+/* Append a JSON string literal (with surrounding quotes) for a text label,
+ * escaping the characters JSON requires. */
+static void append_label(Buf* b, const Expr* e) {
+    char tmp[64];
+    const char* s = NULL;
+    if (e && e->type == EXPR_STRING)      s = e->data.string;
+    else if (e && e->type == EXPR_SYMBOL) s = e->data.symbol;
+    else if (e && e->type == EXPR_INTEGER) {
+        snprintf(tmp, sizeof(tmp), "%lld", (long long)e->data.integer); s = tmp;
+    } else {
+        double d;
+        if (e && expr_to_double(e, &d)) { snprintf(tmp, sizeof(tmp), "%.7g", d); s = tmp; }
+        else s = "?";
+    }
+    buf_cat(b, "\"");
+    for (; *s; s++) {
+        unsigned char c = (unsigned char)*s;
+        if (c == '"' || c == '\\') { char e2[3] = {'\\', (char)c, 0}; buf_cat(b, e2); }
+        else if (c == '\n') buf_cat(b, "\\n");
+        else if (c < 0x20)  { char u[8]; snprintf(u, sizeof(u), "\\u%04x", c); buf_cat(b, u); }
+        else { char one[2] = {(char)c, 0}; buf_cat(b, one); }
+    }
+    buf_cat(b, "\"");
 }
 
 /* -----------------------------------------------------------------------
@@ -159,8 +195,22 @@ char* graphics_to_plotly_json(const Expr* g) {
     const Expr* prim_list = g->data.function.args[0];
     if (!head_is(prim_list, SYM_List)) return NULL;
 
-    Buf data_buf;
+    size_t n = prim_list->data.function.arg_count;
+
+    /* Diagram mode: a node-link picture (GraphPlot) rather than a function
+     * plot. Signalled by the presence of Disk (vertices) or Text (labels),
+     * which Plot[] never emits. */
+    int diagram_mode = 0;
+    for (size_t i = 0; i < n; i++) {
+        const Expr* p = prim_list->data.function.args[i];
+        if (head_is(p, SYM_Disk) || head_is(p, SYM_Text)) { diagram_mode = 1; break; }
+    }
+
+    Buf data_buf, anno_buf;
     if (!buf_init(&data_buf, 65536)) return NULL;
+    if (!buf_init(&anno_buf, 4096)) { buf_free(&data_buf); return NULL; }
+    buf_cat(&anno_buf, "[");
+    int first_anno = 1;
 
     /* Track current drawing state. */
     double cur_r = 0.2, cur_g = 0.4, cur_b = 0.8; /* Mathematica default blue */
@@ -169,7 +219,6 @@ char* graphics_to_plotly_json(const Expr* g) {
 
     buf_cat(&data_buf, "[");
 
-    size_t n = prim_list->data.function.arg_count;
     for (size_t i = 0; i < n; i++) {
         const Expr* p = prim_list->data.function.args[i];
         if (!p) continue;
@@ -211,7 +260,9 @@ char* graphics_to_plotly_json(const Expr* g) {
             append_coord_array(&data_buf, pts, 1);
             buf_cat(&data_buf, ",\"line\":{\"color\":\"");
             buf_cat(&data_buf, color_str);
-            buf_cat(&data_buf, "\",\"width\":1.5},\"showlegend\":false}");
+            /* Diagram edges a touch heavier; plot curves stay thin. */
+            buf_cat(&data_buf, diagram_mode ? "\",\"width\":2},\"hoverinfo\":\"skip\",\"showlegend\":false}"
+                                            : "\",\"width\":1.5},\"showlegend\":false}");
             continue;
         }
 
@@ -238,35 +289,114 @@ char* graphics_to_plotly_json(const Expr* g) {
             continue;
         }
 
+        /* ----- Disk[{x,y}, r] — a vertex marker ---------------------- */
+        if (head_is(p, SYM_Disk) && p->data.function.arg_count >= 1) {
+            double x, y;
+            if (!get_xy(p->data.function.args[0], &x, &y)) continue;
+
+            char color_str[64];
+            rgba_str(color_str, sizeof(color_str), cur_r, cur_g, cur_b, 1.0);
+
+            if (!first_trace) buf_cat(&data_buf, ",");
+            first_trace = 0;
+
+            buf_cat(&data_buf, "{\"type\":\"scatter\",\"mode\":\"markers\",\"x\":[");
+            buf_catd(&data_buf, x);
+            buf_cat(&data_buf, "],\"y\":[");
+            buf_catd(&data_buf, y);
+            buf_cat(&data_buf, "],\"marker\":{\"size\":22,\"color\":\"");
+            buf_cat(&data_buf, color_str);
+            buf_cat(&data_buf, "\"},\"hoverinfo\":\"skip\",\"showlegend\":false}");
+            continue;
+        }
+
+        /* ----- Point[List[pts...]] — marker points ------------------- */
+        if (head_is(p, SYM_Point) && p->data.function.arg_count >= 1) {
+            const Expr* pts = p->data.function.args[0];
+            if (!head_is(pts, SYM_List)) continue;
+
+            char color_str[64];
+            rgba_str(color_str, sizeof(color_str), cur_r, cur_g, cur_b, 1.0);
+
+            if (!first_trace) buf_cat(&data_buf, ",");
+            first_trace = 0;
+
+            buf_cat(&data_buf, "{\"type\":\"scatter\",\"mode\":\"markers\",\"x\":");
+            append_coord_array(&data_buf, pts, 0);
+            buf_cat(&data_buf, ",\"y\":");
+            append_coord_array(&data_buf, pts, 1);
+            buf_cat(&data_buf, ",\"marker\":{\"size\":8,\"color\":\"");
+            buf_cat(&data_buf, color_str);
+            buf_cat(&data_buf, "\"},\"showlegend\":false}");
+            continue;
+        }
+
+        /* ----- Text[label, {x,y}] — an annotation -------------------- */
+        if (head_is(p, SYM_Text) && p->data.function.arg_count >= 2) {
+            double x, y;
+            if (!get_xy(p->data.function.args[1], &x, &y)) continue;
+
+            if (!first_anno) buf_cat(&anno_buf, ",");
+            first_anno = 0;
+
+            buf_cat(&anno_buf, "{\"x\":");
+            buf_catd(&anno_buf, x);
+            buf_cat(&anno_buf, ",\"y\":");
+            buf_catd(&anno_buf, y);
+            buf_cat(&anno_buf, ",\"text\":");
+            append_label(&anno_buf, p->data.function.args[0]);
+            /* White label centred on the vertex marker. */
+            buf_cat(&anno_buf, ",\"showarrow\":false,\"font\":{\"color\":\"#fff\",\"size\":12}}");
+            continue;
+        }
+
         /* All other primitives (Rule, $PlotResample, etc.) — skip. */
     }
 
     buf_cat(&data_buf, "]");
+    buf_cat(&anno_buf, "]");
 
     /* Build the layout object. */
-    char layout[512];
-    snprintf(layout, sizeof(layout),
-             "{\"xaxis\":{\"showgrid\":true,\"zeroline\":true,"
-             "\"zerolinecolor\":\"#aaa\",\"zerolinewidth\":1},"
-             "\"yaxis\":{\"showgrid\":true,\"zeroline\":true,"
-             "\"zerolinecolor\":\"#aaa\",\"zerolinewidth\":1},"
-             "\"margin\":{\"l\":50,\"r\":20,\"t\":20,\"b\":50},"
-             "\"height\":350,"
-             "\"plot_bgcolor\":\"#fff\","
-             "\"paper_bgcolor\":\"#fff\"}");
+    Buf layout;
+    if (!buf_init(&layout, 1024)) { buf_free(&data_buf); buf_free(&anno_buf); return NULL; }
+    if (diagram_mode) {
+        /* Square, axis-free canvas with equal x/y scaling so a circular
+         * vertex layout stays circular. */
+        buf_cat(&layout,
+            "{\"xaxis\":{\"visible\":false,\"showgrid\":false,\"zeroline\":false},"
+            "\"yaxis\":{\"visible\":false,\"showgrid\":false,\"zeroline\":false,"
+            "\"scaleanchor\":\"x\",\"scaleratio\":1},"
+            "\"margin\":{\"l\":20,\"r\":20,\"t\":20,\"b\":20},"
+            "\"height\":400,\"showlegend\":false,"
+            "\"plot_bgcolor\":\"#fff\",\"paper_bgcolor\":\"#fff\",");
+        buf_cat(&layout, "\"annotations\":");
+        buf_cat(&layout, anno_buf.buf);
+        buf_cat(&layout, "}");
+    } else {
+        buf_cat(&layout,
+            "{\"xaxis\":{\"showgrid\":true,\"zeroline\":true,"
+            "\"zerolinecolor\":\"#aaa\",\"zerolinewidth\":1},"
+            "\"yaxis\":{\"showgrid\":true,\"zeroline\":true,"
+            "\"zerolinecolor\":\"#aaa\",\"zerolinewidth\":1},"
+            "\"margin\":{\"l\":50,\"r\":20,\"t\":20,\"b\":50},"
+            "\"height\":350,"
+            "\"plot_bgcolor\":\"#fff\",\"paper_bgcolor\":\"#fff\"}");
+    }
 
     /* Assemble the final JSON object. */
     Buf out;
-    if (!buf_init(&out, data_buf.len + 1024)) {
-        buf_free(&data_buf);
+    if (!buf_init(&out, data_buf.len + layout.len + 64)) {
+        buf_free(&data_buf); buf_free(&anno_buf); buf_free(&layout);
         return NULL;
     }
     buf_cat(&out, "{\"data\":");
     buf_cat(&out, data_buf.buf);
     buf_cat(&out, ",\"layout\":");
-    buf_cat(&out, layout);
+    buf_cat(&out, layout.buf);
     buf_cat(&out, "}");
 
     buf_free(&data_buf);
+    buf_free(&anno_buf);
+    buf_free(&layout);
     return out.buf; /* caller frees */
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -706,6 +706,7 @@ typedef enum {
     OP_APPLY1,
     OP_RULE,
     OP_RULEDELAYED,
+    OP_TWOWAYRULE,
     OP_CONDITION,
     OP_ALTERNATIVES,
     OP_MAP,
@@ -765,6 +766,11 @@ static OperatorDef get_operator(const char* pos) {
         def.type = OP_REPLACEREPEATED; def.prec = 110; def.right_assoc = 0; def.head_name = "ReplaceRepeated"; def.len = 3;
     } else if (strncmp(pos, "//@", 3) == 0) {
         def.type = OP_MAPALL; def.prec = 620; def.right_assoc = 1; def.head_name = "MapAll"; def.len = 3;
+    } else if (strncmp(pos, "<->", 3) == 0) {
+        /* TwoWayRule (u <-> v). Same precedence/associativity as Rule; the
+         * graph subsystem normalizes it to UndirectedEdge on construction.
+         * Checked before "<>", "<=", "<" so the 3-char form wins. */
+        def.type = OP_TWOWAYRULE; def.prec = 120; def.right_assoc = 1; def.head_name = "TwoWayRule"; def.len = 3;
     } else if (strncmp(pos, "//", 2) == 0) {
         def.type = OP_POSTFIX; def.prec = 70; def.head_name = "Postfix"; def.len = 2;
     } else if (strncmp(pos, "/.", 2) == 0 && !isdigit(pos[2])) {

--- a/src/print.c
+++ b/src/print.c
@@ -12,6 +12,7 @@
 #include "arithmetic.h"
 #include "context.h"
 #include "sym_names.h"
+#include "graph.h"   /* graph_is_list, for the Graph[...] summary form */
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -50,6 +51,7 @@ static int get_expr_prec(Expr* e) {
     if (head == SYM_Set || head == SYM_SetDelayed) return 40;
     if (head == SYM_MessageName) return 780;
     if (head == SYM_Rule || head == SYM_RuleDelayed) return 120;
+    if (head == SYM_DirectedEdge || head == SYM_UndirectedEdge) return 120;
     if (head == SYM_Condition) return 130;
     if (head == SYM_Alternatives) return 160;
     if (head == SYM_Repeated || head == SYM_RepeatedNull) return 170;
@@ -187,6 +189,26 @@ static void print_standard(Expr* e, int parent_prec) {
         }
         else if (head == SYM_Graphics && e->data.function.arg_count >= 1 && g_inputform_depth == 0) {
             printf("-Graphics-");
+        }
+        else if ((head == SYM_DirectedEdge || head == SYM_UndirectedEdge)
+                 && e->data.function.arg_count == 2) {
+            /* u -> v (directed) / u <-> v (undirected). Infix in both Standard
+             * and Input forms so the literal round-trips through the parser. */
+            print_standard(e->data.function.args[0], my_prec);
+            printf("%s", head == SYM_DirectedEdge ? " -> " : " <-> ");
+            print_standard(e->data.function.args[1], my_prec);
+        }
+        else if (head == SYM_Graph && e->data.function.arg_count == 2
+                 && g_inputform_depth == 0
+                 && graph_is_list(e->data.function.args[0])
+                 && graph_is_list(e->data.function.args[1])) {
+            /* Terse summary in standard output; InputForm/FullForm fall through
+             * to the literal Graph[{...}, {...}] constructor (round-trippable). */
+            unsigned long nv = (unsigned long)e->data.function.args[0]->data.function.arg_count;
+            unsigned long ne = (unsigned long)e->data.function.args[1]->data.function.arg_count;
+            printf("Graph[<%lu %s, %lu %s>]",
+                   nv, nv == 1 ? "vertex" : "vertices",
+                   ne, ne == 1 ? "edge" : "edges");
         }
         else if (head == SYM_Rational && e->data.function.arg_count == 2) {
             print_standard(e->data.function.args[0], 470);

--- a/src/repl.c
+++ b/src/repl.c
@@ -373,12 +373,34 @@ static void json_escape(const char* s, char* out, size_t outlen) {
 static void pipe_process_input(const char* input, int id) {
     Expr* parsed = parse_expression(input);
     if (!parsed) {
-        char buf[256];
-        snprintf(buf, sizeof(buf),
-                 "{\"id\":%d,\"type\":\"error\",\"message\":\"Parse error\"}", id);
-        pipe_emit(buf);
-        snprintf(buf, sizeof(buf), "{\"id\":%d,\"type\":\"done\"}", id);
-        pipe_emit(buf);
+        /* Echo the exact received input in the error so a stray/invisible
+         * character or bracket mismatch in the caller's text is diagnosable
+         * rather than an opaque "Parse error". */
+        size_t esc_cap = strlen(input) * 6 + 8;
+        char* esc = malloc(esc_cap);
+        char* buf = NULL;
+        if (esc) {
+            json_escape(input, esc, esc_cap);
+            size_t bcap = esc_cap + 128;
+            buf = malloc(bcap);
+            if (buf)
+                snprintf(buf, bcap,
+                    "{\"id\":%d,\"type\":\"error\",\"message\":\"Parse error: %s\"}",
+                    id, esc);
+        }
+        if (buf) {
+            pipe_emit(buf);
+        } else {
+            char sbuf[128];
+            snprintf(sbuf, sizeof(sbuf),
+                "{\"id\":%d,\"type\":\"error\",\"message\":\"Parse error\"}", id);
+            pipe_emit(sbuf);
+        }
+        free(esc);
+        free(buf);
+        char dbuf[64];
+        snprintf(dbuf, sizeof(dbuf), "{\"id\":%d,\"type\":\"done\"}", id);
+        pipe_emit(dbuf);
         return;
     }
 

--- a/src/sym_names.c
+++ b/src/sym_names.c
@@ -616,6 +616,38 @@ const char* SYM_LabelStyle = NULL;
 const char* SYM_PlotLegendData = NULL;
 const char* SYM_PlotResample = NULL;
 
+/* Graph subsystem (src/graph/). */
+const char* SYM_Graph = NULL;
+const char* SYM_DirectedEdge = NULL;
+const char* SYM_UndirectedEdge = NULL;
+const char* SYM_TwoWayRule = NULL;
+const char* SYM_GraphQ = NULL;
+const char* SYM_DirectedGraphQ = NULL;
+const char* SYM_ConnectedGraphQ = NULL;
+const char* SYM_VertexList = NULL;
+const char* SYM_EdgeList = NULL;
+const char* SYM_VertexCount = NULL;
+const char* SYM_EdgeCount = NULL;
+const char* SYM_AdjacencyList = NULL;
+const char* SYM_VertexDegree = NULL;
+const char* SYM_VertexInDegree = NULL;
+const char* SYM_VertexOutDegree = NULL;
+const char* SYM_AdjacencyMatrix = NULL;
+const char* SYM_IncidenceMatrix = NULL;
+const char* SYM_AdjacencyGraph = NULL;
+const char* SYM_CompleteGraph = NULL;
+const char* SYM_CycleGraph = NULL;
+const char* SYM_PathGraph = NULL;
+const char* SYM_RandomGraph = NULL;
+const char* SYM_FindShortestPath = NULL;
+const char* SYM_GraphDistance = NULL;
+const char* SYM_ConnectedComponents = NULL;
+const char* SYM_WeaklyConnectedComponents = NULL;
+const char* SYM_StronglyConnectedComponents = NULL;
+const char* SYM_FindSpanningTree = NULL;
+const char* SYM_VertexConnectivity = NULL;
+const char* SYM_GraphPlot = NULL;
+
 void sym_names_init(void) {
     /* intern_symbol is idempotent and stable, so this can run multiple
      * times without re-allocating. */
@@ -1224,6 +1256,38 @@ void sym_names_init(void) {
     SYM_LabelStyle                 = intern_symbol("LabelStyle");
     SYM_PlotLegendData             = intern_symbol("$PlotLegendData");
     SYM_PlotResample               = intern_symbol("$PlotResample");
+
+    /* Graph subsystem (src/graph/). */
+    SYM_Graph                      = intern_symbol("Graph");
+    SYM_DirectedEdge               = intern_symbol("DirectedEdge");
+    SYM_UndirectedEdge             = intern_symbol("UndirectedEdge");
+    SYM_TwoWayRule                 = intern_symbol("TwoWayRule");
+    SYM_GraphQ                     = intern_symbol("GraphQ");
+    SYM_DirectedGraphQ             = intern_symbol("DirectedGraphQ");
+    SYM_ConnectedGraphQ            = intern_symbol("ConnectedGraphQ");
+    SYM_VertexList                 = intern_symbol("VertexList");
+    SYM_EdgeList                   = intern_symbol("EdgeList");
+    SYM_VertexCount                = intern_symbol("VertexCount");
+    SYM_EdgeCount                  = intern_symbol("EdgeCount");
+    SYM_AdjacencyList              = intern_symbol("AdjacencyList");
+    SYM_VertexDegree               = intern_symbol("VertexDegree");
+    SYM_VertexInDegree             = intern_symbol("VertexInDegree");
+    SYM_VertexOutDegree            = intern_symbol("VertexOutDegree");
+    SYM_AdjacencyMatrix            = intern_symbol("AdjacencyMatrix");
+    SYM_IncidenceMatrix            = intern_symbol("IncidenceMatrix");
+    SYM_AdjacencyGraph             = intern_symbol("AdjacencyGraph");
+    SYM_CompleteGraph              = intern_symbol("CompleteGraph");
+    SYM_CycleGraph                 = intern_symbol("CycleGraph");
+    SYM_PathGraph                  = intern_symbol("PathGraph");
+    SYM_RandomGraph                = intern_symbol("RandomGraph");
+    SYM_FindShortestPath           = intern_symbol("FindShortestPath");
+    SYM_GraphDistance              = intern_symbol("GraphDistance");
+    SYM_ConnectedComponents        = intern_symbol("ConnectedComponents");
+    SYM_WeaklyConnectedComponents  = intern_symbol("WeaklyConnectedComponents");
+    SYM_StronglyConnectedComponents = intern_symbol("StronglyConnectedComponents");
+    SYM_FindSpanningTree           = intern_symbol("FindSpanningTree");
+    SYM_VertexConnectivity         = intern_symbol("VertexConnectivity");
+    SYM_GraphPlot                  = intern_symbol("GraphPlot");
 
     /* System symbols that have no kernel implementation and no cached SYM_*
      * pointer, but must still be recognized as System` (not qualified into a

--- a/src/sym_names.h
+++ b/src/sym_names.h
@@ -639,6 +639,41 @@ extern const char* SYM_PlotLegendData;
  * Graphics[...] so the renderer can re-sample adaptively on zoom. */
 extern const char* SYM_PlotResample;
 
+/* Graph subsystem (src/graph/): the Graph head, its edge constructors, and
+ * every builtin head. Graphs are ordinary Expr trees
+ * Graph[List[verts...], List[edges...]]; no new EXPR_* tag. SYM_Rule and
+ * SYM_Graphics primitives (Line/Point/Disk/Text) are reused, not re-declared. */
+extern const char* SYM_Graph;
+extern const char* SYM_DirectedEdge;
+extern const char* SYM_UndirectedEdge;
+extern const char* SYM_TwoWayRule;
+extern const char* SYM_GraphQ;
+extern const char* SYM_DirectedGraphQ;
+extern const char* SYM_ConnectedGraphQ;
+extern const char* SYM_VertexList;
+extern const char* SYM_EdgeList;
+extern const char* SYM_VertexCount;
+extern const char* SYM_EdgeCount;
+extern const char* SYM_AdjacencyList;
+extern const char* SYM_VertexDegree;
+extern const char* SYM_VertexInDegree;
+extern const char* SYM_VertexOutDegree;
+extern const char* SYM_AdjacencyMatrix;
+extern const char* SYM_IncidenceMatrix;
+extern const char* SYM_AdjacencyGraph;
+extern const char* SYM_CompleteGraph;
+extern const char* SYM_CycleGraph;
+extern const char* SYM_PathGraph;
+extern const char* SYM_RandomGraph;
+extern const char* SYM_FindShortestPath;
+extern const char* SYM_GraphDistance;
+extern const char* SYM_ConnectedComponents;
+extern const char* SYM_WeaklyConnectedComponents;
+extern const char* SYM_StronglyConnectedComponents;
+extern const char* SYM_FindSpanningTree;
+extern const char* SYM_VertexConnectivity;
+extern const char* SYM_GraphPlot;
+
 /* Populate every SYM_* by interning its name string. Idempotent: safe
  * to call repeatedly. Must run before any consumer reads a SYM_*
  * pointer; in practice it is called from core_init(). */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ include_directories(../src/special_functions)
 include_directories(../src/numerical_calculus)
 include_directories(../src/numerical_roots)
 include_directories(../src/graphics)
+include_directories(../src/graph)
 if(USE_ECM)
     include_directories(../src/external/ecm)
 endif()
@@ -396,6 +397,25 @@ set(COMMON_SRC
     ../src/graphics/sampling.c
     ../src/graphics/plot.c
     ../src/graphics/show.c
+    ../src/graph/graph.c
+    ../src/graph/graph_util.c
+    ../src/graph/construct.c
+    ../src/graph/graphq.c
+    ../src/graph/vertexlist.c
+    ../src/graph/edgelist.c
+    ../src/graph/counts.c
+    ../src/graph/adjlist.c
+    ../src/graph/degree.c
+    ../src/graph/directedq.c
+    ../src/graph/adjmat.c
+    ../src/graph/incmat.c
+    ../src/graph/adjgraph.c
+    ../src/graph/generators.c
+    ../src/graph/shortestpath.c
+    ../src/graph/components.c
+    ../src/graph/spanningtree.c
+    ../src/graph/connectivity.c
+    ../src/graph/graphplot.c
 )
 
 # render.c / hershey_font.c need a live Raylib + display; only compiled
@@ -430,6 +450,11 @@ target_include_directories(regression_tests PRIVATE ../src)
 
 add_executable(comparisons_tests test_comparisons.c ${COMMON_SRC})
 target_include_directories(comparisons_tests PRIVATE ../src)
+
+add_executable(graph_tests test_graph.c ${COMMON_SRC})
+target_link_libraries(graph_tests m)
+target_include_directories(graph_tests PRIVATE ../src ../src/graph)
+add_test(NAME graph_tests COMMAND graph_tests)
 
 add_executable(zero_test_tests test_zero_test.c ${COMMON_SRC})
 target_link_libraries(zero_test_tests m)

--- a/tests/test_graph.c
+++ b/tests/test_graph.c
@@ -1,0 +1,319 @@
+/* test_graph.c - Phase 1 graph subsystem tests.
+ *
+ * Covers construction/normalization (all four edge sugars), vertex derivation,
+ * directed-by-default, rejection of self-loops / parallel edges / 3-arg edges /
+ * unknown endpoints, the GraphQ predicate, terse-summary printing, and the
+ * InputForm round-trip through the parser.
+ */
+
+#include "expr.h"
+#include "eval.h"
+#include "core.h"
+#include "symtab.h"
+#include "parse.h"
+#include "print.h"
+#include "test_utils.h"
+#include <stdlib.h>
+
+/* ---- Normalization + FullForm (edge sugar -> canonical edges) ------------- */
+static void test_edge_sugar_normalization(void) {
+    /* All four accepted edge forms canonicalize to Directed/UndirectedEdge. */
+    assert_eval_eq("Graph[{1,2},{1->2}]",
+                   "Graph[List[1, 2], List[DirectedEdge[1, 2]]]", 1);
+    assert_eval_eq("Graph[{1,2},{DirectedEdge[1,2]}]",
+                   "Graph[List[1, 2], List[DirectedEdge[1, 2]]]", 1);
+    assert_eval_eq("Graph[{1,2},{1<->2}]",
+                   "Graph[List[1, 2], List[UndirectedEdge[1, 2]]]", 1);
+    assert_eval_eq("Graph[{1,2},{TwoWayRule[1,2]}]",
+                   "Graph[List[1, 2], List[UndirectedEdge[1, 2]]]", 1);
+    assert_eval_eq("Graph[{1,2},{UndirectedEdge[1,2]}]",
+                   "Graph[List[1, 2], List[UndirectedEdge[1, 2]]]", 1);
+}
+
+/* ---- Vertex derivation (Graph[edges], directed by default) ---------------- */
+static void test_vertex_derivation(void) {
+    /* Vertices derived in first-appearance order; Rule defaults to directed. */
+    assert_eval_eq("Graph[{1->2,2->3,3->1}]",
+                   "Graph[List[1, 2, 3], "
+                   "List[DirectedEdge[1, 2], DirectedEdge[2, 3], DirectedEdge[3, 1]]]", 1);
+    /* Derivation preserves the order endpoints first appear, not sorted. */
+    assert_eval_eq("Graph[{3->1,1->2}]",
+                   "Graph[List[3, 1, 2], "
+                   "List[DirectedEdge[3, 1], DirectedEdge[1, 2]]]", 1);
+}
+
+/* ---- Terse summary printing (standard form) ------------------------------- */
+static void test_summary_printing(void) {
+    assert_eval_eq("Graph[{1,2,3},{1->2,2->3}]", "Graph[<3 vertices, 2 edges>]", 0);
+    assert_eval_eq("Graph[{1,2},{1->2}]",        "Graph[<2 vertices, 1 edge>]", 0);
+    assert_eval_eq("Graph[{1},{}]",              "Graph[<1 vertex, 0 edges>]", 0);
+}
+
+/* ---- GraphQ truth table --------------------------------------------------- */
+static void test_graphq(void) {
+    assert_eval_eq("GraphQ[Graph[{1,2},{1->2}]]", "True", 0);
+    assert_eval_eq("GraphQ[Graph[{1,2},{1<->2}]]", "True", 0);
+    assert_eval_eq("GraphQ[Graph[{1,2,3},{1->2,2->3}]]", "True", 0);
+    /* Not a graph at all. */
+    assert_eval_eq("GraphQ[5]", "False", 0);
+    assert_eval_eq("GraphQ[foo]", "False", 0);
+}
+
+/* ---- Rejection of malformed graphs (stay unevaluated -> GraphQ False) ------ */
+static void test_rejections(void) {
+    /* Self-loop. */
+    assert_eval_eq("GraphQ[Graph[{1},{1->1}]]", "False", 0);
+    /* Parallel/duplicate edges. */
+    assert_eval_eq("GraphQ[Graph[{1,2},{1->2,1->2}]]", "False", 0);
+    assert_eval_eq("GraphQ[Graph[{1,2},{1<->2,2<->1}]]", "False", 0);
+    /* 3-argument edge (reserved for future edge tags). */
+    assert_eval_eq("GraphQ[Graph[{1,2},{DirectedEdge[1,2,x]}]]", "False", 0);
+    /* Edge endpoint absent from an explicit vertex list. */
+    assert_eval_eq("GraphQ[Graph[{1,2},{1->3}]]", "False", 0);
+    /* Anti-parallel *directed* edges are allowed (distinct). */
+    assert_eval_eq("GraphQ[Graph[{1,2},{1->2,2->1}]]", "True", 0);
+}
+
+/* ---- InputForm round-trips through the parser ----------------------------- */
+static void test_inputform_roundtrip(void) {
+    static const char* inputs[] = {
+        "Graph[{1,2},{1<->2}]",
+        "Graph[{1,2,3},{1->2,2->3,3->1}]",
+        "Graph[{a,b,c},{a<->b,b->c}]",
+    };
+    for (size_t i = 0; i < sizeof(inputs) / sizeof(inputs[0]); i++) {
+        Expr* g = evaluate(parse_expression(inputs[i]));
+        ASSERT(g != NULL);
+        /* Wrap in InputForm and print: yields the literal constructor. */
+        Expr* wrap_args[1] = { expr_copy(g) };
+        Expr* wrap = expr_new_function(expr_new_symbol("InputForm"), wrap_args, 1);
+        char* s = expr_to_string(wrap);
+        /* Re-parse and evaluate: must reproduce an equal graph. */
+        Expr* g2 = evaluate(parse_expression(s));
+        ASSERT(expr_eq(g, g2));
+        free(s);
+        expr_free(wrap);
+        expr_free(g);
+        expr_free(g2);
+    }
+    /* Spot-check the exact InputForm text for the undirected case. */
+    assert_eval_eq("InputForm[Graph[{1,2},{1<->2}]]", "Graph[{1, 2}, {1 <-> 2}]", 0);
+    assert_eval_eq("InputForm[Graph[{1,2},{1->2}]]",  "Graph[{1, 2}, {1 -> 2}]", 0);
+}
+
+/* ---- Phase 2: query / representation builtins ----------------------------- */
+static void test_query_builtins(void) {
+    /* g = 1->2->3->4->1 (directed cycle). */
+    const char* g = "Graph[{1,2,3,4},{1->2,2->3,3->4,4->1}]";
+    char buf[256];
+
+    snprintf(buf, sizeof(buf), "VertexList[%s]", g);
+    assert_eval_eq(buf, "{1, 2, 3, 4}", 0);
+    snprintf(buf, sizeof(buf), "EdgeList[%s]", g);
+    assert_eval_eq(buf, "{1 -> 2, 2 -> 3, 3 -> 4, 4 -> 1}", 0);
+    snprintf(buf, sizeof(buf), "VertexCount[%s]", g);
+    assert_eval_eq(buf, "4", 0);
+    snprintf(buf, sizeof(buf), "EdgeCount[%s]", g);
+    assert_eval_eq(buf, "4", 0);
+
+    /* Directed cycle: every vertex has in=out=1, total degree 2. */
+    snprintf(buf, sizeof(buf), "VertexDegree[%s, 1]", g);
+    assert_eval_eq(buf, "2", 0);
+    snprintf(buf, sizeof(buf), "VertexInDegree[%s, 1]", g);
+    assert_eval_eq(buf, "1", 0);
+    snprintf(buf, sizeof(buf), "VertexOutDegree[%s, 1]", g);
+    assert_eval_eq(buf, "1", 0);
+    snprintf(buf, sizeof(buf), "VertexDegree[%s]", g);
+    assert_eval_eq(buf, "{2, 2, 2, 2}", 0);
+
+    /* Successor adjacency for a directed graph. */
+    snprintf(buf, sizeof(buf), "AdjacencyList[%s, 1]", g);
+    assert_eval_eq(buf, "{2}", 0);
+    snprintf(buf, sizeof(buf), "AdjacencyList[%s]", g);
+    assert_eval_eq(buf, "{{2}, {3}, {4}, {1}}", 0);
+
+    snprintf(buf, sizeof(buf), "DirectedGraphQ[%s]", g);
+    assert_eval_eq(buf, "True", 0);
+}
+
+static void test_query_undirected(void) {
+    /* Path 1 <-> 2 <-> 3 (undirected). */
+    const char* g = "Graph[{1,2,3},{1<->2,2<->3}]";
+    char buf[256];
+
+    /* Undirected: middle vertex has degree 2, ends degree 1. */
+    snprintf(buf, sizeof(buf), "VertexDegree[%s]", g);
+    assert_eval_eq(buf, "{1, 2, 1}", 0);
+    /* Undirected neighbors go both ways. */
+    snprintf(buf, sizeof(buf), "AdjacencyList[%s, 2]", g);
+    assert_eval_eq(buf, "{1, 3}", 0);
+    snprintf(buf, sizeof(buf), "DirectedGraphQ[%s]", g);
+    assert_eval_eq(buf, "False", 0);
+    /* In/out degree equal the degree for undirected graphs. */
+    snprintf(buf, sizeof(buf), "VertexInDegree[%s, 2]", g);
+    assert_eval_eq(buf, "2", 0);
+    snprintf(buf, sizeof(buf), "VertexOutDegree[%s, 2]", g);
+    assert_eval_eq(buf, "2", 0);
+}
+
+/* ---- Phase 3: matrix views ------------------------------------------------ */
+static void test_matrix_views(void) {
+    /* Directed 4-cycle: circulant adjacency matrix. */
+    const char* dg = "Graph[{1,2,3,4},{1->2,2->3,3->4,4->1}]";
+    char buf[256];
+    snprintf(buf, sizeof(buf), "AdjacencyMatrix[%s]", dg);
+    assert_eval_eq(buf,
+        "{{0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}", 0);
+
+    /* Undirected edge -> symmetric matrix. */
+    assert_eval_eq("AdjacencyMatrix[Graph[{1,2},{1<->2}]]",
+                   "{{0, 1}, {1, 0}}", 0);
+
+    /* Feeds linalg unchanged: trace of the 4-cycle adjacency is 0. */
+    snprintf(buf, sizeof(buf), "Tr[AdjacencyMatrix[%s]]", dg);
+    assert_eval_eq(buf, "0", 0);
+    /* Det of the directed 4-cycle circulant is -1. */
+    snprintf(buf, sizeof(buf), "Det[AdjacencyMatrix[%s]]", dg);
+    assert_eval_eq(buf, "-1", 0);
+
+    /* Round-trip: AdjacencyGraph[AdjacencyMatrix[g]] reproduces the edges. */
+    snprintf(buf, sizeof(buf), "EdgeList[AdjacencyGraph[AdjacencyMatrix[%s]]]", dg);
+    assert_eval_eq(buf, "{1 -> 2, 2 -> 3, 3 -> 4, 4 -> 1}", 0);
+    /* Undirected round-trip stays undirected. */
+    assert_eval_eq(
+        "EdgeList[AdjacencyGraph[AdjacencyMatrix[Graph[{1,2,3},{1<->2,2<->3}]]]]",
+        "{1 <-> 2, 2 <-> 3}", 0);
+
+    /* Incidence matrix of an undirected path 1<->2<->3. */
+    assert_eval_eq("IncidenceMatrix[Graph[{1,2,3},{1<->2,2<->3}]]",
+                   "{{1, 0}, {1, 1}, {0, 1}}", 0);
+}
+
+/* ---- Phase 4: generators -------------------------------------------------- */
+static void test_generators(void) {
+    /* K5: 5 vertices, 10 edges, undirected, every vertex degree 4. */
+    assert_eval_eq("VertexCount[CompleteGraph[5]]", "5", 0);
+    assert_eval_eq("EdgeCount[CompleteGraph[5]]", "10", 0);
+    assert_eval_eq("DirectedGraphQ[CompleteGraph[5]]", "False", 0);
+    assert_eval_eq("VertexDegree[CompleteGraph[5]]", "{4, 4, 4, 4, 4}", 0);
+
+    /* CycleGraph[n]: n vertices, n edges, every degree 2. */
+    assert_eval_eq("EdgeCount[CycleGraph[5]]", "5", 0);
+    assert_eval_eq("VertexDegree[CycleGraph[5]]", "{2, 2, 2, 2, 2}", 0);
+    assert_eval_eq("EdgeList[CycleGraph[4]]",
+                   "{1 <-> 2, 2 <-> 3, 3 <-> 4, 4 <-> 1}", 0);
+
+    /* PathGraph[n]: n vertices, n-1 edges; endpoints degree 1. */
+    assert_eval_eq("EdgeCount[PathGraph[5]]", "4", 0);
+    assert_eval_eq("VertexDegree[PathGraph[5]]", "{1, 2, 2, 2, 1}", 0);
+    /* Explicit-vertex path. */
+    assert_eval_eq("EdgeList[PathGraph[{a,b,c}]]", "{a <-> b, b <-> c}", 0);
+}
+
+static void test_random_graph(void) {
+    /* Exactly m distinct edges, n vertices, valid simple graph. */
+    assert_eval_eq("VertexCount[RandomGraph[{6, 5}]]", "6", 0);
+    assert_eval_eq("EdgeCount[RandomGraph[{6, 5}]]", "5", 0);
+    assert_eval_eq("GraphQ[RandomGraph[{6, 5}]]", "True", 0);
+    /* Too many edges for a simple graph -> unevaluated (GraphQ False). */
+    assert_eval_eq("GraphQ[RandomGraph[{3, 10}]]", "False", 0);
+    /* Determinism under a fixed seed. */
+    Expr* e1 = evaluate(parse_expression(
+        "(SeedRandom[42]; EdgeList[RandomGraph[{6,5}]]) === "
+        "(SeedRandom[42]; EdgeList[RandomGraph[{6,5}]])"));
+    char* s = expr_to_string(e1);
+    ASSERT(strcmp(s, "True") == 0);
+    free(s);
+    expr_free(e1);
+}
+
+/* ---- Phase 5: algorithms -------------------------------------------------- */
+static void test_shortest_path(void) {
+    /* Directed path 1->2->3->4. */
+    const char* dg = "Graph[{1,2,3,4},{1->2,2->3,3->4}]";
+    char buf[256];
+    snprintf(buf, sizeof(buf), "FindShortestPath[%s, 1, 4]", dg);
+    assert_eval_eq(buf, "{1, 2, 3, 4}", 0);
+    snprintf(buf, sizeof(buf), "GraphDistance[%s, 1, 4]", dg);
+    assert_eval_eq(buf, "3", 0);
+    /* Direction matters: 4 cannot reach 1. */
+    snprintf(buf, sizeof(buf), "GraphDistance[%s, 4, 1]", dg);
+    assert_eval_eq(buf, "Infinity", 0);
+    snprintf(buf, sizeof(buf), "FindShortestPath[%s, 4, 1]", dg);
+    assert_eval_eq(buf, "{}", 0);
+    /* Undirected: reachable both ways. */
+    assert_eval_eq("GraphDistance[Graph[{1,2,3,4},{1<->2,2<->3,3<->4}], 4, 1]", "3", 0);
+    /* A shortcut shortens the path. */
+    assert_eval_eq(
+        "GraphDistance[Graph[{1,2,3,4},{1->2,2->3,3->4,1->4}], 1, 4]", "1", 0);
+}
+
+static void test_components(void) {
+    /* Directed 4-cycle: one weak and one strong component. */
+    assert_eval_eq("ConnectedComponents[Graph[{1,2,3,4},{1->2,2->3,3->4,4->1}]]",
+                   "{{1, 2, 3, 4}}", 0);
+    /* Two disjoint directed pieces -> two weak components. */
+    assert_eval_eq("ConnectedComponents[Graph[{1,2,3,4},{1->2,3->4}]]",
+                   "{{1, 2}, {3, 4}}", 0);
+    /* Directed chain 1->2->3: weak = all together, strong = singletons. */
+    assert_eval_eq("WeaklyConnectedComponents[Graph[{1,2,3},{1->2,2->3}]]",
+                   "{{1, 2, 3}}", 0);
+    assert_eval_eq("StronglyConnectedComponents[Graph[{1,2,3},{1->2,2->3}]]",
+                   "{{1}, {2}, {3}}", 0);
+    /* A directed cycle is one strong component. */
+    assert_eval_eq("StronglyConnectedComponents[Graph[{1,2,3},{1->2,2->3,3->1}]]",
+                   "{{1, 2, 3}}", 0);
+}
+
+static void test_spanning_and_connectivity(void) {
+    /* Spanning tree of a connected graph has VertexCount - 1 edges. */
+    assert_eval_eq("EdgeCount[FindSpanningTree[CompleteGraph[5]]]", "4", 0);
+    assert_eval_eq("EdgeCount[FindSpanningTree[CycleGraph[6]]]", "5", 0);
+
+    /* Connectivity. */
+    assert_eval_eq("ConnectedGraphQ[PathGraph[4]]", "True", 0);
+    assert_eval_eq("ConnectedGraphQ[Graph[{1,2,3,4},{1<->2,3<->4}]]", "False", 0);
+    /* kappa: path=1, cycle=2, complete K4=3, disconnected=0. */
+    assert_eval_eq("VertexConnectivity[PathGraph[4]]", "1", 0);
+    assert_eval_eq("VertexConnectivity[CycleGraph[5]]", "2", 0);
+    assert_eval_eq("VertexConnectivity[CompleteGraph[4]]", "3", 0);
+    assert_eval_eq("VertexConnectivity[Graph[{1,2,3,4},{1<->2,3<->4}]]", "0", 0);
+}
+
+/* ---- Phase 6: GraphPlot --------------------------------------------------- */
+static void test_graphplot(void) {
+    /* Emits a Graphics object. */
+    assert_eval_eq("Head[GraphPlot[CycleGraph[5]]]", "Graphics", 0);
+    /* One Line per edge, one Disk per vertex. */
+    assert_eval_eq("Count[GraphPlot[CycleGraph[5]], _Line, Infinity]", "5", 0);
+    assert_eval_eq("Count[GraphPlot[CycleGraph[5]], _Disk, Infinity]", "5", 0);
+    /* CompleteGraph[6]: 15 edges, 6 vertices. */
+    assert_eval_eq("Count[GraphPlot[CompleteGraph[6]], _Line, Infinity]", "15", 0);
+    assert_eval_eq("Count[GraphPlot[CompleteGraph[6]], _Disk, Infinity]", "6", 0);
+    /* Non-graph argument stays unevaluated. */
+    assert_eval_eq("Head[GraphPlot[5]]", "GraphPlot", 0);
+}
+
+int main(void) {
+    symtab_init();
+    core_init();
+
+    TEST(test_edge_sugar_normalization);
+    TEST(test_vertex_derivation);
+    TEST(test_summary_printing);
+    TEST(test_graphq);
+    TEST(test_rejections);
+    TEST(test_inputform_roundtrip);
+    TEST(test_query_builtins);
+    TEST(test_query_undirected);
+    TEST(test_matrix_views);
+    TEST(test_generators);
+    TEST(test_random_graph);
+    TEST(test_shortest_path);
+    TEST(test_components);
+    TEST(test_spanning_and_connectivity);
+    TEST(test_graphplot);
+
+    printf("All graph tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
Adds a graph subsystem to Mathilda — `Graph` as a first-class symbol with
construction, queries, matrix views, generators, algorithms, and visualization —
plus notebook fixes so `GraphPlot` renders as a node-link diagram and cell
copy/paste works. Graphs are ordinary `Expr` trees
(`Graph[List[verts], List[edges]]`); no new `EXPR_*` tag and no changes under
`src/external/`.

## Changes
- **Graph subsystem (`src/graph/`, 30 builtins, one per file):** construction/
  normalization (`Graph`), predicates (`GraphQ`, `DirectedGraphQ`,
  `ConnectedGraphQ`), queries (`VertexList`, `EdgeList`, counts, `AdjacencyList`,
  degrees), matrix views (`AdjacencyMatrix`, `IncidenceMatrix`, `AdjacencyGraph`
  — interop with `Det`/`Tr`/`Eigenvalues`), generators (`CompleteGraph`,
  `CycleGraph`, `PathGraph`, `RandomGraph`), algorithms (`FindShortestPath`,
  `GraphDistance`, connected components incl. Tarjan SCC, `FindSpanningTree`,
  `VertexConnectivity`), and `GraphPlot`.
- **Parser/printer:** `<->` (`TwoWayRule`) operator; infix `Directed`/
  `UndirectedEdge` printing and a terse, round-trippable `Graph` form.
- **Notebook renderer (`graphics_json.c`):** serialize `Disk`/`Point` as markers
  and `Text` as annotations, with an equal-aspect diagram layout so `GraphPlot`
  draws correctly (Plot output unchanged).
- **Diagnostics (`repl.c`):** parse errors echo the received input.
- **Notebook clipboard (`src-tauri/src/lib.rs`):** use predefined
  Cut/Copy/Paste/Select-All/Undo/Redo menu items so cell copy/paste works on
  macOS.
- Docs: `docs/spec/builtins/graphs.md` + weekly changelog; `Mathilda_spec.md`
  rows.

## Testing
- New `tests/test_graph.c` (wired into the CMake suite): normalization of all
  edge sugars, vertex derivation, `GraphQ` truth table, malformed-input
  rejection, query builtins, `AdjacencyMatrix` symmetry + `AdjacencyGraph`
  round-trip, generator counts/degrees, shortest paths (incl. unreachable),
  weak vs. strong components, spanning-tree edge counts, connectivity values,
  and `GraphPlot` structure. All pass.
- Clean `-std=c99 -Wall -Wextra` build; full Desired-End-State REPL walkthrough
  matches (e.g. `Eigenvalues[AdjacencyMatrix[4-cycle]] = {-1, 1, -I, I}`).
- Note: valgrind is unavailable on the dev machine (Darwin ARM64); ownership
  follows the SPEC §4 build-from-copies / paired alloc-free contract.

## JIRA Ticket
N/A
