### PR TITLE
build: auto-link raylib's static X11/GL transitive deps (fixes #18)

### DIFF
--- a/docs/spec/changelog/2026-07-13.md
+++ b/docs/spec/changelog/2026-07-13.md
@@ -652,3 +652,21 @@ holds and `sizeof(Expr)` is unchanged.
   cost. Implemented for architectural completeness; the measurable win came from Phase 1.
 - Files: `src/expr.h`, `src/expr.c`, `src/symtab.c`, `src/eval.c`, plus the mechanical rename
   across `src/` and `tests/`. Struct definition changed → `make clean` required.
+
+## Build: raylib static X11/GL transitive deps auto-linked (issue #18)
+
+The graphics engine links raylib, which on Linux is commonly a static archive
+(`libraylib.a`) whose transitive windowing deps — `-lX11 -lGL -lpthread -ldl
+-lrt ...` — live in the `.pc` file's `Libs.private:` line. Both build systems
+were pulling only the plain `Libs:` set, so test executables (and the makefile
+build without `EXTRA_LIBS`) failed to link with undefined `XInternAtom`,
+`XSync`, `XFree`, etc. Fixed to link the pkg-config *static* (private-dep-
+inclusive) set:
+
+- `tests/CMakeLists.txt`: link `${RAYLIB_STATIC_LIBRARIES}` / `_STATIC_LIBRARY_DIRS`
+  (falling back to the plain set if empty) instead of `${RAYLIB_LIBRARIES}`.
+- `makefile`: `pkg-config --static --libs raylib` instead of `--libs`.
+- No-op on macOS, where `Libs.private` is empty (frameworks are recorded in the
+  dylib) so the static set equals the plain set; verified the link line and a
+  test build are byte-identical there. Removes the need for the manual
+  `make EXTRA_LIBS="-lX11"` workaround on Linux.

--- a/makefile
+++ b/makefile
@@ -165,7 +165,13 @@ endif
 ifeq ($(USE_GRAPHICS), 1)
   ifneq ($(shell $(PKG_CONFIG) --exists raylib 2>/dev/null && echo y),)
     CFLAGS  += -DUSE_GRAPHICS $(shell $(PKG_CONFIG) --cflags raylib)
-    LDFLAGS += $(shell $(PKG_CONFIG) --libs raylib)
+    # `--static` appends the `Libs.private:` transitive deps (on Linux: -lX11
+    # -lGL -lpthread -ldl -lrt ...) that a static libraylib.a needs but `--libs`
+    # alone omits — otherwise the link fails with undefined XInternAtom/XSync
+    # (issue #18). Identical to `--libs` on macOS, where Libs.private is empty
+    # (frameworks are recorded in the dylib). EXTRA_LIBS below remains as a
+    # manual escape hatch for anything pkg-config still can't infer.
+    LDFLAGS += $(shell $(PKG_CONFIG) --static --libs raylib)
   else
     $(warning Raylib not detected; building with USE_GRAPHICS=0 (Show/Plot will print a text placeholder))
     $(warning   macOS (Homebrew): brew install raylib)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,8 +64,24 @@ if(USE_GRAPHICS)
     if(RAYLIB_FOUND)
         add_compile_definitions(USE_GRAPHICS)
         include_directories(${RAYLIB_INCLUDE_DIRS})
-        link_directories(${RAYLIB_LIBRARY_DIRS})
-        link_libraries(${RAYLIB_LIBRARIES})
+        # On Linux, libraylib is commonly a static archive (Ubuntu's
+        # libraylib-dev, or a from-source `make install`) whose transitive
+        # windowing deps — X11, GL, pthread, dl, rt, ... — live in the .pc
+        # file's `Libs.private:` line. pkg_check_modules exposes those only via
+        # its _STATIC_ variables; linking the plain _LIBRARIES set drops them,
+        # so every test executable fails with undefined `XInternAtom`, `XSync`,
+        # `XFree`, etc. (issue #18). The _STATIC_ set is a superset that equals
+        # the plain set on macOS (Libs.private is empty there — frameworks are
+        # recorded in the dylib), so prefer it unconditionally, keeping
+        # pkg-config's link order (raylib before its deps) that static archives
+        # require. Fall back to the plain set if _STATIC_ ever comes back empty.
+        if(RAYLIB_STATIC_LIBRARIES)
+            link_directories(${RAYLIB_STATIC_LIBRARY_DIRS})
+            link_libraries(${RAYLIB_STATIC_LIBRARIES})
+        else()
+            link_directories(${RAYLIB_LIBRARY_DIRS})
+            link_libraries(${RAYLIB_LIBRARIES})
+        endif()
     else()
         message(WARNING "Raylib not detected; building tests with USE_GRAPHICS=OFF")
         message(WARNING "  macOS (Homebrew): brew install raylib")


### PR DESCRIPTION
## Problem

Building the test suite on Linux fails at link time with undefined references to `XInternAtom`, `XConvertSelection`, `XSync`, `XCheckTypedEvent`, `XGetWindowProperty`, `XFree`, etc. (issue #18). The reported workaround was hand-editing each generated `link.txt` to add `-lX11`.

## Root cause

The graphics engine links **raylib**. On Linux `libraylib` is commonly a **static archive** (Ubuntu's `libraylib-dev`, or a from-source `make install`), whose transitive windowing dependencies — `-lX11 -lGL -lpthread -ldl -lrt …` — are recorded in the `.pc` file's `Libs.private:` line, not the plain `Libs:` line.

Both build systems linked only the plain set:
- CMake: `link_libraries(${RAYLIB_LIBRARIES})` — `pkg_check_modules` places the private deps only in the `_STATIC_` variables.
- makefile: `pkg-config --libs raylib` — needs `--static` to append `Libs.private`.

So with a static `libraylib.a` the X11 symbols went unresolved. The makefile has a documented `EXTRA_LIBS="-lX11"` escape hatch (so `./Mathilda` could be made to link), but the CMake test build had no equivalent — hence the per-`link.txt` editing.

## Fix

- **`tests/CMakeLists.txt`** — link the pkg-config *static* (private-dep-inclusive) set `${RAYLIB_STATIC_LIBRARIES}` / `_STATIC_LIBRARY_DIRS`, falling back to the plain set if empty. Applies to every test target automatically; no `link.txt` editing.
- **`makefile`** — `pkg-config --static --libs raylib` instead of `--libs`, so a plain `make` no longer needs `EXTRA_LIBS="-lX11"`. `EXTRA_LIBS` remains as a manual escape hatch.
- Changelog note under `docs/spec/changelog/2026-07-13.md`.

## Safety / verification

No-op on macOS, where `Libs.private` is empty (raylib's frameworks are recorded in the dylib), so the static set equals the plain set. Verified on this Darwin machine:
- `pkg-config --static --libs raylib` == `pkg-config --libs raylib`.
- The generated CMake link line is unchanged (`-lraylib`, no X11).
- A full `expr_tests` build links cleanly (exit 0).

On Linux the same code paths now additionally emit `-lX11 -lGL …` from `Libs.private`, resolving the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mkk4AbGajNy8kewu5m2TRH
