### PR TITLE
Trace[expr, form]: filter the evaluation chain by a pattern

### DIFF
--- a/docs/spec/builtins/expression-information.md
+++ b/docs/spec/builtins/expression-information.md
@@ -498,6 +498,10 @@ Records the successive top-level expressions produced while evaluating `expr`.
   evaluator passes through while reducing `expr` to a fixed point, in order:
   `{e0, e1, ..., eN}` where `e0` is the (held) input and `eN` is the final
   result. Returns `{}` when `expr` needs no top-level rewriting.
+- `Trace[expr, form]`: The same flat trace, filtered to the steps whose
+  expression matches the pattern `form` (structural match, as in `MatchQ`).
+  `form` is held, so pattern literals such as `_Integer` or `f[_]` may be given
+  directly. Returns `{}` when no step matches.
 
 **Features**:
 - `HoldAll`, `Protected`. The argument is held so its rewrite sequence can be
@@ -513,8 +517,13 @@ Records the successive top-level expressions produced while evaluating `expr`.
   already-evaluated argument is still traced in full.
 - Reentrant: `Trace` may appear inside a traced expression; the inner list is
   produced independently.
-- The two-argument form `Trace[expr, form]` (pattern filtering) and
-  `TraceDepth` are not yet implemented; `Trace[expr, form]` stays unevaluated.
+- **`Trace[expr, form]`** matches `form` against each recorded top-level step
+  (never against argument sub-evaluations, per the flat v1 semantics), so it is
+  the flat analogue of Mathematica's form-restricted trace rather than a full
+  nested one. A bare symbol `form` matches only that literal symbol among the
+  steps, not "every use of the symbol".
+- `TraceDepth` and arities other than 1 or 2 are not implemented; e.g.
+  `Trace[expr, form, extra]` stays unevaluated.
 
 ```mathematica
 In[1]:= Trace[1 + 1]
@@ -528,6 +537,12 @@ Out[3]= {x + 1, 4}
 
 In[4]:= Trace[{Trace[1 + 1], 2 + 2}]
 Out[4]= {{Trace[1 + 1], 2 + 2}, {{1 + 1, 2}, 4}}
+
+In[5]:= Trace[1 + 2 + 3, _Integer]
+Out[5]= {6}
+
+In[6]:= Trace[Nest[f, x, 3], _f]
+Out[6]= {f[f[f[x]]]}
 ```
 
 ## ReleaseHold

--- a/docs/spec/changelog/2026-07-20.md
+++ b/docs/spec/changelog/2026-07-20.md
@@ -345,3 +345,35 @@ against a truncated subject length so `\z` tracks the shrinking end. Registered
 as `Protected` in `regex_init()`; docstring in `info.c`; symbol `SYM_StringTrim`
 in `sym_names.c`. Tests in `tests/test_stringfns.c`; no memory leaks (valgrind
 totals identical to baseline).
+
+## `Trace[expr, form]` — filter the evaluation chain by a pattern (2026-07-20)
+
+Implemented the two-argument form of `Trace` (beads-planning-h4u), the follow-up
+to the merged one-argument `Trace[expr]`. `Trace[expr, form]` returns the flat
+top-level trace filtered to the steps whose expression matches the pattern
+`form`, using the same structural matcher as `MatchQ` (`match()`, `src/match.c`).
+Since `Trace` is `HoldAll`, `form` reaches the builtin unevaluated, so pattern
+literals work directly.
+
+- `Trace[1 + 2 + 3, _Integer]` → `{6}` (the unevaluated `Plus` step is dropped;
+  only the integer result matches).
+- `Trace[Nest[f, x, 3], _f]` → `{f[f[f[x]]]}` (head pattern).
+- `Trace[1 + 2 + 3, _]` → `{1 + 2 + 3, 6}` (a blank keeps every step — identical
+  to the one-argument form).
+- `Trace[1 + 2 + 3, _Real]` → `{}` (no step matches). A bare symbol `form`
+  matches only that literal symbol among the steps, not "every use" of it.
+
+Filtering runs on the raw pre-`HoldForm` steps so `form` matches the plain
+expression a user wrote (`_Integer` against `5`, not `HoldForm[5]`); survivors
+are then `HoldForm`-wrapped like the one-arg form. Consistent with the flat,
+top-level v1 semantics, `form` is matched only against top-level rewrites, never
+against argument sub-evaluations — the flat analogue of Mathematica's
+form-restricted trace. Arities other than 1 or 2 (and `TraceDepth`,
+beads-planning-asv) remain unimplemented and stay unevaluated.
+
+Implementation entirely in `src/trace.c` (`trace_filter_by_form` +
+`trace_wrap_holdform` helpers; `builtin_trace` now dispatches arity 1 and 2);
+docstring updated in the same file; docs in
+`docs/spec/builtins/expression-information.md`. Tests in `tests/test_trace.c`
+(`test_builtin_two_arg_form`). Leak-clean on macOS `leaks` (the only residual
+leak is the pre-existing `system_constants_init` constant, beads-planning-dbl).

--- a/src/trace.c
+++ b/src/trace.c
@@ -1,4 +1,5 @@
-/* Trace[expr] — user-facing builtin (beads-planning-b3k, Phase 3).
+/* Trace[expr] / Trace[expr, form] — user-facing builtin
+ * (beads-planning-b3k Phase 3; the two-arg form is beads-planning-h4u).
  *
  * A thin wrapper over the evaluator-side collector eval_collect_trace()
  * (src/eval.c). Trace[expr] returns a flat List of the successive top-level
@@ -6,17 +7,26 @@
  *   - >=1 top-level rewrite -> {e0, e1, ..., eN}
  *   - no top-level rewrite (inert atom / normal form) -> {}
  *
+ * Trace[expr, form] additionally filters that flat list to the steps whose
+ * expression matches the pattern `form`, using the same structural matcher as
+ * MatchQ (src/match.c). Because Trace is HoldAll, `form` reaches the builtin
+ * unevaluated, so pattern literals like `_Integer` or `f[_]` work directly.
+ * This is the flat, top-level analogue of Mathematica's Trace[expr, form]:
+ * only the top-level rewrite sequence (never argument sub-evaluations) is
+ * produced, then filtered -- consistent with the v1 flat semantics of the
+ * one-arg form. A form that matches nothing yields {}.
+ *
  * All the depth/clock/ownership subtlety lives in eval_collect_trace; this file
- * only handles arity dispatch, registration, attributes, and the docstring.
- * The 2-argument form Trace[expr, form] (form filtering) is deferred to
- * beads-planning-h4u: builtin_trace returns NULL for arities != 1 so those
- * calls stay unevaluated rather than silently misbehaving.
+ * only handles arity dispatch, form filtering, HoldForm wrapping, registration,
+ * attributes, and the docstring. Arities other than 1 or 2 return NULL so the
+ * call stays unevaluated rather than silently misbehaving.
  */
 #include "expr.h"
 #include "eval.h"
 #include "symtab.h"
 #include "attr.h"
 #include "sym_names.h"
+#include "match.h"
 
 /* Trace requires HoldAll: the argument must reach the builtin unevaluated so
  * the collector can observe its rewrite sequence from the start. Without Hold,
@@ -36,19 +46,57 @@
  * yielding the Mathematica-style {1 + 1, 2}. The raw collector output is left
  * unwrapped so eval_collect_trace stays a clean data primitive for later
  * phases (TraceDepth, Trace[expr, form]). */
-Expr* builtin_trace(Expr* res) {
-    if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 1)
-        return NULL;   /* 2-arg form (h4u) and malformed calls stay unevaluated */
-
-    Expr* raw = eval_collect_trace(res->data.function.args[0]);
-    if (!raw) return NULL;
-
+/* Filter `raw` (a flat List owned by the caller) in place, keeping only the
+ * steps that structurally match `form` (borrowed). Dropped steps are freed;
+ * kept steps are compacted to the front and arg_count is shrunk. The slot array
+ * itself is untouched (still owned by `raw`), so no reallocation is needed and
+ * expr_free(raw) later reclaims it. */
+static void trace_filter_by_form(Expr* raw, Expr* form) {
+    size_t keep = 0;
     for (size_t i = 0; i < raw->data.function.arg_count; i++) {
-        Expr* step = raw->data.function.args[i];       /* ownership moves into HoldForm */
+        Expr* step = raw->data.function.args[i];
+        MatchEnv* env = env_new();
+        bool matched = match(step, form, env);
+        env_free(env);
+        if (matched) {
+            raw->data.function.args[keep++] = step;   /* compact toward front */
+        } else {
+            expr_free(step);                          /* drop */
+        }
+    }
+    raw->data.function.arg_count = keep;
+}
+
+/* Wrap every element of `raw` (a flat List, owned) in HoldForm, in place, so
+ * the returned list stays inert under the evaluator's fixed-point re-pass while
+ * still printing transparently. Ownership of each step moves into its HoldForm
+ * wrapper; the wrapper takes the slot. */
+static void trace_wrap_holdform(Expr* raw) {
+    for (size_t i = 0; i < raw->data.function.arg_count; i++) {
+        Expr* step = raw->data.function.args[i];
         Expr* wrap[1] = { step };
         raw->data.function.args[i] =
             expr_new_function(expr_new_symbol(SYM_HoldForm), wrap, 1);
     }
+}
+
+Expr* builtin_trace(Expr* res) {
+    if (res->type != EXPR_FUNCTION) return NULL;
+    size_t argc = res->data.function.arg_count;
+    if (argc != 1 && argc != 2) return NULL;  /* other arities stay unevaluated */
+
+    Expr* raw = eval_collect_trace(res->data.function.args[0]);
+    if (!raw) return NULL;
+
+    /* Trace[expr, form]: drop steps that don't match the (held) pattern form.
+     * Filtering runs on the raw, pre-HoldForm steps so `form` matches the plain
+     * expression a user wrote (e.g. _Integer against 5, not against
+     * HoldForm[5]). The collector has already restored the outer trace state,
+     * so match()'s internal evaluation (for /; and ?test) is safe here. */
+    if (argc == 2)
+        trace_filter_by_form(raw, res->data.function.args[1]);
+
+    trace_wrap_holdform(raw);
     return raw;
 }
 
@@ -58,5 +106,7 @@ void trace_init(void) {
     symtab_set_docstring("Trace",
         "Trace[expr]\n\tGenerates a list of the successive top-level expressions\n"
         "\tproduced while evaluating expr. Returns {} when expr needs no\n"
-        "\trewriting. Sub-evaluations of arguments are not recorded (flat form).");
+        "\trewriting. Sub-evaluations of arguments are not recorded (flat form).\n"
+        "Trace[expr, form]\n\tIncludes only the steps whose expression matches the\n"
+        "\tpattern form (e.g. Trace[expr, _Integer]).");
 }

--- a/tests/test_trace.c
+++ b/tests/test_trace.c
@@ -147,9 +147,27 @@ static void test_builtin_holdform_idempotent(void) {
      * collapse under re-evaluation (guards the HoldForm wrapping). */
     assert_eval_eq("Trace[1 + 1]", "{1 + 1, 2}", 0);
     assert_eval_eq("Trace[1 + 1]", "{1 + 1, 2}", 0);
-    /* The 2-argument form (h4u) is not yet implemented: builtin_trace returns
-     * NULL, and HoldAll keeps the args unevaluated, so it stays fully held. */
-    assert_eval_eq("Trace[1 + 1, x]", "Trace[1 + 1, x]", 0);
+}
+
+/* The two-argument form Trace[expr, form] (h4u): the flat trace filtered to the
+ * steps whose expression matches the pattern form. HoldAll delivers form to the
+ * builtin unevaluated, so pattern literals like _Integer work directly. */
+static void test_builtin_two_arg_form(void) {
+    /* _Integer keeps only the integer results, dropping the unevaluated Plus. */
+    assert_eval_eq("Trace[1 + 2 + 3, _Integer]", "{6}", 0);
+    assert_eval_eq("Trace[2*3 + 1, _Integer]", "{7}", 0);
+    /* Blank matches every step -> identical to the one-arg form. */
+    assert_eval_eq("Trace[1 + 2 + 3, _]", "{1 + 2 + 3, 6}", 0);
+    /* A form nothing matches -> {} (there are steps, but none is a Real). */
+    assert_eval_eq("Trace[1 + 2 + 3, _Real]", "{}", 0);
+    /* A bare symbol form matches only that literal symbol, not the steps. */
+    assert_eval_eq("Trace[1 + 1, x]", "{}", 0);
+    /* Head pattern: _f keeps the f[...] result of a nested application. */
+    assert_eval_eq("Trace[Nest[f, x, 3], _f]", "{f[f[f[x]]]}", 0);
+    /* No steps at all (normal form) stays {} whatever the form is. */
+    assert_eval_eq("Trace[zzz, _]", "{}", 0);
+    /* Arities other than 1/2 stay unevaluated (returns NULL, HoldAll holds). */
+    assert_eval_eq("Trace[1 + 1, x, y]", "Trace[1 + 1, x, y]", 0);
 }
 
 int main(void) {
@@ -163,6 +181,7 @@ int main(void) {
     TEST(test_reentrancy_and_repeat);
     TEST(test_builtin_basic);
     TEST(test_builtin_holdform_idempotent);
+    TEST(test_builtin_two_arg_form);
 
     printf("All trace tests passed!\n");
     symtab_clear();


### PR DESCRIPTION
## Summary
Implements the two-argument form of `Trace` (beads-planning-h4u), the follow-up to the merged one-argument `Trace[expr]` (Phases 2+3, #23). `Trace[expr, form]` returns the flat top-level trace filtered to the steps whose expression matches the pattern `form`.

## Changes
- **`src/trace.c`** — `builtin_trace` now dispatches arity 1 and 2 (other arities still return `NULL` and stay unevaluated). New helpers:
  - `trace_filter_by_form` — matches each raw, pre-`HoldForm` step against `form` via the same `match()` used by `MatchQ`; frees dropped steps, compacts the kept ones, shrinks `arg_count` with no reallocation.
  - `trace_wrap_holdform` — the existing wrapping, factored out.
  Filtering runs on the plain steps so `form` matches what the user wrote (`_Integer` against `5`, not `HoldForm[5]`); survivors are then `HoldForm`-wrapped. `Trace` is `HoldAll`, so `form` arrives unevaluated and pattern literals like `_Integer` / `f[_]` work directly. Docstring updated.
- **`docs/spec/builtins/expression-information.md`** — document `Trace[expr, form]` with examples; supersede the "not yet implemented" note.
- **`docs/spec/changelog/2026-07-20.md`** — changelog entry.
- **`tests/test_trace.c`** — `test_builtin_two_arg_form`.

## Semantics
Consistent with the flat, top-level v1 semantics of the one-arg form: `form` is matched only against top-level rewrites, never argument sub-evaluations — the flat analogue of Mathematica's form-restricted trace. A bare symbol `form` matches only that literal symbol among the steps (not "every use" of it).

```mathematica
Trace[1 + 2 + 3, _Integer]   (* {6} — the unevaluated Plus step is dropped *)
Trace[Nest[f, x, 3], _f]     (* {f[f[f[x]]]} — head pattern *)
Trace[1 + 2 + 3, _]          (* {1 + 2 + 3, 6} — a blank keeps every step *)
Trace[1 + 2 + 3, _Real]      (* {} — no step matches *)
```

## Testing
- `trace_tests` passes (new `test_builtin_two_arg_form` + existing).
- Verified end-to-end through the REPL NDJSON pipe.
- Leak-clean on macOS `leaks`: the only residual leak is the pre-existing `system_constants_init` constant (beads-planning-dbl), unrelated to this change.

## JIRA Ticket
n/a — tracked in beads issue beads-planning-h4u (discovered from epic beads-planning-b3k).

Note: independent of the Phase-4 doc/LaTeX follow-up (#24); either can merge first.