### PR TITLE
Trace[expr] Phase 4: changelog + transparent HoldForm in LaTeX

### DIFF
--- a/docs/spec/changelog/2026-07-20.md
+++ b/docs/spec/changelog/2026-07-20.md
@@ -164,3 +164,47 @@ against a truncated subject length so `\z` tracks the shrinking end. Registered
 as `Protected` in `regex_init()`; docstring in `info.c`; symbol `SYM_StringTrim`
 in `sym_names.c`. Tests in `tests/test_stringfns.c`; no memory leaks (valgrind
 totals identical to baseline).
+
+## `Trace` — record the evaluation chain (2026-07-20)
+
+Added `Trace[expr]` (beads-planning-b3k), a Mathematica-style debugging tool that
+returns a flat `List` of the successive top-level expressions the evaluator
+produces while reducing `expr` to a fixed point. Docs in
+`docs/spec/builtins/expression-information.md`.
+
+- One rewrite or more → `{e0, e1, …, eN}`; an inert atom or normal-form symbol
+  that needs no rewriting → `{}`. `Trace[1 + 1]` → `{1 + 1, 2}`; `Trace[5]` → `{}`;
+  `Trace[zzz]` → `{}`.
+- Flat / top-level v1 semantics: only the traced expression's own fixed-point
+  loop is recorded; argument sub-evaluations (which run at a deeper recursion
+  level) are excluded. `Trace[{Trace[1 + 1], 2 + 2}]` →
+  `{{Trace[1 + 1], 2 + 2}, {{1 + 1, 2}, 4}}` (the inner trace appears to the
+  outer as a single value).
+- `Trace` has attributes `{HoldAll, Protected}` — the argument reaches the
+  builtin unevaluated so the collector can observe the chain from the start.
+- Each recorded step is wrapped in `HoldForm` so the returned list stays inert
+  under the evaluator's fixed-point re-pass (otherwise `1 + 1` would reduce a
+  second time to give `{2, 2}`); `HoldForm` prints transparently, yielding the
+  Mathematica-style `{1 + 1, 2}`.
+- Not memoized: `Trace` bumps the evaluation clock once per call so the
+  timestamp early-exit cannot short-circuit an already-stamped root and empty
+  the trace. Reentrant: the active collector is saved/restored on the C stack.
+
+Implementation split across `src/eval.c` (evaluator-side collector
+`eval_collect_trace`, depth-gated recording in the fixed-point loop; Phase 2),
+`src/trace.c` (arity dispatch, `HoldForm` wrapping, registration; Phase 3), and
+`src/sym_names.c` (`SYM_Trace`). The two-argument form `Trace[expr, form]`
+(beads-planning-h4u) and `TraceDepth` (beads-planning-asv) are deferred:
+`Trace[expr, form]` returns `NULL` and stays unevaluated rather than
+misbehaving. Tests in `tests/test_trace.c` (collector + builtin, reentrancy,
+2-arg no-op, attributes). Leak-clean on macOS `leaks`.
+
+### Fix: `HoldForm` now transparent in LaTeX output
+
+The LaTeX printer (`src/print_latex.c`) did not special-case `HoldForm`, so
+`HoldForm[1 + 1]` rendered as `HoldForm[1+1]` in notebook math instead of
+`1+1` — which made every `Trace` step leak `HoldForm[…]` in the notebook while
+the plain-text printer already rendered it transparently. `to_latex_prec` now
+renders `HoldForm[x]` as `x` at the enclosing precedence, matching `print.c`.
+Regression covered in `tests/test_holdform` (`tests/test_print.c`), which now
+also asserts the LaTeX form; `print_latex.c` added to the tests' `COMMON_SRC`.

--- a/src/print_latex.c
+++ b/src/print_latex.c
@@ -296,6 +296,16 @@ static void to_latex_prec(LBuf* b, const Expr* e, int ctx_prec) {
     if (!head || head->type != EXPR_SYMBOL) goto fallback;
     const char* hname = head->data.symbol.name;
 
+    /* ---- HoldForm[x] → x (transparent) ----
+     * HoldForm suppresses evaluation but is invisible when printed; it must
+     * render its argument at the enclosing precedence, exactly as the plain
+     * printer does (print.c). Trace[expr] wraps each step in HoldForm, so
+     * without this the notebook LaTeX would leak "HoldForm[...]". */
+    if (hname == SYM_HoldForm && argc == 1) {
+        to_latex_prec(b, args[0], ctx_prec);
+        return;
+    }
+
     /* ---- Rational[p, q] ---- */
     if (hname == SYM_Rational && argc == 2) {
         lb_cat(b, "\\frac{");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -233,6 +233,7 @@ set(COMMON_SRC
     ../src/ndarray.c
     ../src/ndkernels.c
     ../src/print.c
+    ../src/print_latex.c
     ../src/plus.c
     ../src/times.c
     ../src/arithmetic.c

--- a/tests/test_print.c
+++ b/tests/test_print.c
@@ -4,6 +4,7 @@
 #include "symtab.h"
 #include "core.h"
 #include "print.h"
+#include "print_latex.h"
 #include "test_utils.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -77,7 +78,14 @@ void test_holdform() {
     char* full = expr_to_string_fullform(res);
     ASSERT(strcmp(full, "HoldForm[Plus[1, 1]]") == 0);
     free(full);
-    
+
+    /* HoldForm must be transparent in LaTeX too (notebook rendering), not leak
+     * "HoldForm[...]". This is what makes Trace[]'s HoldForm-wrapped steps
+     * render cleanly in the notebook. */
+    char* tex = expr_to_latex(res);
+    ASSERT(strcmp(tex, "1+1") == 0);
+    free(tex);
+
     expr_free(e);
     expr_free(res);
 }


### PR DESCRIPTION
## Summary
Follow-up to the merged Trace[expr] Phases 2+3 (#23). Completes the doc/test tail and fixes a `HoldForm` rendering bug that the Trace feature exposed.

## Changes
- **`src/print_latex.c`** — render `HoldForm[x]` transparently (as `x`, at the enclosing precedence), matching the plain printer (`print.c`). The LaTeX printer previously had no `HoldForm` case, so `HoldForm[1 + 1]` rendered as `HoldForm[1+1]` in notebook math. Every `Trace` step is `HoldForm`-wrapped, so the whole trace leaked `HoldForm[...]`. This is a general `HoldForm` bug that Trace merely surfaced.
- **`docs/spec/changelog/2026-07-20.md`** — record the `Trace[expr]` feature (flat/top-level semantics, `{HoldAll, Protected}`, `HoldForm` wrapping, non-memoization, reentrancy) and the LaTeX fix. The builtin reference (`expression-information.md`) already landed in Phase 3.
- **`tests/test_print.c`** — `test_holdform` now also asserts the LaTeX form is `1+1`.
- **`tests/CMakeLists.txt`** — add `print_latex.c` to `COMMON_SRC` so tests link it.

## Testing
- `trace_tests` and `print_tests` pass.
- LaTeX `HoldForm` transparency verified end-to-end through the REPL NDJSON pipe: `Trace[1 + 2 + 3]` now emits `"latex":"\\{1+2+3, 6\\}"` (previously `\\{HoldForm[1+2+3], HoldForm[6]\\}`).
- Full suite: 109/119; the 10 failures are pre-existing/environmental (FLINT/ECM disabled + known evaluate_tests bug) and unrelated to these files.

## JIRA Ticket
n/a — tracked in beads epic beads-planning-b3k (Trace[expr]), Phase 4.