### PR TITLE
Fix one-time memory leak of $MaxExtraPrecision init constant

### DIFF
--- a/docs/spec/changelog/2026-07-20.md
+++ b/docs/spec/changelog/2026-07-20.md
@@ -3,6 +3,18 @@
 
 Feature additions and fixes recorded during this week.
 
+### Fixed
+
+- **`$MaxExtraPrecision` init leak** (beads-planning-dbl). The inline
+  `$MaxExtraPrecision` registration block in `system_constants_init`
+  (`src/core.c`) passed an `expr_new_real(50.0)` temporary to
+  `symtab_add_own_value` without freeing it — a 64-byte `EXPR_REAL` leak at
+  startup (`symtab_add_own_value` deep-copies its replacement, so the caller
+  retains ownership of its own reference). Fixed by capturing the value in a
+  local and `expr_free`-ing it, mirroring the `register_system_constant` helper.
+  macOS `leaks` on `trace_tests` now reports 0 leaks (was "1 leak for 64 total
+  leaked bytes" rooted at `system_constants_init -> expr_new_real`).
+
 ## Numeric loop fast-path + iteration allocation cleanups (2026-07-20)
 
 Closed the large gap to Mathematica on tight numeric loops. Reference (10^6

--- a/src/core.c
+++ b/src/core.c
@@ -163,8 +163,10 @@ static void system_constants_init(void) {
      * other constants it is user-settable, so it is NOT marked Protected. */
     {
         Expr* sym = expr_new_symbol(SYM_DollarMaxExtraPrecision);
-        symtab_add_own_value("$MaxExtraPrecision", sym, expr_new_real(50.0));
+        Expr* val = expr_new_real(50.0);
+        symtab_add_own_value("$MaxExtraPrecision", sym, val);
         expr_free(sym);
+        expr_free(val);
     }
     register_system_constant("$MachineEpsilon",   expr_new_real(DBL_EPSILON));
     register_system_constant("$MinMachineNumber", expr_new_real(DBL_MIN));


### PR DESCRIPTION
## Summary
`system_constants_init` leaked a single 64-byte `Expr` (the `$MaxExtraPrecision` real) at startup. Reported by macOS `leaks` and valgrind, rooted at `system_constants_init -> expr_new_real`. Non-growing, but a genuine one-time leak.

## Root cause
`add_rule` inc-refs (`expr_copy`) its replacement, so a caller of `symtab_add_own_value` retains ownership of the value it passes and must free its own reference. `register_system_constant` does this correctly, but the inlined `$MaxExtraPrecision` block (which must stay non-Protected, hence inlined) freed only `sym`, never the `expr_new_real(50.0)` temporary.

## Changes
- `src/core.c`: capture the value in `val` and `expr_free(val)` after `symtab_add_own_value`, mirroring `register_system_constant`.
- `docs/spec/changelog/2026-07-20.md`: note the fix.

## Testing
- macOS `leaks --atExit ./trace_tests`: **0 leaks / 0 bytes** (was 1 leak / 64 bytes).
- Clean C99 build (`-std=c99 -Wall -Wextra`).

## Ticket
beads-planning-dbl