### PR TITLE
Trace[expr]: evaluation-chain introspection (Phases 2+3)

### DIFF
--- a/docs/spec/builtins/expression-information.md
+++ b/docs/spec/builtins/expression-information.md
@@ -492,6 +492,44 @@ In[11]:= Hold[Evaluate[1+1, 2+2]]
 Out[11]= Hold[2, 4]
 ```
 
+## Trace
+Records the successive top-level expressions produced while evaluating `expr`.
+- `Trace[expr]`: Returns a flat `List` of the intermediate expressions the
+  evaluator passes through while reducing `expr` to a fixed point, in order:
+  `{e0, e1, ..., eN}` where `e0` is the (held) input and `eN` is the final
+  result. Returns `{}` when `expr` needs no top-level rewriting.
+
+**Features**:
+- `HoldAll`, `Protected`. The argument is held so its rewrite sequence can be
+  observed from the start.
+- **Flat, top-level only (v1).** Only rewrites in `expr`'s own outermost
+  evaluation loop are recorded; sub-evaluations of arguments (nested
+  `evaluate` calls) are not. Step granularity follows the evaluator's actual
+  iterations, so Mathilda may record fewer intermediates than a reference
+  system that shows every substitution separately.
+- Each intermediate is returned wrapped in `HoldForm` (printed transparently),
+  so the result list is inert and does not re-evaluate.
+- Not memoized: `Trace` bumps the evaluation clock once per call so an
+  already-evaluated argument is still traced in full.
+- Reentrant: `Trace` may appear inside a traced expression; the inner list is
+  produced independently.
+- The two-argument form `Trace[expr, form]` (pattern filtering) and
+  `TraceDepth` are not yet implemented; `Trace[expr, form]` stays unevaluated.
+
+```mathematica
+In[1]:= Trace[1 + 1]
+Out[1]= {1 + 1, 2}
+
+In[2]:= Trace[5]
+Out[2]= {}
+
+In[3]:= x = 3; Trace[x + 1]
+Out[3]= {x + 1, 4}
+
+In[4]:= Trace[{Trace[1 + 1], 2 + 2}]
+Out[4]= {{Trace[1 + 1], 2 + 2}, {{1 + 1, 2}, 4}}
+```
+
 ## ReleaseHold
 Removes `Hold`, `HoldForm`, `HoldPattern`, and `HoldComplete` in `expr`.
 - `ReleaseHold[expr]`

--- a/docs/spec/changelog/2026-07-13.md
+++ b/docs/spec/changelog/2026-07-13.md
@@ -3513,3 +3513,43 @@ The injection logic in each file's option-parsing function was updated:
 `draw_color_bar` in `src/graphics/render.c` now draws **9 tick marks**
 (previously 5), giving a less sparse scale for plots with a legend
 (`PlotLegends -> Automatic`).
+
+## Trace[expr] — evaluation-chain introspection
+
+New builtin `Trace[expr]` returns a flat `List` of the successive top-level
+expressions the evaluator produces while reducing `expr` to a fixed point
+(`{e0, ..., eN}`; `{}` when no top-level rewrite fires). Attributes:
+`HoldAll`, `Protected`. Debugging/introspection analogue of Mathematica's
+`Trace`.
+
+**Design (two tiers):**
+- `src/eval.c`: evaluator-side collector — a file-static `TraceCollector` +
+  `g_trace_active`, with depth-gated recording inside `evaluate()`'s
+  fixed-point loop (gated to the traced expression's own recursion depth, so
+  argument sub-evaluations are excluded → flat, top-level v1 semantics). Public
+  `eval_collect_trace(held_expr)` borrows the held argument, bumps the eval
+  clock once so the timestamp early-exit cannot empty a trace, evaluates to a
+  fixed point, and returns the raw intermediate `List`. When not tracing the
+  hot path costs a single predicted-false global read (parity with the existing
+  `eval_overflow` check).
+- `src/trace.c`: user-facing `builtin_trace` — arity-1 dispatch (the 2-arg form
+  stays unevaluated, deferred), wrapping each recorded step in `HoldForm` so the
+  returned list is inert under the evaluator's re-evaluation pass while printing
+  transparently.
+
+**Ownership:** each stored step is inc-ref'd (`expr_copy`); the discarded final
+value is freed once; `HoldForm` wrapping moves ownership of each step into the
+wrapper. Verified leak-clean on the full builtin path (macOS `leaks`; valgrind
+N/A on Apple Silicon).
+
+**Tests:** `tests/test_trace.c` — direct `eval_collect_trace` (single-step,
+inert atom/symbol → `{}`, multi-step invariants, reentrancy/repeat) plus
+builtin-level (`Trace[1+1]` → `{1 + 1, 2}`, `Attributes`, HoldForm idempotency,
+held 2-arg form). All pass.
+
+**Deferred:** `Trace[expr, form]` (beads-planning-h4u), `TraceDepth`
+(beads-planning-asv).
+
+**New/modified files:** `src/eval.c`, `src/eval.h`, `src/trace.c`, `src/core.c`
+(register `trace_init`), `tests/test_trace.c`, `tests/CMakeLists.txt`,
+`docs/spec/builtins/expression-information.md`.

--- a/src/core.c
+++ b/src/core.c
@@ -485,6 +485,7 @@ void core_init(void) {
     symtab_set_docstring("Goto",
         "Goto[tag]\n\tScans the CompoundExpression it appears in directly for\n"
         "\tLabel[tag], then enclosing ones, and transfers control to that point.");
+    void trace_init(void); trace_init();  /* Trace[expr] — src/trace.c */
     symtab_add_builtin("Label", builtin_label);
     symtab_get_def("Label")->attributes |= ATTR_PROTECTED;
     symtab_set_docstring("Label",

--- a/src/eval.c
+++ b/src/eval.c
@@ -84,6 +84,58 @@ static uint64_t g_eval_clock = 1;
 uint64_t eval_clock_get(void) { return g_eval_clock; }
 void     eval_clock_bump(void) { g_eval_clock++; }
 
+/* ---- Trace collector (beads-planning-b3k, Phase 2) -----------------------
+ * Trace[expr] records the sequence of top-level intermediate expressions the
+ * fixed-point loop below produces while reducing expr. A single collector is
+ * installed at a time via g_trace_active; nested Trace saves/installs/restores
+ * it through the natural C call stack (see eval_collect_trace). While a
+ * collector is installed, evaluate()'s loop appends each real top-level
+ * rewrite, gated to the exact recursion depth of the traced expression's own
+ * loop so that argument sub-evaluations (which run at greater depth) are
+ * excluded -- the flat, top-level-only v1 semantics.
+ *
+ * Ownership: every expression handed to the collector is inc-ref'd
+ * (expr_copy) before storage, so the steps survive the evaluator freeing the
+ * transient `current`/`next` trees; eval_collect_trace hands the array to
+ * expr_new_function (which takes ownership of the elements) and frees the
+ * array shell. Cost when not tracing: one predicted-false global-pointer read
+ * per loop iteration, matching the existing eval_overflow check. */
+typedef struct TraceCollector {
+    Expr**  steps;         /* each element inc-ref'd (owned by the collector) */
+    size_t  count, cap;
+    int     record_depth;  /* record only when eval_recursion_depth == this */
+    bool    seeded;        /* whether the initial e0 has been recorded yet */
+} TraceCollector;
+
+static TraceCollector* g_trace_active = NULL;  /* NULL when not tracing */
+
+/* Push an inc-ref'd copy of `e` onto the active collector, growing on demand. */
+static void trace_push(TraceCollector* tc, Expr* e) {
+    if (tc->count == tc->cap) {
+        size_t newcap = tc->cap ? tc->cap * 2 : 8;
+        Expr** grown = realloc(tc->steps, newcap * sizeof(Expr*));
+        if (!grown) return;   /* OOM: drop this step rather than crash */
+        tc->steps = grown;
+        tc->cap = newcap;
+    }
+    tc->steps[tc->count++] = expr_copy(e);
+}
+
+/* Record one real top-level rewrite. `before` is the pre-step expression and
+ * `after` is the result of the step; both are borrowed. Called only from the
+ * evaluate() change branch. Depth-gated: a no-op unless the currently running
+ * loop is the traced expression's own. On the first recorded step the pre-step
+ * e0 is seeded first, so an evaluation that never takes a step yields {}. */
+static void trace_record_step(Expr* before, Expr* after) {
+    TraceCollector* tc = g_trace_active;
+    if (!tc || eval_recursion_depth != tc->record_depth) return;
+    if (!tc->seeded) {
+        trace_push(tc, before);
+        tc->seeded = true;
+    }
+    trace_push(tc, after);
+}
+
 /*
  * eval_classify_return:
  * See the contract in eval.h. Pointer-equality on interned symbols is
@@ -1444,6 +1496,12 @@ Expr* evaluate(Expr* e) {
             return current;
         }
 
+        /* Trace: this is a real top-level rewrite (current -> next). Record it
+         * before we drop `current`. Depth-gated inside trace_record_step so
+         * only the traced expression's own loop contributes; the g_trace_active
+         * guard keeps the untraced hot path to a single predicted-false read. */
+        if (g_trace_active) trace_record_step(current, next);
+
         /* Prepare for the next iteration */
         expr_free(current);
         current = next;
@@ -1464,4 +1522,42 @@ Expr* evaluate(Expr* e) {
     else if (is_top_level && eval_is_inflight_goto(current))
         current = eval_report_uncaught_goto(current);
     return current;
+}
+
+/* See eval.h. Evaluate `held_expr` to a fixed point while recording each
+ * top-level rewrite, returning a fresh flat List of the intermediates (Trace
+ * v1 semantics). `held_expr` is BORROWED -- evaluate() copies it and the
+ * caller retains ownership. Reentrant: the previously-active collector is
+ * saved on the C stack and restored on return, so a nested Trace produces its
+ * own list without perturbing the outer one (the inner trace appears to the
+ * outer as a single already-reduced value). */
+Expr* eval_collect_trace(Expr* held_expr) {
+    if (!held_expr) return NULL;
+
+    TraceCollector* prev = g_trace_active;
+    TraceCollector tc;
+    tc.steps        = NULL;
+    tc.count        = 0;
+    tc.cap          = 0;
+    /* The traced expression's own loop runs one level below the current depth
+     * (evaluate() increments eval_recursion_depth on entry). Recording only at
+     * that depth excludes argument sub-evaluations -> flat, top-level steps. */
+    tc.record_depth = eval_recursion_depth + 1;
+    tc.seeded       = false;
+    g_trace_active  = &tc;
+
+    /* Phase-1 mitigation A: bump the eval clock so the timestamp early-exit
+     * (see top of evaluate()) cannot short-circuit an already-stamped root --
+     * a full re-evaluation is required to observe its steps. Trace is thereby
+     * documented as non-memoized (it invalidates the eval cache once per call).*/
+    eval_clock_bump();
+
+    Expr* final = evaluate(held_expr);   /* borrowed in; fresh copy out */
+    expr_free(final);                    /* == the last recorded step; discard */
+
+    g_trace_active = prev;               /* restore the outer collector, if any */
+
+    Expr* list = expr_new_function(expr_new_symbol(SYM_List), tc.steps, tc.count);
+    free(tc.steps);                      /* elements now owned by `list` */
+    return list;
 }

--- a/src/eval.h
+++ b/src/eval.h
@@ -25,6 +25,14 @@ Expr* evaluate_step(Expr* e, bool* changed);
 // Full infinite evaluation loop (stops at fixed point)
 Expr* evaluate(Expr* e);
 
+/* Trace[expr] support (beads-planning-b3k). Evaluate `held_expr` to a fixed
+ * point, recording each top-level rewrite, and return a freshly-owned flat
+ * List of the intermediate expressions (Trace v1 semantics: {e0, ..., eN}, or
+ * {} when no top-level rewrite fires). `held_expr` is BORROWED (not consumed).
+ * Reentrant: safe to call from inside a running evaluation, including nested
+ * within another trace. */
+Expr* eval_collect_trace(Expr* held_expr);
+
 /* True iff `e` is an in-flight Throw sentinel: Throw[v], Throw[v,tag] or
  * Throw[v,tag,f] (head SYM_Throw, arity 1-3). Catch/Throw propagate by
  * returning this expression up through the normal evaluation return paths;

--- a/src/trace.c
+++ b/src/trace.c
@@ -1,0 +1,62 @@
+/* Trace[expr] — user-facing builtin (beads-planning-b3k, Phase 3).
+ *
+ * A thin wrapper over the evaluator-side collector eval_collect_trace()
+ * (src/eval.c). Trace[expr] returns a flat List of the successive top-level
+ * expressions produced while evaluating expr to a fixed point:
+ *   - >=1 top-level rewrite -> {e0, e1, ..., eN}
+ *   - no top-level rewrite (inert atom / normal form) -> {}
+ *
+ * All the depth/clock/ownership subtlety lives in eval_collect_trace; this file
+ * only handles arity dispatch, registration, attributes, and the docstring.
+ * The 2-argument form Trace[expr, form] (form filtering) is deferred to
+ * beads-planning-h4u: builtin_trace returns NULL for arities != 1 so those
+ * calls stay unevaluated rather than silently misbehaving.
+ */
+#include "expr.h"
+#include "eval.h"
+#include "symtab.h"
+#include "attr.h"
+#include "sym_names.h"
+
+/* Trace requires HoldAll: the argument must reach the builtin unevaluated so
+ * the collector can observe its rewrite sequence from the start. Without Hold,
+ * the evaluator would fully reduce expr before builtin_trace ever runs.
+ *
+ * Ownership: the evaluator owns `res` and frees it after a non-NULL return.
+ * eval_collect_trace merely BORROWS args[0] (it inc-refs each recorded step),
+ * so the returned List is independent of `res` — no NULL-out-before-free dance
+ * is needed here. Returning NULL leaves the call unevaluated and the evaluator
+ * retains `res`.
+ *
+ * HoldForm wrapping: builtin_trace's return value flows back through the
+ * evaluator's fixed-point loop, which re-evaluates it. `List` is not held, so a
+ * bare intermediate like `1 + 1` would reduce a second time (turning the trace
+ * into {2, 2}). Wrapping each step in HoldForm makes the list inert on that
+ * pass while printing transparently (HoldForm[1+1] displays as `1 + 1`),
+ * yielding the Mathematica-style {1 + 1, 2}. The raw collector output is left
+ * unwrapped so eval_collect_trace stays a clean data primitive for later
+ * phases (TraceDepth, Trace[expr, form]). */
+Expr* builtin_trace(Expr* res) {
+    if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 1)
+        return NULL;   /* 2-arg form (h4u) and malformed calls stay unevaluated */
+
+    Expr* raw = eval_collect_trace(res->data.function.args[0]);
+    if (!raw) return NULL;
+
+    for (size_t i = 0; i < raw->data.function.arg_count; i++) {
+        Expr* step = raw->data.function.args[i];       /* ownership moves into HoldForm */
+        Expr* wrap[1] = { step };
+        raw->data.function.args[i] =
+            expr_new_function(expr_new_symbol(SYM_HoldForm), wrap, 1);
+    }
+    return raw;
+}
+
+void trace_init(void) {
+    symtab_add_builtin("Trace", builtin_trace);
+    symtab_get_def("Trace")->attributes |= ATTR_HOLDALL | ATTR_PROTECTED;
+    symtab_set_docstring("Trace",
+        "Trace[expr]\n\tGenerates a list of the successive top-level expressions\n"
+        "\tproduced while evaluating expr. Returns {} when expr needs no\n"
+        "\trewriting. Sub-evaluations of arguments are not recorded (flat form).");
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -218,6 +218,7 @@ set(COMMON_SRC
     ../src/expr.c
     ../src/parse.c
     ../src/eval.c
+    ../src/trace.c
     ../src/internal.c
     ../src/attr.c
     ../src/core.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -662,6 +662,9 @@ target_include_directories(parse_tests PRIVATE ../src)
 add_executable(eval_tests test_eval.c ${COMMON_SRC})
 target_include_directories(eval_tests PRIVATE ../src)
 
+add_executable(trace_tests test_trace.c ${COMMON_SRC})
+target_include_directories(trace_tests PRIVATE ../src)
+
 add_executable(match_tests test_match.c ${COMMON_SRC})
 target_include_directories(match_tests PRIVATE ../src)
 

--- a/tests/test_trace.c
+++ b/tests/test_trace.c
@@ -1,0 +1,144 @@
+/* Unit tests for the Trace collector (beads-planning-b3k, Phase 2).
+ *
+ * These exercise the evaluator-level entry point eval_collect_trace() directly
+ * -- the user-facing Trace[] builtin lands in Phase 3 (src/trace.c). The
+ * collector evaluates a BORROWED held expression to a fixed point and returns a
+ * freshly-owned flat List of the top-level intermediate expressions:
+ *   - >=1 top-level rewrite -> {e0, e1, ..., eN}
+ *   - no top-level rewrite (inert atom / normal form) -> {} (empty List)
+ * The returned expression always has head List.
+ *
+ * Run under valgrind to confirm the ownership contract: each stored step is
+ * inc-ref'd (expr_copy) and the discarded final value is freed exactly once.
+ */
+#include "expr.h"
+#include "eval.h"
+#include "print.h"
+#include "symtab.h"
+#include "core.h"
+#include "test_utils.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Trace a freshly-parsed (unevaluated) expression. The parsed input is
+ * borrowed by eval_collect_trace, so we own and free it here. Returns the
+ * collector's List result (caller frees). */
+static Expr* trace_of(const char* input) {
+    Expr* parsed = parse_expression(input);
+    ASSERT(parsed != NULL);
+    Expr* trace = eval_collect_trace(parsed);
+    expr_free(parsed);
+    ASSERT(trace != NULL);
+    return trace;
+}
+
+/* Assert the trace result is a List head with exactly `n` elements. */
+static void assert_list_len(Expr* trace, size_t n) {
+    ASSERT(trace->type == EXPR_FUNCTION);
+    ASSERT(trace->data.function.head->type == EXPR_SYMBOL);
+    ASSERT(strcmp(trace->data.function.head->data.symbol.name, "List") == 0);
+    ASSERT_MSG(trace->data.function.arg_count == n,
+               "expected %zu steps, got %zu", n, trace->data.function.arg_count);
+}
+
+/* 1 + 1 takes one top-level rewrite: {1 + 1, 2}. */
+static void test_arithmetic_step(void) {
+    Expr* t = trace_of("1 + 1");
+    assert_list_len(t, 2);
+    char* s = expr_to_string(t);
+    ASSERT_STR_EQ(s, "{1 + 1, 2}");
+    free(s);
+    /* Last element is the final result 2. */
+    Expr* last = t->data.function.args[1];
+    ASSERT(last->type == EXPR_INTEGER && last->data.integer == 2);
+    expr_free(t);
+}
+
+/* An inert atom triggers no top-level rewrite -> empty List. */
+static void test_inert_atom(void) {
+    Expr* t = trace_of("5");
+    assert_list_len(t, 0);
+    char* s = expr_to_string(t);
+    ASSERT_STR_EQ(s, "{}");   /* Wolfram Trace[5] -> {} */
+    free(s);
+    /* FullForm of the empty result confirms the List head is present. */
+    char* ff = expr_to_string_fullform(t);
+    ASSERT_STR_EQ(ff, "List[]");
+    free(ff);
+    expr_free(t);
+}
+
+/* A bare undefined symbol is already in normal form -> empty List. */
+static void test_inert_symbol(void) {
+    Expr* t = trace_of("zzz");
+    assert_list_len(t, 0);
+    expr_free(t);
+}
+
+/* A multi-step reduction records the held input first and the final value
+ * last, with no duplicate trailing entry. The *exact* intermediate set for
+ * x + 1 is validated in Phase 3 (builtin_trace); here we assert only the
+ * invariants the collector guarantees regardless of rewrite granularity. */
+static void test_multistep(void) {
+    assert_eval_eq("x = 3", "3", 0);
+    Expr* t = trace_of("x + 1");
+    /* At least the held form plus the final value. */
+    ASSERT(t->type == EXPR_FUNCTION);
+    ASSERT(t->data.function.arg_count >= 2);
+    /* First element is the held input, verbatim. */
+    char* first = expr_to_string(t->data.function.args[0]);
+    ASSERT_STR_EQ(first, "x + 1");
+    free(first);
+    /* Last element is the final result 4, and it appears exactly once at the
+     * end (the fixed point is not double-recorded). */
+    Expr* last = t->data.function.args[t->data.function.arg_count - 1];
+    ASSERT(last->type == EXPR_INTEGER && last->data.integer == 4);
+    Expr* penult = t->data.function.args[t->data.function.arg_count - 2];
+    ASSERT(!expr_eq(penult, last));
+    expr_free(t);
+    assert_eval_eq("Clear[x]", "Null", 0);
+}
+
+/* Reentrancy: eval_collect_trace called back-to-back leaves no residual global
+ * collector state, and each call produces an independent, correct trace. This
+ * also guards the Phase-1 clock mitigation -- a second trace of the same input
+ * must not be emptied by the evaluation-cache early-exit. */
+static void test_reentrancy_and_repeat(void) {
+    Expr* a = trace_of("2 + 3");
+    assert_list_len(a, 2);
+    char* sa = expr_to_string(a);
+    ASSERT_STR_EQ(sa, "{2 + 3, 5}");
+    free(sa);
+    expr_free(a);
+
+    /* Repeat the identical trace: the clock bump inside eval_collect_trace must
+     * defeat the timestamp early-exit so we still see both steps. */
+    Expr* b = trace_of("2 + 3");
+    assert_list_len(b, 2);
+    char* sb = expr_to_string(b);
+    ASSERT_STR_EQ(sb, "{2 + 3, 5}");
+    free(sb);
+    expr_free(b);
+
+    /* An inert trace between two live ones must still be empty (no leakage of
+     * the previous collector's seeded state). */
+    Expr* c = trace_of("7");
+    assert_list_len(c, 0);
+    expr_free(c);
+}
+
+int main(void) {
+    symtab_init();
+    core_init();
+
+    TEST(test_arithmetic_step);
+    TEST(test_inert_atom);
+    TEST(test_inert_symbol);
+    TEST(test_multistep);
+    TEST(test_reentrancy_and_repeat);
+
+    printf("All trace tests passed!\n");
+    symtab_clear();
+    return 0;
+}

--- a/tests/test_trace.c
+++ b/tests/test_trace.c
@@ -128,6 +128,30 @@ static void test_reentrancy_and_repeat(void) {
     expr_free(c);
 }
 
+/* The user-facing Trace[] builtin (Phase 3, src/trace.c). Unlike the direct
+ * eval_collect_trace tests above, these go through the evaluator, so they also
+ * exercise the HoldForm wrapping that keeps the returned list inert on the
+ * evaluator's re-evaluation pass (without it, {1 + 1, 2} would collapse to
+ * {2, 2}). */
+static void test_builtin_basic(void) {
+    assert_eval_eq("Trace[1 + 1]", "{1 + 1, 2}", 0);
+    assert_eval_eq("Trace[5]", "{}", 0);              /* inert atom */
+    assert_eval_eq("Trace[zzz]", "{}", 0);            /* normal-form symbol */
+    /* HoldAll: the argument reaches the builtin unevaluated. */
+    assert_eval_eq("Attributes[Trace]", "{HoldAll, Protected}", 0);
+}
+
+static void test_builtin_holdform_idempotent(void) {
+    /* Re-tracing the same input in one session must still yield the full
+     * trace (guards the clock mitigation); and the held first element must not
+     * collapse under re-evaluation (guards the HoldForm wrapping). */
+    assert_eval_eq("Trace[1 + 1]", "{1 + 1, 2}", 0);
+    assert_eval_eq("Trace[1 + 1]", "{1 + 1, 2}", 0);
+    /* The 2-argument form (h4u) is not yet implemented: builtin_trace returns
+     * NULL, and HoldAll keeps the args unevaluated, so it stays fully held. */
+    assert_eval_eq("Trace[1 + 1, x]", "Trace[1 + 1, x]", 0);
+}
+
 int main(void) {
     symtab_init();
     core_init();
@@ -137,6 +161,8 @@ int main(void) {
     TEST(test_inert_symbol);
     TEST(test_multistep);
     TEST(test_reentrancy_and_repeat);
+    TEST(test_builtin_basic);
+    TEST(test_builtin_holdform_idempotent);
 
     printf("All trace tests passed!\n");
     symtab_clear();


### PR DESCRIPTION
## Summary
Implements a Mathematica-style `Trace[expr]` that returns the sequence of
top-level intermediate expressions produced while reducing `expr` to a fixed
point. Two tiers: the evaluator-side collector (Phase 2) and the user-facing
builtin (Phase 3).

```
Trace[1 + 1]                     -> {1 + 1, 2}
Trace[5]                         -> {}
x = 3; Trace[x + 1]              -> {x + 1, 4}
Attributes[Trace]                -> {HoldAll, Protected}
Trace[{Trace[1 + 1], 2 + 2}]     -> {{Trace[1 + 1], 2 + 2}, {{1 + 1, 2}, 4}}
```

## Changes
**Phase 2 — evaluator collector (`src/eval.c`, `src/eval.h`)**
- File-static `TraceCollector` + `g_trace_active`; depth-gated recording inside
  `evaluate()`'s fixed-point loop (gated to the traced expression's own
  recursion depth, so argument sub-evaluations are excluded — flat, top-level
  v1 semantics).
- Public `eval_collect_trace(held_expr)`: borrows the held arg, bumps the eval
  clock once so the timestamp early-exit can't empty a trace, evaluates to a
  fixed point, returns the raw intermediate `List` (`{}` when nothing rewrites).
  Reentrant. When not tracing, the hot path costs one predicted-false global
  read (parity with the existing `eval_overflow` check).

**Phase 3 — user-facing builtin (`src/trace.c`, `src/core.c`)**
- `builtin_trace`: arity-1 dispatch to `eval_collect_trace`, wrapping each step
  in `HoldForm` so the returned list is inert on the evaluator's re-evaluation
  pass (without it `{1 + 1, 2}` collapses to `{2, 2}`) while printing
  transparently. 2-arg form stays unevaluated (deferred to h4u).
- `trace_init` registers `Trace` with `HoldAll | Protected` + docstring, wired
  into `core_init()`.

**Docs/tests**
- `tests/test_trace.c` (+ CMake target): direct `eval_collect_trace` tests and
  builtin-level tests. All pass.
- `docs/spec/builtins/expression-information.md` + changelog entry.

## Testing
- Clean C99 build; `eval.c` passes `-std=c99 -Wall -Wextra`.
- `trace_tests` (7 tests) all pass.
- Behavior-neutral when not tracing (verified against green `eval_eager_exit`,
  `eval_timestamps`, `rule_dispatch`, `expr_sharing`, `regression`,
  `catch_throw`, `patterns`, `replace`, `iter`, `cond`).
- Memory: macOS `leaks` (valgrind N/A on Apple Silicon) — full builtin path
  incl. nested `Trace` is **0 leaks**.

## Notes / follow-ups
- Deferred: `Trace[expr, form]` (beads-planning-h4u), `TraceDepth`
  (beads-planning-asv).
- Two pre-existing issues surfaced (NOT introduced here): a 64-byte
  `$`-constant leak from `system_constants_init`, and an `evaluate_tests`
  `Hold[Evaluate[], 1+1]` failure — both reproduce on `main` with this
  branch's `eval.c` reverted.