### PR TITLE
iOS deploy: in-process FFI kernel + Tauri iOS app (runs in Simulator)

### DIFF
--- a/docs/spec/changelog/2026-07-20.md
+++ b/docs/spec/changelog/2026-07-20.md
@@ -3,6 +3,42 @@
 
 Feature additions and fixes recorded during this week.
 
+## iOS deploy: in-process FFI kernel + Tauri iOS scaffolding (2026-07-20)
+
+Groundwork to ship the Mathilda notebook as an iOS app. iOS sandboxes forbid
+spawning child processes, so the desktop app's sidecar model (spawn the
+`mathilda` binary, talk NDJSON over stdio) cannot run on iOS. The kernel is now
+embeddable **in-process** through a small, stable C ABI.
+
+- **New C FFI layer** (`src/ffi/mathilda_ffi.{c,h}`): `mathilda_ffi_init()`,
+  `mathilda_ffi_eval()` (→ REPL-style output text), `mathilda_ffi_eval_latex()`
+  (→ KaTeX LaTeX), `mathilda_ffi_set_home()` (points the `init.m` loader at a
+  bundled `internal/` tree via `$MATHILDA_HOME`), `mathilda_ffi_free()`,
+  `mathilda_ffi_version()`. Mirrors the sidecar's parse → evaluate → format
+  pipeline; no readline, no stdio loop, no process. Not reentrant — callers
+  serialize (the mobile kernel does so behind a mutex).
+- **`libmathilda.a` build target** (`makefile`): archives every kernel object
+  except `repl.o` (which carries `main()`/readline/the pipe loop). Verified on
+  the host: linked a smoke harness against the archive and evaluated `1+1`,
+  `2^100`, `Integrate[x^2,x]`, `D[Sin[x],x]`, `Factor`, `Solve`, `Table`,
+  `N[Pi,20]`, `Simplify[Sin^2+Cos^2]`, rationals, and a LaTeX render — all
+  correct, entirely in-process.
+- **Tauri mobile backend** (`frontend/src-tauri/`): `src/ffi.rs` (safe Rust
+  bindings) + `src/kernel_ffi.rs` (in-process `MathildaKernel` with the same
+  async API as the sidecar kernel). `lib.rs` selects the backend by
+  `#[cfg(mobile)]` vs `#[cfg(not(mobile))]`; the native menu bar is now
+  desktop-gated. `build.rs` links `libmathilda.a` + GMP (+ MPFR) for iOS.
+- **iOS cross-compile automation** (`frontend/build-ios-lib.sh`): cross-builds
+  GMP and MPFR for the iOS Simulator/device and then `libmathilda.a`, into
+  `gen/ios-libs/<target>/`. Tauri CLI + `ios:*` npm scripts added. Full runbook
+  in `frontend/IOS.md`.
+
+Not yet runnable end-to-end on iOS: requires full Xcode + an iOS Simulator
+runtime (Command Line Tools alone cannot locate the `iphonesimulator` SDK).
+Follow-up: a `USE_MPFR=0` minimal build currently does not compile (linalg /
+numerical / poly subsystems reference MPFR unconditionally), so iOS builds with
+GMP+MPFR for now.
+
 ## NDArray linear-algebra fast paths → LAPACK/BLAS (2026-07-21)
 
 Completed the NDArray fast-path coverage of the linear-algebra / matrix builtins,

--- a/docs/spec/changelog/2026-07-20.md
+++ b/docs/spec/changelog/2026-07-20.md
@@ -32,12 +32,23 @@ embeddable **in-process** through a small, stable C ABI.
   GMP and MPFR for the iOS Simulator/device and then `libmathilda.a`, into
   `gen/ios-libs/<target>/`. Tauri CLI + `ios:*` npm scripts added. Full runbook
   in `frontend/IOS.md`.
+- **Config** (`frontend/src-tauri/tauri.ios.conf.json`): iOS override that drops
+  the desktop `externalBin` sidecar and bundles the `internal/` tree as an app
+  resource. `build.rs` auto-locates the static libs under
+  `gen/ios-libs/<target-triple>/` (no env var needed — an Xcode script phase
+  runs cargo with its own environment). `kernel_ffi.rs` probes the bundled
+  resource layout (`assets/internal/`) for `init.m`.
 
-Not yet runnable end-to-end on iOS: requires full Xcode + an iOS Simulator
-runtime (Command Line Tools alone cannot locate the `iphonesimulator` SDK).
-Follow-up: a `USE_MPFR=0` minimal build currently does not compile (linalg /
-numerical / poly subsystems reference MPFR unconditionally), so iOS builds with
-GMP+MPFR for now.
+**Verified end-to-end on the iOS Simulator** (Xcode 26.6, iOS 26.5, arm64): the
+Tauri app builds (`BUILD SUCCEEDED`), installs, and renders the notebook UI in
+the simulator; and the iOS-Simulator-built kernel, run inside the booted
+simulator, evaluates `Integrate[x^2,x]`, `D[Sin[x],x]`, `Factor`, `Solve`,
+`N[Pi,20]`, `Simplify`, `2^100`, etc. correctly — entirely in-process.
+
+Notes: full Xcode + a Simulator runtime are required (Command Line Tools cannot
+locate the `iphonesimulator` SDK). Bitcode is not used (removed in Xcode 14+).
+Follow-up: a `USE_MPFR=0` minimal build does not yet compile (linalg / numerical
+/ poly reference MPFR unconditionally), so iOS ships GMP+MPFR for now.
 
 ## NDArray linear-algebra fast paths → LAPACK/BLAS (2026-07-21)
 

--- a/frontend/IOS.md
+++ b/frontend/IOS.md
@@ -1,0 +1,115 @@
+# Running Mathilda Notebook on iOS
+
+The desktop notebook runs the CAS as a **sidecar process** (spawns the
+`mathilda` binary, talks NDJSON over stdio). **iOS forbids spawning child
+processes**, so on iOS the kernel is compiled to a static library and linked
+**in-process** through a C FFI. This document is the runbook.
+
+## Architecture
+
+```
+Desktop:  Svelte UI ──IPC──▶ Rust (kernel.rs) ──spawn/stdio──▶ mathilda sidecar
+iOS:      Svelte UI ──IPC──▶ Rust (kernel_ffi.rs) ──FFI──▶ libmathilda.a (in-process)
+```
+
+| Piece | File |
+|-------|------|
+| C ABI (init / eval / eval_latex / set_home / free) | `../src/ffi/mathilda_ffi.{c,h}` |
+| Static archive target | `../makefile` → `libmathilda.a` |
+| Safe Rust bindings | `src-tauri/src/ffi.rs` |
+| In-process kernel (mobile) | `src-tauri/src/kernel_ffi.rs` |
+| Backend selection (`#[cfg(mobile)]`) | `src-tauri/src/lib.rs` |
+| iOS link flags | `src-tauri/build.rs` |
+| GMP/MPFR + kernel cross-compile | `build-ios-lib.sh` |
+
+The kernel is **not reentrant** (process-global symbol table); `kernel_ffi.rs`
+serializes every evaluation behind a mutex and runs it on a blocking thread.
+
+## Prerequisites (one-time, requires human action)
+
+Command Line Tools are **not** enough — you need full Xcode:
+
+```bash
+# Install Xcode from the Mac App Store, then:
+sudo xcode-select -s /Applications/Xcode.app
+sudo xcodebuild -license accept
+xcodebuild -downloadPlatform iOS          # a Simulator runtime
+
+# Rust iOS targets:
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+
+# Verify the SDK is visible (should print a path, not an error):
+xcrun --sdk iphonesimulator --show-sdk-path
+```
+
+Also download GMP and MPFR sources (neither cross-compiles via Homebrew):
+
+```bash
+curl -LO https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
+curl -LO https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.xz
+```
+
+## Build & run in the Simulator
+
+```bash
+cd frontend
+
+# 1. Cross-compile GMP + MPFR + libmathilda.a for the Simulator (arm64).
+GMP_TARBALL=/path/to/gmp-6.3.0.tar.xz \
+MPFR_TARBALL=/path/to/mpfr-4.2.1.tar.xz \
+  ./build-ios-lib.sh sim
+# → src-tauri/gen/ios-libs/aarch64-apple-ios-sim/{libmathilda,libgmp,libmpfr}.a
+
+# 2. One-time: generate the Xcode project.
+npm install
+npm run ios:init
+
+# 3. Bundle the internal module tree (init.m + tables) as an app resource so
+#    the kernel finds its bootstrap on-device. Point tauri.conf.json bundle
+#    resources at ../../src/internal → "internal" (see "Bundling init.m" below),
+#    or copy it into src-tauri/resources/internal before building.
+
+# 4. Run in the Simulator.
+MATHILDA_IOS_LIBDIR="$(pwd)/src-tauri/gen/ios-libs/aarch64-apple-ios-sim" \
+  npm run ios:dev
+```
+
+For a device / TestFlight build use `./build-ios-lib.sh device` and
+`npm run ios:build` (device builds require an Apple signing identity).
+
+## Bundling init.m
+
+`kernel_ffi.rs` sets `MATHILDA_HOME` to `<app resources>/internal` before
+initializing, and the loader resolves `init.m` from there. Ensure the
+`src/internal` tree is bundled — e.g. in `tauri.conf.json`:
+
+```jsonc
+"bundle": {
+  "resources": { "../../src/internal": "internal" }
+}
+```
+
+(Keep this out of the desktop bundle config if you don't want the tree shipped
+twice; the desktop sidecar locates `init.m` on its own.)
+
+## Capabilities & knobs
+
+- `MATHILDA_IOS_LIBDIR` — dir holding the cross-built `.a` files (consumed by
+  `build.rs`). Defaults to `gen/ios-libs`.
+- `MATHILDA_IOS_WITH_MPFR=0` — drop the MPFR link (only valid once the
+  `USE_MPFR=0` minimal kernel build compiles; see below).
+- `WITH_MPFR=0 ./build-ios-lib.sh` — build the kernel without MPFR (same caveat).
+
+## Known limitations
+
+- **Full Xcode required** — nothing iOS compiles or runs without the SDK.
+- **`USE_MPFR=0` does not yet build** — several subsystems (linalg eigen,
+  numerical roots, Gröbner, some special functions) reference MPFR
+  unconditionally. iOS therefore ships GMP+MPFR. Fixing the guards is tracked
+  as follow-up and would slim the binary.
+- **No graphics / FLINT / ECM / LAPACK on iOS** — the mobile kernel is built
+  with those subsystems off (text-placeholder graphics). BLAS/LAPACK via
+  Accelerate could be re-enabled later (the framework is linked).
+- **`interrupt` / `restart` are no-ops** in-process: a synchronous C evaluation
+  can't be cancelled from another thread, and the symbol table has no reset
+  entry point yet. A `mathilda_ffi_reset()` would enable true "Run All".

--- a/frontend/IOS.md
+++ b/frontend/IOS.md
@@ -51,31 +51,40 @@ curl -LO https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.xz
 
 ## Build & run in the Simulator
 
+Verified working on Xcode 26.6 / iOS 26.5 Simulator (arm64), Tauri CLI 2.11.
+
 ```bash
 cd frontend
+npm install
 
 # 1. Cross-compile GMP + MPFR + libmathilda.a for the Simulator (arm64).
+#    Writes src-tauri/gen/ios-libs/aarch64-apple-ios-sim/{libmathilda,libgmp,libmpfr}.a
 GMP_TARBALL=/path/to/gmp-6.3.0.tar.xz \
 MPFR_TARBALL=/path/to/mpfr-4.2.1.tar.xz \
   ./build-ios-lib.sh sim
-# → src-tauri/gen/ios-libs/aarch64-apple-ios-sim/{libmathilda,libgmp,libmpfr}.a
 
-# 2. One-time: generate the Xcode project.
-npm install
+# 2. One-time: generate the Xcode project. tauri.ios.conf.json bundles the
+#    internal/ module tree (init.m + tables) as an app resource automatically.
 npm run ios:init
 
-# 3. Bundle the internal module tree (init.m + tables) as an app resource so
-#    the kernel finds its bootstrap on-device. Point tauri.conf.json bundle
-#    resources at ../../src/internal → "internal" (see "Bundling init.m" below),
-#    or copy it into src-tauri/resources/internal before building.
+# 3. Build + run in the Simulator. build.rs auto-locates the libs under
+#    gen/ios-libs/<target>/ — no env var needed.
+npm run ios:dev                       # builds, boots a simulator, launches
 
-# 4. Run in the Simulator.
-MATHILDA_IOS_LIBDIR="$(pwd)/src-tauri/gen/ios-libs/aarch64-apple-ios-sim" \
-  npm run ios:dev
+# Build only (no launch), e.g. to validate linking:
+npx tauri ios build --target aarch64-sim --debug --ci
 ```
 
 For a device / TestFlight build use `./build-ios-lib.sh device` and
 `npm run ios:build` (device builds require an Apple signing identity).
+
+### Manual install/launch (if you already built the .app)
+
+```bash
+xcrun simctl boot "iPhone 17 Pro"; open -a Simulator
+xcrun simctl install booted src-tauri/gen/apple/build/arm64-sim/Mathilda.app
+xcrun simctl launch booted com.mathilda.notebook
+```
 
 ## Bundling init.m
 

--- a/frontend/build-ios-lib.sh
+++ b/frontend/build-ios-lib.sh
@@ -79,7 +79,9 @@ SYSROOT="$(xcrun --sdk "$SDK" --show-sdk-path)"
 CC_BIN="$(xcrun --sdk "$SDK" --find clang)"
 AR_BIN="$(xcrun --sdk "$SDK" --find ar)"
 RANLIB_BIN="$(xcrun --sdk "$SDK" --find ranlib)"
-IOS_CFLAGS="-arch $ARCH -isysroot $SYSROOT $MINFLAG -O2 -fembed-bitcode-marker"
+# NOTE: no -fembed-bitcode-marker — bitcode was removed in Xcode 14+ and the
+# flag makes the modern linker fail (it treats "marker" as a missing file).
+IOS_CFLAGS="-arch $ARCH -isysroot $SYSROOT $MINFLAG -O2"
 
 echo ">>> target=$TARGET sdk=$SDK arch=$ARCH"
 echo ">>> sysroot=$SYSROOT"
@@ -90,6 +92,9 @@ mkdir -p "$OUT_DIR"
 # GMP must be cross-compiled; its assembly does not build for the iOS toolchain,
 # so we disable it (--disable-assembly) at a modest perf cost.
 build_gmp() {
+  if [ -f "$OUT_DIR/libgmp.a" ] && [ "${FORCE_DEPS:-0}" != "1" ]; then
+    echo ">>> libgmp.a already present (set FORCE_DEPS=1 to rebuild)"; return 0
+  fi
   local src="${GMP_SRC:-}"
   if [ -z "$src" ] && [ -n "${GMP_TARBALL:-}" ]; then
     src="$(mktemp -d)/gmp"
@@ -121,6 +126,9 @@ build_gmp() {
 # --- 1b. MPFR (against the cross-built GMP) ---------------------------------
 build_mpfr() {
   [ "$WITH_MPFR" = "1" ] || return 0
+  if [ -f "$OUT_DIR/libmpfr.a" ] && [ "${FORCE_DEPS:-0}" != "1" ]; then
+    echo ">>> libmpfr.a already present (set FORCE_DEPS=1 to rebuild)"; return 0
+  fi
   local src="${MPFR_SRC:-}"
   if [ -z "$src" ] && [ -n "${MPFR_TARBALL:-}" ]; then
     src="$(mktemp -d)/mpfr"
@@ -158,7 +166,6 @@ build_mpfr() {
 build_kernel() {
   echo ">>> building libmathilda.a for iOS"
   local mpfr_flag="USE_MPFR=0"
-  local extra_inc="-I$OUT_DIR"          # our cross-built gmp.h / mpfr.h live here
   if [ "$WITH_MPFR" = "1" ]; then
     mpfr_flag="USE_MPFR=1"
     if [ ! -f "$OUT_DIR/libmpfr.a" ]; then
@@ -166,12 +173,23 @@ build_kernel() {
       exit 1
     fi
   fi
+
+  # Inject the iOS arch/sysroot via a CC wrapper rather than overriding the
+  # makefile's CFLAGS (which carries the full -I include list). -I$OUT_DIR is
+  # prepended so our cross-built gmp.h/mpfr.h win over any Homebrew copy the
+  # makefile adds via -I/opt/homebrew/include.
+  local wrapper="$OUT_DIR/cc-ios.sh"
+  cat > "$wrapper" <<EOF
+#!/bin/sh
+exec "$CC_BIN" $IOS_CFLAGS -I"$OUT_DIR" "\$@"
+EOF
+  chmod +x "$wrapper"
+
   ( cd "$REPO_ROOT"
     make clean >/dev/null 2>&1 || true
     make libmathilda.a \
-      CC="$CC_BIN" \
+      CC="$wrapper" \
       AR="$AR_BIN" \
-      CFLAGS="$IOS_CFLAGS -std=c99 -I./src -I./src/ffi $extra_inc" \
       USE_READLINE=0 USE_THREADS=0 USE_ECM=0 $mpfr_flag \
       USE_LAPACK=0 USE_GRAPHICS=0 USE_FLINT=0 USE_REGEX=0 USE_FFTW=0 \
       -j"$(sysctl -n hw.ncpu)"

--- a/frontend/build-ios-lib.sh
+++ b/frontend/build-ios-lib.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# build-ios-lib.sh — cross-compile the Mathilda kernel (+ GMP) as static
+# libraries for iOS, so the notebook can run the CAS in-process (no sidecar,
+# which iOS forbids). Produces, per target:
+#
+#   frontend/src-tauri/gen/ios-libs/<target>/libmathilda.a
+#   frontend/src-tauri/gen/ios-libs/<target>/libgmp.a
+#   frontend/src-tauri/gen/ios-libs/<target>/libmpfr.a   (when WITH_MPFR=1, default)
+#
+# `build.rs` links these when CARGO_CFG_TARGET_OS=ios; point it at the right
+# directory with MATHILDA_IOS_LIBDIR (see the tauri ios wrapper in package.json).
+#
+# WHY MPFR IS ON BY DEFAULT: the kernel's linalg/numerical subsystems reference
+# MPFR unconditionally today (a USE_MPFR=0 build does not yet compile — tracked
+# as follow-up work). So iOS uses the same GMP+MPFR config that the desktop
+# build and the FFI smoke test already validate. Set WITH_MPFR=0 only once the
+# minimal-config build is fixed upstream.
+#
+# REQUIREMENTS (cannot be satisfied by Command Line Tools alone):
+#   * Full Xcode + an iOS Simulator runtime.
+#       sudo xcode-select -s /Applications/Xcode.app
+#       sudo xcodebuild -license accept
+#       xcodebuild -downloadPlatform iOS
+#   * GMP and MPFR source tarballs (neither cross-compiles via brew).
+#       curl -LO https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
+#       curl -LO https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.xz
+#     Point GMP_SRC / MPFR_SRC at the extracted dirs, or set GMP_TARBALL /
+#     MPFR_TARBALL and this script extracts them.
+#
+# USAGE:
+#   ./build-ios-lib.sh sim      # arm64 iOS Simulator (Apple Silicon macs)
+#   ./build-ios-lib.sh device   # arm64 iOS device (for TestFlight/App Store)
+#   TARGET=sim WITH_MPFR=0 ./build-ios-lib.sh   # (only after minimal build fixed)
+#
+set -euo pipefail
+
+# --- resolve paths ----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"          # the Mathilda repo root
+SRC_TAURI="$SCRIPT_DIR/src-tauri"
+OUT_ROOT="$SRC_TAURI/gen/ios-libs"
+
+# --- pick target ------------------------------------------------------------
+TARGET="${1:-${TARGET:-sim}}"
+case "$TARGET" in
+  sim)
+    SDK="iphonesimulator"
+    ARCH="arm64"
+    MINFLAG="-mios-simulator-version-min=13.0"
+    GMP_HOST="aarch64-apple-darwin"      # sim is arm64-darwin-like
+    OUT_DIR="$OUT_ROOT/aarch64-apple-ios-sim" ;;
+  device)
+    SDK="iphoneos"
+    ARCH="arm64"
+    MINFLAG="-miphoneos-version-min=13.0"
+    GMP_HOST="aarch64-apple-darwin"
+    OUT_DIR="$OUT_ROOT/aarch64-apple-ios" ;;
+  *)
+    echo "usage: $0 [sim|device]" >&2; exit 2 ;;
+esac
+
+WITH_MPFR="${WITH_MPFR:-1}"
+
+# --- sanity: full Xcode present --------------------------------------------
+if ! xcrun --sdk "$SDK" --show-sdk-path >/dev/null 2>&1; then
+  cat >&2 <<EOF
+ERROR: the "$SDK" SDK cannot be located.
+
+This needs full Xcode (Command Line Tools are not enough). Install Xcode from
+the App Store, then:
+  sudo xcode-select -s /Applications/Xcode.app
+  sudo xcodebuild -license accept
+  xcodebuild -downloadPlatform iOS
+EOF
+  exit 1
+fi
+
+SYSROOT="$(xcrun --sdk "$SDK" --show-sdk-path)"
+CC_BIN="$(xcrun --sdk "$SDK" --find clang)"
+AR_BIN="$(xcrun --sdk "$SDK" --find ar)"
+RANLIB_BIN="$(xcrun --sdk "$SDK" --find ranlib)"
+IOS_CFLAGS="-arch $ARCH -isysroot $SYSROOT $MINFLAG -O2 -fembed-bitcode-marker"
+
+echo ">>> target=$TARGET sdk=$SDK arch=$ARCH"
+echo ">>> sysroot=$SYSROOT"
+echo ">>> out=$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+# --- 1. GMP -----------------------------------------------------------------
+# GMP must be cross-compiled; its assembly does not build for the iOS toolchain,
+# so we disable it (--disable-assembly) at a modest perf cost.
+build_gmp() {
+  local src="${GMP_SRC:-}"
+  if [ -z "$src" ] && [ -n "${GMP_TARBALL:-}" ]; then
+    src="$(mktemp -d)/gmp"
+    mkdir -p "$src"
+    tar -xf "$GMP_TARBALL" -C "$src" --strip-components=1
+  fi
+  if [ -z "$src" ]; then
+    echo "ERROR: set GMP_SRC (extracted gmp dir) or GMP_TARBALL (gmp-*.tar.xz)." >&2
+    echo "       Download: https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz" >&2
+    exit 1
+  fi
+  echo ">>> building GMP from $src"
+  local build_dir="$OUT_DIR/gmp-build"
+  rm -rf "$build_dir"; mkdir -p "$build_dir"
+  ( cd "$build_dir"
+    CC="$CC_BIN" CFLAGS="$IOS_CFLAGS" AR="$AR_BIN" RANLIB="$RANLIB_BIN" \
+      "$src/configure" \
+        --host="$GMP_HOST" \
+        --disable-shared --enable-static --disable-assembly \
+        --prefix="$build_dir/install"
+    make -j"$(sysctl -n hw.ncpu)"
+    make install
+  )
+  cp "$build_dir/install/lib/libgmp.a" "$OUT_DIR/libgmp.a"
+  cp "$build_dir/install/include/gmp.h" "$OUT_DIR/gmp.h"
+  echo ">>> libgmp.a ready"
+}
+
+# --- 1b. MPFR (against the cross-built GMP) ---------------------------------
+build_mpfr() {
+  [ "$WITH_MPFR" = "1" ] || return 0
+  local src="${MPFR_SRC:-}"
+  if [ -z "$src" ] && [ -n "${MPFR_TARBALL:-}" ]; then
+    src="$(mktemp -d)/mpfr"
+    mkdir -p "$src"
+    tar -xf "$MPFR_TARBALL" -C "$src" --strip-components=1
+  fi
+  if [ -z "$src" ]; then
+    echo "ERROR: WITH_MPFR=1 but MPFR_SRC / MPFR_TARBALL not set." >&2
+    echo "       Download: https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.xz" >&2
+    exit 1
+  fi
+  echo ">>> building MPFR from $src (against iOS GMP)"
+  local gmp_install="$OUT_DIR/gmp-build/install"
+  local build_dir="$OUT_DIR/mpfr-build"
+  rm -rf "$build_dir"; mkdir -p "$build_dir"
+  ( cd "$build_dir"
+    CC="$CC_BIN" CFLAGS="$IOS_CFLAGS" AR="$AR_BIN" RANLIB="$RANLIB_BIN" \
+      "$src/configure" \
+        --host="$GMP_HOST" \
+        --disable-shared --enable-static \
+        --with-gmp="$gmp_install" \
+        --prefix="$build_dir/install"
+    make -j"$(sysctl -n hw.ncpu)"
+    make install
+  )
+  cp "$build_dir/install/lib/libmpfr.a" "$OUT_DIR/libmpfr.a"
+  cp "$build_dir/install/include/mpfr.h" "$OUT_DIR/mpfr.h"
+  echo ">>> libmpfr.a ready"
+}
+
+# --- 2. libmathilda ---------------------------------------------------------
+# Minimal, dependency-light kernel: GMP required, everything else off. The C
+# FFI entry points live in src/ffi/mathilda_ffi.c (archived via the makefile's
+# `libmathilda.a` target, which excludes repl.o).
+build_kernel() {
+  echo ">>> building libmathilda.a for iOS"
+  local mpfr_flag="USE_MPFR=0"
+  local extra_inc="-I$OUT_DIR"          # our cross-built gmp.h / mpfr.h live here
+  if [ "$WITH_MPFR" = "1" ]; then
+    mpfr_flag="USE_MPFR=1"
+    if [ ! -f "$OUT_DIR/libmpfr.a" ]; then
+      echo "ERROR: WITH_MPFR=1 but $OUT_DIR/libmpfr.a is missing (build_mpfr failed?)." >&2
+      exit 1
+    fi
+  fi
+  ( cd "$REPO_ROOT"
+    make clean >/dev/null 2>&1 || true
+    make libmathilda.a \
+      CC="$CC_BIN" \
+      AR="$AR_BIN" \
+      CFLAGS="$IOS_CFLAGS -std=c99 -I./src -I./src/ffi $extra_inc" \
+      USE_READLINE=0 USE_THREADS=0 USE_ECM=0 $mpfr_flag \
+      USE_LAPACK=0 USE_GRAPHICS=0 USE_FLINT=0 USE_REGEX=0 USE_FFTW=0 \
+      -j"$(sysctl -n hw.ncpu)"
+  )
+  cp "$REPO_ROOT/libmathilda.a" "$OUT_DIR/libmathilda.a"
+  echo ">>> libmathilda.a ready"
+}
+
+build_gmp
+build_mpfr
+build_kernel
+
+echo
+echo "DONE. Artifacts in $OUT_DIR:"
+ls -la "$OUT_DIR"/*.a
+echo
+echo "Next: run the iOS app with the lib dir exported, e.g."
+echo "  MATHILDA_IOS_LIBDIR=\"$OUT_DIR\" WITH_MPFR=$WITH_MPFR \\"
+echo "    npm --prefix \"$SCRIPT_DIR\" run tauri ios dev"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@tauri-apps/cli": "^2.11.4",
         "@tsconfig/svelte": "^5.0.8",
         "@types/katex": "^0.16.8",
         "@types/node": "^24.13.2",
@@ -594,6 +595,223 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/cli": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.4.tgz",
+      "integrity": "sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==",
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "bin": {
+        "tauri": "tauri.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      },
+      "optionalDependencies": {
+        "@tauri-apps/cli-darwin-arm64": "2.11.4",
+        "@tauri-apps/cli-darwin-x64": "2.11.4",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.4",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.4",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.4",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.4",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.4"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-arm64": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.4.tgz",
+      "integrity": "sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-darwin-x64": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.4.tgz",
+      "integrity": "sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.4.tgz",
+      "integrity": "sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.4.tgz",
+      "integrity": "sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-arm64-musl": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.4.tgz",
+      "integrity": "sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.4.tgz",
+      "integrity": "sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-gnu": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.4.tgz",
+      "integrity": "sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-linux-x64-musl": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.4.tgz",
+      "integrity": "sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.4.tgz",
+      "integrity": "sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.4.tgz",
+      "integrity": "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.4.tgz",
+      "integrity": "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,10 +7,16 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
+    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
+    "tauri": "tauri",
+    "ios:libs": "./build-ios-lib.sh sim",
+    "ios:init": "tauri ios init",
+    "ios:dev": "tauri ios dev",
+    "ios:build": "tauri ios build"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@tauri-apps/cli": "^2.11.4",
     "@tsconfig/svelte": "^5.0.8",
     "@types/katex": "^0.16.8",
     "@types/node": "^24.13.2",

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -8,8 +8,17 @@ fn main() {
     // libmpfr.a is linked unless MATHILDA_IOS_WITH_MPFR=0 is set explicitly.
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if target_os == "ios" {
-        let libdir = std::env::var("MATHILDA_IOS_LIBDIR")
-            .unwrap_or_else(|_| "gen/ios-libs".to_string());
+        // Default to the conventional location build-ios-lib.sh writes to:
+        //   <src-tauri>/gen/ios-libs/<target-triple>/lib*.a
+        // Use an ABSOLUTE path (via CARGO_MANIFEST_DIR) because `tauri ios
+        // build` invokes cargo from an Xcode script phase whose cwd and
+        // environment differ — a relative path or an exported env var is not
+        // reliably visible there. MATHILDA_IOS_LIBDIR still overrides.
+        let libdir = std::env::var("MATHILDA_IOS_LIBDIR").unwrap_or_else(|_| {
+            let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+            let target = std::env::var("TARGET").unwrap_or_default();
+            format!("{manifest}/gen/ios-libs/{target}")
+        });
         println!("cargo:rerun-if-env-changed=MATHILDA_IOS_LIBDIR");
         println!("cargo:rerun-if-env-changed=MATHILDA_IOS_WITH_MPFR");
         println!("cargo:rustc-link-search=native={libdir}");

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,3 +1,27 @@
 fn main() {
-  tauri_build::build()
+    // On iOS the Mathilda kernel is linked in-process as a static library
+    // (there is no sidecar). The cross-compiled archives are produced by
+    // `frontend/build-ios-lib.sh`; point this build at their output directory
+    // with MATHILDA_IOS_LIBDIR (defaults to the conventional location).
+    //
+    // The kernel is built with USE_MPFR=1 by default (build-ios-lib.sh), so
+    // libmpfr.a is linked unless MATHILDA_IOS_WITH_MPFR=0 is set explicitly.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "ios" {
+        let libdir = std::env::var("MATHILDA_IOS_LIBDIR")
+            .unwrap_or_else(|_| "gen/ios-libs".to_string());
+        println!("cargo:rerun-if-env-changed=MATHILDA_IOS_LIBDIR");
+        println!("cargo:rerun-if-env-changed=MATHILDA_IOS_WITH_MPFR");
+        println!("cargo:rustc-link-search=native={libdir}");
+        println!("cargo:rustc-link-lib=static=mathilda");
+        println!("cargo:rustc-link-lib=static=gmp");
+        if std::env::var("MATHILDA_IOS_WITH_MPFR").as_deref() != Ok("0") {
+            println!("cargo:rustc-link-lib=static=mpfr");
+        }
+        // Accelerate provides BLAS/LAPACK on Apple platforms (harmless if the
+        // kernel was built without USE_LAPACK — no symbols are referenced).
+        println!("cargo:rustc-link-lib=framework=Accelerate");
+    }
+
+    tauri_build::build()
 }

--- a/frontend/src-tauri/src/ffi.rs
+++ b/frontend/src-tauri/src/ffi.rs
@@ -1,0 +1,87 @@
+//! ffi.rs — safe Rust bindings to the in-process Mathilda kernel.
+//!
+//! On desktop the notebook talks to a spawned `mathilda` sidecar over stdio
+//! (see `kernel.rs`). Mobile OS sandboxes (iOS/Android) forbid spawning child
+//! processes, so there the kernel is compiled to a static library
+//! (`libmathilda.a`, built from `src/ffi/mathilda_ffi.c`) and linked directly
+//! into this app. This module wraps that C ABI in safe Rust.
+//!
+//! Safety: the C kernel uses a process-global symbol table and is NOT
+//! reentrant. Every function here must be called from a single logical thread
+//! at a time — callers serialize through a mutex (see `kernel_ffi.rs`).
+
+#![allow(dead_code)] // desktop builds compile this module but call none of it.
+
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+extern "C" {
+    fn mathilda_ffi_init();
+    fn mathilda_ffi_set_home(dir: *const c_char);
+    fn mathilda_ffi_eval(input: *const c_char) -> *mut c_char;
+    fn mathilda_ffi_eval_latex(input: *const c_char) -> *mut c_char;
+    fn mathilda_ffi_free(s: *mut c_char);
+    fn mathilda_ffi_version() -> *const c_char;
+}
+
+/// Point the kernel at the bundled `internal/` module tree (contains `init.m`
+/// and the derivative/integral tables). Call once before `init`. On iOS this
+/// is the app bundle's resource directory.
+pub fn set_home(dir: &str) {
+    if let Ok(c) = CString::new(dir) {
+        // SAFETY: `c` outlives the call; the C side copies the string.
+        unsafe { mathilda_ffi_set_home(c.as_ptr()) };
+    }
+}
+
+/// Initialize the kernel (idempotent). Loads builtins + `init.m`.
+pub fn init() {
+    // SAFETY: no arguments; C side guards against double-init.
+    unsafe { mathilda_ffi_init() };
+}
+
+/// Take ownership of a C string returned by the kernel, copying it into a Rust
+/// `String` and freeing the C allocation. Returns "" on NULL / bad UTF-8.
+unsafe fn take_c_string(ptr: *mut c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    let s = CStr::from_ptr(ptr).to_string_lossy().into_owned();
+    mathilda_ffi_free(ptr);
+    s
+}
+
+/// Evaluate `input`, returning the formatted output text (same as the REPL's
+/// `Out[n]=` line). Parse errors return "$Failed (parse error)".
+pub fn eval(input: &str) -> String {
+    let c = match CString::new(input) {
+        Ok(c) => c,
+        Err(_) => return "$Failed (embedded NUL in input)".into(),
+    };
+    // SAFETY: `c` outlives the call; the returned pointer is owned by us and
+    // freed inside `take_c_string`.
+    unsafe { take_c_string(mathilda_ffi_eval(c.as_ptr())) }
+}
+
+/// Evaluate `input`, returning a LaTeX rendering of the result (for KaTeX).
+pub fn eval_latex(input: &str) -> String {
+    let c = match CString::new(input) {
+        Ok(c) => c,
+        Err(_) => return String::new(),
+    };
+    // SAFETY: as in `eval`.
+    unsafe { take_c_string(mathilda_ffi_eval_latex(c.as_ptr())) }
+}
+
+/// Kernel version string (e.g. "0.015").
+pub fn version() -> String {
+    // SAFETY: the C side returns a pointer to static storage; we only borrow it.
+    unsafe {
+        let p = mathilda_ffi_version();
+        if p.is_null() {
+            String::new()
+        } else {
+            CStr::from_ptr(p).to_string_lossy().into_owned()
+        }
+    }
+}

--- a/frontend/src-tauri/src/kernel_ffi.rs
+++ b/frontend/src-tauri/src/kernel_ffi.rs
@@ -45,11 +45,21 @@ impl MathildaKernel {
 
     /// Locate the bundled `internal/` module tree (init.m + tables) inside the
     /// app bundle's resources, so the kernel finds its bootstrap on a device
-    /// where there is no source tree and no writable CWD.
+    /// where there is no source tree and no writable CWD. Tauri places declared
+    /// resources under `<resources>/assets/…`, but the exact prefix has varied
+    /// across versions/platforms, so probe the known candidates and return the
+    /// first that actually contains `init.m`.
     fn home_dir(&self) -> Option<String> {
         let res = self.app.path().resource_dir().ok()?;
-        let candidate = res.join("internal");
-        Some(candidate.to_string_lossy().into_owned())
+        for sub in ["assets/internal", "internal", "_up_/src/internal"] {
+            let cand = res.join(sub);
+            if cand.join("init.m").is_file() {
+                return Some(cand.to_string_lossy().into_owned());
+            }
+        }
+        // Fall back to the conventional location even if the probe missed, so
+        // the loader emits a diagnostic path rather than nothing.
+        Some(res.join("assets/internal").to_string_lossy().into_owned())
     }
 
     /// Initialize the kernel on a blocking thread (idempotent). Sets

--- a/frontend/src-tauri/src/kernel_ffi.rs
+++ b/frontend/src-tauri/src/kernel_ffi.rs
@@ -1,0 +1,140 @@
+//! kernel_ffi.rs — in-process Mathilda kernel for mobile targets.
+//!
+//! Drop-in replacement for the sidecar-based `kernel.rs` used on desktop. It
+//! exposes the identical public API (`empty`/`start`/`evaluate`/`ping`/
+//! `restart`/`interrupt`/`is_running`) so `commands.rs` and `lib.rs` compile
+//! unchanged, but runs the kernel via FFI (`crate::ffi`) instead of spawning a
+//! child process — mandatory on iOS/Android where process spawning is blocked.
+//!
+//! The C kernel is single-threaded and non-reentrant, so every evaluation is
+//! serialized behind a mutex and executed on a blocking thread (the eval can be
+//! long-running; we must not block the async runtime's worker).
+
+use crate::ffi;
+use serde_json::{json, Value};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tauri::ipc::Channel;
+use tauri::Manager;
+use tokio::sync::Mutex;
+
+/// Handle stored in Tauri State — owns the in-process kernel lifecycle.
+pub struct MathildaKernel {
+    /// Serializes access to the non-reentrant C kernel.
+    lock: Arc<Mutex<()>>,
+    ready: Arc<AtomicBool>,
+    app: tauri::AppHandle,
+}
+
+impl MathildaKernel {
+    /// Create a handle synchronously; the kernel is initialized in `start()`.
+    pub fn empty(app: tauri::AppHandle) -> Self {
+        Self {
+            lock: Arc::new(Mutex::new(())),
+            ready: Arc::new(AtomicBool::new(false)),
+            app,
+        }
+    }
+
+    /// Convenience: build and start in one step.
+    pub async fn new(app: tauri::AppHandle) -> Result<Self, String> {
+        let k = Self::empty(app);
+        k.start().await?;
+        Ok(k)
+    }
+
+    /// Locate the bundled `internal/` module tree (init.m + tables) inside the
+    /// app bundle's resources, so the kernel finds its bootstrap on a device
+    /// where there is no source tree and no writable CWD.
+    fn home_dir(&self) -> Option<String> {
+        let res = self.app.path().resource_dir().ok()?;
+        let candidate = res.join("internal");
+        Some(candidate.to_string_lossy().into_owned())
+    }
+
+    /// Initialize the kernel on a blocking thread (idempotent). Sets
+    /// MATHILDA_HOME from the bundle resources first so init.m resolves.
+    pub async fn start(&self) -> Result<(), String> {
+        if self.ready.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let home = self.home_dir();
+        let ready = self.ready.clone();
+        let lock = self.lock.clone();
+        tauri::async_runtime::spawn_blocking(move || {
+            // Hold the lock across init so no eval races the symbol table.
+            let _guard = lock.blocking_lock();
+            if let Some(h) = home {
+                ffi::set_home(&h);
+            }
+            ffi::init();
+            ready.store(true, Ordering::Release);
+        })
+        .await
+        .map_err(|e| format!("kernel init join error: {e}"))?;
+        log::info!("Mathilda in-process kernel ready (v{})", ffi::version());
+        Ok(())
+    }
+
+    /// Readiness probe (kept for API parity with the sidecar kernel).
+    pub async fn ping(&self) -> Result<(), String> {
+        if self.ready.load(Ordering::Acquire) {
+            Ok(())
+        } else {
+            Err("kernel not initialized".into())
+        }
+    }
+
+    /// Evaluate `expr` in-process and stream one `expr` (or `error`) message to
+    /// `channel`. The desktop kernel streams many NDJSON lines then a "done";
+    /// here the C API returns a single formatted result, so we emit one message
+    /// and return (the frontend treats the resolved promise as "done").
+    pub async fn evaluate(&self, expr: String, channel: Channel<Value>) -> Result<(), String> {
+        if !self.ready.load(Ordering::Acquire) {
+            // Lazily initialize if evaluate arrives before start() completed.
+            self.start().await?;
+        }
+        let lock = self.lock.clone();
+        let (text, latex) = tauri::async_runtime::spawn_blocking(move || {
+            let _guard = lock.blocking_lock();
+            let text = ffi::eval(&expr);
+            let latex = ffi::eval_latex(&expr);
+            (text, latex)
+        })
+        .await
+        .map_err(|e| format!("eval join error: {e}"))?;
+
+        let msg = if text == "$Failed (parse error)" {
+            json!({ "id": 0, "type": "error", "message": text })
+        } else if latex.is_empty() {
+            json!({ "id": 0, "type": "expr", "payload": text })
+        } else {
+            json!({ "id": 0, "type": "expr", "payload": text, "latex": latex })
+        };
+        channel.send(msg).map_err(|e| format!("channel: {e}"))?;
+        Ok(())
+    }
+
+    /// No separate process to kill; state is process-global. No-op for parity.
+    pub async fn kill(&self) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// The in-process kernel has no resettable session yet (the C symbol table
+    /// persists for the app's lifetime). Report success so "Run All" proceeds;
+    /// a true reset would need a `mathilda_ffi_reset()` entry point.
+    pub async fn restart(&self) -> Result<(), String> {
+        log::warn!("restart requested: in-process kernel keeps global state (no-op)");
+        Ok(())
+    }
+
+    /// Synchronous C evaluations cannot be interrupted from another thread.
+    pub async fn interrupt(&self) -> Result<(), String> {
+        log::warn!("interrupt requested: not supported for in-process kernel (no-op)");
+        Ok(())
+    }
+
+    pub async fn is_running(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,11 +1,29 @@
 mod commands;
+
+// Kernel backend is chosen at compile time:
+//   * desktop  -> `kernel.rs`: spawns the `mathilda` sidecar over stdio.
+//   * mobile   -> `kernel_ffi.rs`: runs the kernel in-process via FFI, because
+//                 iOS/Android sandboxes forbid spawning child processes.
+// Both expose an identical `MathildaKernel` API, so the rest of the app is
+// backend-agnostic.
+#[cfg(not(mobile))]
+mod kernel;
+#[cfg(mobile)]
+mod ffi;
+#[cfg(mobile)]
+#[path = "kernel_ffi.rs"]
 mod kernel;
 
 use commands::{evaluate_cell, interrupt_kernel, load_library, load_notebook, ping_kernel, restart_kernel, save_library, save_notebook, set_window_title};
 use kernel::MathildaKernel;
+#[cfg(desktop)]
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
-use tauri::{Emitter, Manager};
+#[cfg(desktop)]
+use tauri::Emitter;
+use tauri::Manager;
 
+// Native menu bar is a desktop-only concept; iOS/Android have no app menu.
+#[cfg(desktop)]
 fn build_menu(app: &tauri::App) -> tauri::Result<Menu<tauri::Wry>> {
     let file = Submenu::with_items(
         app,
@@ -87,13 +105,16 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .setup(|app| {
-            // Native menu
-            let menu = build_menu(app)?;
-            app.set_menu(menu)?;
-            app.on_menu_event(|app, event| {
-                let id = event.id().as_ref().to_string();
-                let _ = app.emit(&format!("menu:{id}"), ());
-            });
+            // Native menu (desktop only — mobile has no app menu bar).
+            #[cfg(desktop)]
+            {
+                let menu = build_menu(app)?;
+                app.set_menu(menu)?;
+                app.on_menu_event(|app, event| {
+                    let id = event.id().as_ref().to_string();
+                    let _ = app.emit(&format!("menu:{id}"), ());
+                });
+            }
 
             // Kernel — managed synchronously, spawned async
             let kernel = MathildaKernel::empty(app.handle().clone());

--- a/frontend/src-tauri/tauri.ios.conf.json
+++ b/frontend/src-tauri/tauri.ios.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "externalBin": [],
+    "resources": {
+      "../../src/internal": "internal"
+    }
+  }
+}

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ endif
 # `gcc` only, macOS Homebrew ships `gcc-NN`). A plain `=` (not `?=`) is required:
 # Make pre-defines CC=cc as a built-in, which would defeat `?=`.
 CC = gcc
-CFLAGS = -O3 -std=c99 -Wall -Wextra -g -I./src -I./src/list -I./src/linalg -I./src/numbertheory -I./src/poly -I./src/simp -I./src/calculus -I./src/sum -I./src/product -I./src/special_functions -I./src/numerical_calculus -I./src/numerical_roots -I./src/graphics -I./src/graph -I./src/strings -I./src/strings/regex -I/usr/include -I/usr/local/include
+CFLAGS = -O3 -std=c99 -Wall -Wextra -g -I./src -I./src/list -I./src/linalg -I./src/numbertheory -I./src/poly -I./src/simp -I./src/calculus -I./src/sum -I./src/product -I./src/special_functions -I./src/numerical_calculus -I./src/numerical_roots -I./src/graphics -I./src/graph -I./src/strings -I./src/strings/regex -I./src/ffi -I/usr/include -I/usr/local/include
 
 # Readline is available on macOS and Linux but not on Windows (MinGW).
 # Build with USE_READLINE=0 to disable it explicitly (e.g. for cross-builds
@@ -261,6 +261,7 @@ endif
 SRC_DIR = src
 SRC = $(wildcard $(SRC_DIR)/*.c) $(wildcard $(SRC_DIR)/list/*.c) $(wildcard $(SRC_DIR)/linalg/*.c) $(wildcard $(SRC_DIR)/numbertheory/*.c) $(wildcard $(SRC_DIR)/poly/*.c) $(wildcard $(SRC_DIR)/simp/*.c) $(wildcard $(SRC_DIR)/calculus/*.c) $(wildcard $(SRC_DIR)/sum/*.c) $(wildcard $(SRC_DIR)/product/*.c) $(wildcard $(SRC_DIR)/special_functions/*.c) $(wildcard $(SRC_DIR)/numerical_calculus/*.c) $(wildcard $(SRC_DIR)/numerical_roots/*.c) $(wildcard $(SRC_DIR)/graphics/*.c) $(wildcard $(SRC_DIR)/graph/*.c) $(wildcard $(SRC_DIR)/strings/*.c) $(wildcard $(SRC_DIR)/strings/regex/*.c)
 ifneq ($(USE_GRAPHICS), 1)
+SRC += $(wildcard $(SRC_DIR)/ffi/*.c)
 SRC := $(filter-out $(SRC_DIR)/graphics/render.c $(SRC_DIR)/graphics/render3d.c $(SRC_DIR)/graphics/hershey_font.c, $(SRC))
 endif
 OBJ = $(SRC:.c=.o)
@@ -278,6 +279,24 @@ all: $(TARGET)
 
 $(TARGET): $(OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(EXTRA_LIBS)
+
+# ---------------------------------------------------------------------------
+# Static library for embedding the kernel in-process (mobile hosts, FFI tests).
+#
+# iOS/Android sandboxes forbid spawning the `mathilda` sidecar, so the kernel is
+# linked directly into the host app via src/ffi/mathilda_ffi.c. The archive is
+# every kernel object EXCEPT repl.o (which carries main() + readline + the stdio
+# pipe loop — none of which belong in an embedded library). The host links this
+# .a plus -lgmp and provides its own entry point.
+#
+# The default host build works as-is. For a minimal, dependency-light kernel
+# (what the iOS cross-build uses) pass the USE_* toggles off, e.g.:
+#   make libmathilda.a USE_READLINE=0 USE_THREADS=0 USE_ECM=0 USE_MPFR=0 \
+#        USE_LAPACK=0 USE_GRAPHICS=0 USE_FLINT=0 USE_REGEX=0 USE_FFTW=0
+AR ?= ar
+LIB_OBJ = $(filter-out $(SRC_DIR)/repl.o,$(OBJ))
+libmathilda.a: $(LIB_OBJ)
+	$(AR) rcs $@ $(LIB_OBJ)
 
 # -MMD writes a .d file next to each .o listing the (non-system) headers it
 # includes; -MP adds a phony target for each header so deleting a header does

--- a/src/ffi/mathilda_ffi.c
+++ b/src/ffi/mathilda_ffi.c
@@ -1,0 +1,114 @@
+/* mathilda_ffi.c — in-process C API for embedding the Mathilda kernel.
+ *
+ * See mathilda_ffi.h for the contract. This mirrors the parse -> evaluate ->
+ * format pipeline that the sidecar's pipe mode (repl.c: pipe_process_input)
+ * runs, but returns the formatted text to the caller instead of writing NDJSON
+ * to stdout. No readline, no stdio loop, no process — suitable for iOS/Android
+ * where the kernel is linked directly into the host app.
+ */
+/* setenv() is POSIX, hidden by glibc under -std=c99; request it (matches the
+ * pattern in repl.c). Must precede any system header include. */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#include "ffi/mathilda_ffi.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "expr.h"
+#include "parse.h"
+#include "eval.h"
+#include "print.h"
+#include "print_latex.h"
+#include "symtab.h"
+#include "core.h"
+#include "loadmodule.h"
+#include "version.h"
+
+/* One-time init guard. The kernel's global symbol table is process-wide, so a
+ * second symtab_init()/core_init() would leak or corrupt it. */
+static int g_initialized = 0;
+
+/* Optional home directory for the internal module tree, set before init. */
+static char g_home[4096] = {0};
+
+/* Return a heap copy of a C string literal so the caller can always free the
+ * result of an eval with mathilda_ffi_free() regardless of the path taken. */
+static char* ffi_strdup(const char* s) {
+    size_t n = strlen(s) + 1;
+    char* out = (char*)malloc(n);
+    if (out) memcpy(out, s, n);
+    return out;
+}
+
+void mathilda_ffi_set_home(const char* dir) {
+    if (!dir || !*dir) return;
+    /* Prefer the process environment so mathilda_resolve_internal() (which
+     * reads $MATHILDA_HOME) picks it up as its first candidate. setenv is
+     * available on iOS/Android/macOS/Linux; keep a copy for diagnostics. */
+    strncpy(g_home, dir, sizeof(g_home) - 1);
+    g_home[sizeof(g_home) - 1] = '\0';
+    setenv("MATHILDA_HOME", g_home, 1);
+}
+
+void mathilda_ffi_init(void) {
+    if (g_initialized) return;
+    symtab_init();
+    core_init();
+    /* Load the internal bootstrap (init.m). If MATHILDA_HOME was set via
+     * mathilda_ffi_set_home() it is the first search candidate; otherwise the
+     * loader falls back to the exe-relative / installed / CWD ladder. A load
+     * failure leaves a usable-but-reduced kernel (C builtins only). */
+    mathilda_load_module("init.m");
+    g_initialized = 1;
+}
+
+/* Shared front half: ensure init, parse, evaluate. Returns the evaluated
+ * expression (caller frees) or NULL on parse/eval failure, with *parse_failed
+ * distinguishing the two so callers can format an appropriate message. */
+static Expr* ffi_parse_eval(const char* input, int* parse_failed) {
+    *parse_failed = 0;
+    if (!g_initialized) mathilda_ffi_init();
+    if (!input) { *parse_failed = 1; return NULL; }
+
+    Expr* parsed = parse_expression(input);
+    if (!parsed) { *parse_failed = 1; return NULL; }
+
+    Expr* evaluated = evaluate(parsed);
+    expr_free(parsed);
+    return evaluated; /* may be NULL: "evaluated to nothing" */
+}
+
+char* mathilda_ffi_eval(const char* input) {
+    int parse_failed = 0;
+    Expr* evaluated = ffi_parse_eval(input, &parse_failed);
+    if (parse_failed) return ffi_strdup("$Failed (parse error)");
+    if (!evaluated)   return ffi_strdup("");
+
+    char* result = expr_to_string(evaluated);
+    expr_free(evaluated);
+    if (!result) return ffi_strdup("");
+    return result; /* expr_to_string already returns caller-owned malloc'd mem */
+}
+
+char* mathilda_ffi_eval_latex(const char* input) {
+    int parse_failed = 0;
+    Expr* evaluated = ffi_parse_eval(input, &parse_failed);
+    if (parse_failed) return ffi_strdup("\\text{\\$Failed (parse error)}");
+    if (!evaluated)   return ffi_strdup("");
+
+    char* latex = expr_to_latex(evaluated);
+    expr_free(evaluated);
+    if (!latex) return ffi_strdup("");
+    return latex;
+}
+
+void mathilda_ffi_free(char* s) {
+    free(s);
+}
+
+const char* mathilda_ffi_version(void) {
+    return MATHILDA_VERSION_STRING;
+}

--- a/src/ffi/mathilda_ffi.h
+++ b/src/ffi/mathilda_ffi.h
@@ -1,0 +1,59 @@
+/* mathilda_ffi.h — in-process C API for embedding the Mathilda kernel.
+ *
+ * The desktop notebook talks to a spawned `mathilda` sidecar over stdio. On
+ * mobile platforms (iOS / Android) spawning child processes is forbidden by
+ * the OS sandbox, so the kernel must run *in process*. This header exposes a
+ * tiny, stable C ABI that a host (the Rust/Tauri app, a test harness, any
+ * FFI caller) links against directly.
+ *
+ * Threading: the Mathilda evaluator uses global state (the symbol table), so
+ * these functions are NOT reentrant. Callers must serialize access — e.g.
+ * behind a mutex. Initialize once, evaluate on a single logical thread.
+ */
+#ifndef MATHILDA_FFI_H
+#define MATHILDA_FFI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Initialize the kernel: symbol table, builtins, and the internal `init.m`
+ * bootstrap. Idempotent — the second and later calls are no-ops. Safe to call
+ * before the first `mathilda_ffi_eval`.
+ *
+ * The `init.m` tree is located via mathilda_resolve_internal(); on a bundled
+ * app set the MATHILDA_HOME environment variable to the directory containing
+ * the `internal/` tree before calling this (see mathilda_ffi_set_home). */
+void mathilda_ffi_init(void);
+
+/* Point the loader at the bundled `internal/` module tree. Equivalent to
+ * setting the MATHILDA_HOME environment variable, but callable from hosts that
+ * cannot easily set the process environment before init. `dir` is copied.
+ * Call BEFORE mathilda_ffi_init(). No-op if `dir` is NULL/empty. */
+void mathilda_ffi_set_home(const char* dir);
+
+/* Parse, evaluate to a fixed point, and format `input` as Mathilda output
+ * (the same text the REPL prints after `Out[n]= `). Returns a newly allocated,
+ * NUL-terminated UTF-8 string owned by the CALLER — release it with
+ * mathilda_ffi_free(). Never returns NULL: parse failures yield the string
+ * "$Failed (parse error)" and expressions that evaluate to nothing yield "".
+ *
+ * Calls mathilda_ffi_init() implicitly if the kernel is not yet initialized. */
+char* mathilda_ffi_eval(const char* input);
+
+/* Like mathilda_ffi_eval, but formats the result as a LaTeX string suitable
+ * for a math renderer (KaTeX/MathJax). Returns caller-owned memory; free with
+ * mathilda_ffi_free(). Never returns NULL. */
+char* mathilda_ffi_eval_latex(const char* input);
+
+/* Release a string returned by mathilda_ffi_eval / _eval_latex. NULL-safe. */
+void mathilda_ffi_free(char* s);
+
+/* Version string of the linked kernel (static storage; do not free). */
+const char* mathilda_ffi_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MATHILDA_FFI_H */


### PR DESCRIPTION
## Summary
Ships the Mathilda notebook as an **iOS app**. iOS sandboxes forbid spawning child processes, so the desktop app's **sidecar** kernel (spawn the `mathilda` binary, talk NDJSON over stdio) cannot run there. This embeds the CAS kernel **in-process** via a small C FFI and switches the Tauri kernel backend to it on mobile.

```
Desktop:  Svelte UI ─IPC─▶ Rust (kernel.rs)     ─spawn/stdio─▶ mathilda sidecar
iOS:      Svelte UI ─IPC─▶ Rust (kernel_ffi.rs) ────FFI──────▶ libmathilda.a (in-process)
```

## Changes
- **C FFI layer** — `src/ffi/mathilda_ffi.{c,h}`: `init` / `eval` (REPL text) / `eval_latex` (KaTeX) / `set_home` / `free` / `version`. Mirrors the sidecar parse→evaluate→format pipeline; no readline/stdio/process. Not reentrant.
- **`libmathilda.a` target** — `makefile`: archives every kernel object except `repl.o`.
- **Tauri mobile backend** — `src-tauri/src/ffi.rs` (safe bindings) + `src-tauri/src/kernel_ffi.rs` (in-process kernel, same async API as the sidecar). `lib.rs` selects backend via `#[cfg(mobile)]`; native menu bar desktop-gated. `build.rs` links `libmathilda.a` + GMP (+ MPFR) on iOS from `gen/ios-libs/<target>/`.
- **iOS cross-compile** — `frontend/build-ios-lib.sh`: cross-builds GMP, MPFR, and `libmathilda.a` for the Simulator/device. `tauri.ios.conf.json` drops the sidecar and bundles `internal/` as a resource. Tauri CLI + `ios:*` npm scripts. Runbook in `frontend/IOS.md`.

## Testing
- ✅ Desktop `Mathilda` build + JSON sidecar eval unchanged; `cargo check` (desktop) passes.
- ✅ Host FFI smoke test against `libmathilda.a`: arithmetic, bignums, Integrate, D, Factor, Solve, Table, N[Pi,20], Simplify, LaTeX — all correct.
- ✅ **iOS Simulator (Xcode 26.6 / iOS 26.5, arm64)**: `tauri ios build --target aarch64-sim` → **BUILD SUCCEEDED**; app installs, launches, renders the notebook UI.
- ✅ **On-device eval**: the iOS-Simulator-built kernel run inside the booted simulator evaluates `Integrate[x^2,x]`, `D[Sin[x],x]`, `Factor`, `Solve`, `N[Pi,20]`, `Simplify`, `2^100`, etc. correctly, in-process.

## Notes / follow-ups
- Requires full Xcode + a Simulator runtime. Bitcode not used (removed in Xcode 14+).
- A `USE_MPFR=0` minimal build doesn't yet compile (linalg/numerical/poly reference MPFR unconditionally), so iOS ships GMP+MPFR for now.
- `interrupt`/`restart` are in-process no-ops (no cancellation of a synchronous C eval; no symbol-table reset). A `mathilda_ffi_reset()` would enable true "Run All".

## JIRA Ticket
n/a