### PR TITLE
Correct Evaluate-in-Hold test expectation for empty Evaluate[]

### DIFF
--- a/tests/test_evaluate.c
+++ b/tests/test_evaluate.c
@@ -69,7 +69,12 @@ void test_evaluate_wrong_args() {
  * Evaluate[] vanishes and Evaluate[a,b] forces then splices both. */
 void test_evaluate_seq_in_hold() {
     assert_eval_eq("Hold[Evaluate[]]", "Hold[]", 0);
-    assert_eval_eq("Hold[Evaluate[], 1+1]", "Hold[2]", 0);
+    /* An empty Evaluate[] splices away (-> Sequence[]) but does NOT force its
+     * siblings: only an Evaluate whose head is directly on a held slot overrides
+     * Hold for that slot. So 1+1 stays held. This mirrors the non-empty case
+     * Hold[Evaluate[1+1], 2+2] -> Hold[2, 2+2] (see test_evaluate_in_hold): an
+     * empty Evaluate cannot have more reach than a non-empty one. (beads-planning-0c8) */
+    assert_eval_eq("Hold[Evaluate[], 1+1]", "Hold[1 + 1]", 0);
     assert_eval_eq("Hold[Evaluate[1+1, 2+2]]", "Hold[2, 4]", 0);
     assert_eval_eq("Hold[a, Evaluate[1+1, 2+2], b]", "Hold[a, 2, 4, b]", 0);
 }


### PR DESCRIPTION
## Summary
`Hold[Evaluate[], 1+1]` was asserted to yield `Hold[2]`, but that expectation is incorrect per Wolfram semantics — the evaluator was already right (`Hold[1 + 1]`). This corrects the sole failing assertion in `evaluate_tests`.

## Changes
- `tests/test_evaluate.c`: change the expected value of `Hold[Evaluate[], 1+1]` from `Hold[2]` to `Hold[1 + 1]`, with an explanatory comment.

## Rationale
An empty `Evaluate[]` splices away (`-> Sequence[]`) but does **not** force its siblings. `Evaluate` overrides `Hold` only when it is directly the head of a held slot. This is consistent with the passing non-empty case `Hold[Evaluate[1+1], 2+2] -> Hold[2, 2+2]`: an empty `Evaluate` cannot have more reach than a non-empty one. No engine/behavior change — test-only.

## Testing
- `evaluate_tests` now exits 0 (was aborting on this assertion); confirmed it was the only failing assertion.

## Ticket
beads-planning-0c8