### PR TITLE
Render SeriesData as a series in notebook LaTeX (fixes #22)

### DIFF
--- a/docs/spec/changelog/2026-07-20.md
+++ b/docs/spec/changelog/2026-07-20.md
@@ -389,3 +389,26 @@ the plain-text printer already rendered it transparently. `to_latex_prec` now
 renders `HoldForm[x]` as `x` at the enclosing precedence, matching `print.c`.
 Regression covered in `tests/test_holdform` (`tests/test_print.c`), which now
 also asserts the LaTeX form; `print_latex.c` added to the tests' `COMMON_SRC`.
+
+## Fix: `SeriesData` now renders as a series in LaTeX output (gh #22)
+
+The notebook (LaTeX / NDJSON pipe) rendered `Series[Sin[x], {x, 0, 5}]` as the
+raw container `SeriesData[x, 0, {0, 1, 0, -1/6, 0, 1/120}, 0, 6, 1]` instead of
+the expected `x - 1/6 x^3 + 1/120 x^5 + O[x]^6` that the CLI already produced.
+The plain printer (`src/print.c`) special-cases `SeriesData`, building an
+equivalent `Plus`/`Times`/`Power`/`O` tree and delegating; the LaTeX printer
+(`src/print_latex.c`) had no such case and fell back to generic `head[args...]`.
+This is the same class of bug as the `HoldForm` LaTeX gap fixed earlier.
+
+- Extracted the tree-building logic from `print.c`'s `print_series_data` into a
+  shared, non-static `series_data_to_display_expr()` (declared in `print.h`).
+  Both printers now call it, so the plain and LaTeX renderings cannot drift.
+- Added a `SeriesData` case to `to_latex_prec` that builds the display tree and
+  delegates; an unrenderable shape falls through to the generic form.
+- Fixed negative rational coefficients in the LaTeX `Plus`/`Times` renderer to
+  display as subtraction (`x - \frac{1}{6} x^3`) rather than `+ \frac{-1}{6}`,
+  via `is_neg_rational` / `render_rational_abs` helpers — a general fix the
+  series output exposed.
+
+Regression covered in `tests/test_series_latex` (`tests/test_print.c`), which
+asserts both the plain (`x - 1/6 x^3 + 1/120 x^5 + O[x]^6`) and LaTeX forms.

--- a/src/print.c
+++ b/src/print.c
@@ -1003,7 +1003,18 @@ static void print_series_generic(Expr* e, int parent_prec) {
     printf("]");
 }
 
-static void print_series_data(Expr* e, int parent_prec) {
+/* Builds the human-readable equivalent of
+ * SeriesData[x, x0, {a0, ..., a_{k-1}}, nmin, nmax, den] as a fresh
+ * Plus-expression of Times/Power/O nodes:
+ *     a0 + a1 (x-x0) + ... + O[x-x0]^(nmax/den).
+ * Returns a freshly-owned expression (caller frees), or NULL when the
+ * arguments are not in a renderable shape (non-literal nmin/nmax/den or a
+ * non-List coefficient container) so the caller can fall back to the generic
+ * head[args...] form. Shared by the plain printer (print_series_data) and the
+ * LaTeX printer (src/print_latex.c) so the two renderings cannot drift. */
+Expr* series_data_to_display_expr(Expr* e) {
+    if (e->type != EXPR_FUNCTION || e->data.function.arg_count != 6) return NULL;
+
     Expr* x        = e->data.function.args[0];
     Expr* x0       = e->data.function.args[1];
     Expr* coefs    = e->data.function.args[2];
@@ -1018,10 +1029,7 @@ static void print_series_data(Expr* e, int parent_prec) {
                      nmax_e->type == EXPR_INTEGER &&
                      den_e->type  == EXPR_INTEGER &&
                      den_e->data.integer != 0);
-    if (!coefs_ok || !ints_ok) {
-        print_series_generic(e, parent_prec);
-        return;
-    }
+    if (!coefs_ok || !ints_ok) return NULL;
 
     int64_t nmin = nmin_e->data.integer;
     int64_t nmax = nmax_e->data.integer;
@@ -1065,9 +1073,18 @@ static void print_series_data(Expr* e, int parent_prec) {
     }
     free(terms);
 
+    expr_free(base);
+    return sum;
+}
+
+static void print_series_data(Expr* e, int parent_prec) {
+    Expr* sum = series_data_to_display_expr(e);
+    if (!sum) {
+        print_series_generic(e, parent_prec);
+        return;
+    }
     print_standard(sum, parent_prec);
     expr_free(sum);
-    expr_free(base);
 }
 
 /* ===================== TeXForm renderer =====================

--- a/src/print.h
+++ b/src/print.h
@@ -8,6 +8,11 @@ void expr_print_fullform(Expr* e);
 char* expr_to_string(Expr* e);
 char* expr_to_string_fullform(Expr* e);
 
+/* Builds the pretty Plus/Times/Power/O equivalent of a 6-argument
+ * SeriesData[...] node, or NULL if it is not in a renderable shape. Shared by
+ * the plain and LaTeX printers. Caller owns and must free the result. */
+Expr* series_data_to_display_expr(Expr* e);
+
 Expr* builtin_print(Expr* res);
 Expr* builtin_fullform(Expr* res);
 Expr* builtin_inputform(Expr* res);

--- a/src/print_latex.c
+++ b/src/print_latex.c
@@ -306,6 +306,21 @@ static void to_latex_prec(LBuf* b, const Expr* e, int ctx_prec) {
         return;
     }
 
+    /* ---- SeriesData[...] → a0 + a1 (x-x0) + ... + O[x-x0]^n ----
+     * SeriesData is an inert head that must display as the sum it represents,
+     * not as the literal 6-argument container. The plain printer (print.c)
+     * builds an equivalent Plus/Times/Power/O tree and delegates; we call the
+     * same shared builder so the notebook LaTeX matches the CLI exactly (gh
+     * #22). A NULL result (unrenderable shape) falls through to generic. */
+    if (hname == SYM_SeriesData && argc == 6) {
+        Expr* disp = series_data_to_display_expr((Expr*)e);
+        if (disp) {
+            to_latex_prec(b, disp, ctx_prec);
+            expr_free(disp);
+            return;
+        }
+    }
+
     /* ---- Rational[p, q] ---- */
     if (hname == SYM_Rational && argc == 2) {
         lb_cat(b, "\\frac{");
@@ -587,15 +602,36 @@ static void to_latex_prec(LBuf* b, const Expr* e, int ctx_prec) {
  * Plus renderer — handles subtraction (negative terms)
  * ======================================================================== */
 
-/* True if e is a negative term: Times[-1, ...] or negative integer/real */
+/* True if e is Rational[p, q] with a negative integer numerator p. Such a
+ * coefficient (e.g. -1/6) should display as subtraction, matching the plain
+ * printer, rather than "+ -1/6" (surfaced by series output, gh #22). */
+static int is_neg_rational(const Expr* e) {
+    return head_is(e, SYM_Rational) && e->data.function.arg_count == 2
+        && e->data.function.args[0]->type == EXPR_INTEGER
+        && e->data.function.args[0]->data.integer < 0;
+}
+
+/* Render |Rational[-p, q]| = \frac{p}{q} (numerator already known negative). */
+static void render_rational_abs(LBuf* b, const Expr* e) {
+    lb_cat(b, "\\frac{");
+    lb_catf(b, "%lld", (long long)(-e->data.function.args[0]->data.integer));
+    lb_cat(b, "}{");
+    to_latex_prec(b, e->data.function.args[1], PREC_ATOM);
+    lb_cat(b, "}");
+}
+
+/* True if e is a negative term: Times[-1, ...] or negative integer/real,
+ * a negative rational, or a Times led by one of those. */
 static int is_negative_term(const Expr* e) {
     if (!e) return 0;
     if (e->type == EXPR_INTEGER) return e->data.integer < 0;
     if (e->type == EXPR_REAL)    return e->data.real < 0;
+    if (is_neg_rational(e))      return 1;
     if (head_is(e, SYM_Times) && e->data.function.arg_count >= 1) {
         const Expr* first = e->data.function.args[0];
         if (first->type == EXPR_INTEGER && first->data.integer < 0) return 1;
         if (first->type == EXPR_REAL    && first->data.real    < 0) return 1;
+        if (is_neg_rational(first)) return 1;
     }
     return 0;
 }
@@ -604,8 +640,18 @@ static int is_negative_term(const Expr* e) {
 static void render_negate(LBuf* b, const Expr* e) {
     if (e->type == EXPR_INTEGER) { lb_catf(b, "%lld", (long long)-e->data.integer); return; }
     if (e->type == EXPR_REAL)    { lb_catf(b, "%g",             -e->data.real);     return; }
+    if (is_neg_rational(e))      { render_rational_abs(b, e); return; }
     if (head_is(e, SYM_Times) && e->data.function.arg_count >= 1) {
         const Expr* first = e->data.function.args[0];
+        if (is_neg_rational(first)) {
+            /* Times[-p/q, rest...] → (p/q) rest */
+            render_rational_abs(b, first);
+            for (size_t i = 1; i < e->data.function.arg_count; i++) {
+                lb_cat(b, "\\,");
+                to_latex_maybe_paren(b, e->data.function.args[i], PREC_MUL + 1);
+            }
+            return;
+        }
         int ok; double v = atom_value(first, &ok);
         if (ok && v == -1 && e->data.function.arg_count == 2) {
             /* Times[-1, x] → just render x */

--- a/tests/test_print.c
+++ b/tests/test_print.c
@@ -90,16 +90,37 @@ void test_holdform() {
     expr_free(res);
 }
 
+void test_series_latex() {
+    /* SeriesData must render as the series it represents in LaTeX (notebook),
+     * not as the raw SeriesData[...] container — matching the plain printer.
+     * Regression for gh #22. Also checks negative rational coefficients show
+     * as subtraction (x - 1/6 x^3), not "+ -1/6". */
+    Expr* e = parse_expression("Series[Sin[x], {x, 0, 5}]");
+    Expr* res = evaluate(e);
+
+    char* str = expr_to_string(res);
+    ASSERT(strcmp(str, "x - 1/6 x^3 + 1/120 x^5 + O[x]^6") == 0);
+    free(str);
+
+    char* tex = expr_to_latex(res);
+    ASSERT(strcmp(tex, "x-\\frac{1}{6}\\,x^{3}+\\frac{1}{120}\\,x^{5}+O[x]^{6}") == 0);
+    free(tex);
+
+    expr_free(e);
+    expr_free(res);
+}
+
 int main() {
     symtab_init();
     core_init();
-    
+
     TEST(test_print_basic);
     TEST(test_fullform_wrapper);
     TEST(test_inputform_wrapper);
     TEST(test_negative_bigint_in_plus);
     TEST(test_holdform);
-    
+    TEST(test_series_latex);
+
     printf("All print tests passed!\n");
     return 0;
 }


### PR DESCRIPTION
## Summary
Fixes #22. In the notebook, `Series[Sin[x],{x,0,5}]` displayed as the raw container `SeriesData[x,0,{0,1,0,-1/6,0,1/120},0,6,1]` instead of the `x - 1/6 x^3 + 1/120 x^5 + O[x]^6` form the CLI already produced. The plain printer (`src/print.c`) special-cases `SeriesData` — building an equivalent `Plus`/`Times`/`Power`/`O` tree and delegating — but the LaTeX printer (`src/print_latex.c`) had no such case and fell back to generic `head[args...]`. Same class of bug as the `HoldForm` LaTeX gap fixed in #24.

## Changes
- **`src/print.c` / `src/print.h`** — extract the tree-building logic from `print_series_data` into a shared, non-static `series_data_to_display_expr()`. `print_series_data` is now a thin wrapper. Both printers call the one builder, so plain and LaTeX renderings cannot drift.
- **`src/print_latex.c`** — add a `SeriesData` case to `to_latex_prec` that builds the display tree and delegates; unrenderable shapes fall through to generic form. Also fix negative rational coefficients to display as subtraction (`x - \frac{1}{6} x^3`) rather than `+ \frac{-1}{6}`, via `is_neg_rational` / `render_rational_abs` — a general LaTeX-printer fix the series output exposed.
- **`tests/test_print.c`** — `test_series_latex` asserts both the plain (`x - 1/6 x^3 + 1/120 x^5 + O[x]^6`) and LaTeX (`x-\frac{1}{6}\,x^{3}+...`) forms.
- **`docs/spec/changelog/2026-07-20.md`** — changelog entry.

## Testing
- `print_tests` pass (incl. new `test_series_latex`).
- Verified end-to-end through the REPL NDJSON pipe: `Series[Sin[x],{x,0,5}]` now emits `"latex":"x-\\frac{1}{6}\\,x^{3}+\\frac{1}{120}\\,x^{5}+O[x]^{6}"`, and the plain `payload` is unchanged (`x - 1/6 x^3 + 1/120 x^5 + O[x]^6`). Checked Cos, Log (centre x=1), and 1/(1-x) series too.

## Beads
beads-planning-3a9.1 (child of frontend epic beads-planning-3a9)