### PR TITLE
Fix 3D graphics on mobile: well-formed Plotly JSON + FLINT-less build

### DIFF
--- a/docs/spec/changelog/2026-07-20.md
+++ b/docs/spec/changelog/2026-07-20.md
@@ -3,6 +3,35 @@
 
 Feature additions and fixes recorded during this week.
 
+## Fix: FLINT-less build broken by `rat_has_algebraic_atom` (2026-07-22)
+
+`src/rat.c` used `rat_has_algebraic_atom()` from FLINT-independent paths
+(`~740`, `~2012`) while its definition sat inside `#ifdef USE_FLINT`. With FLINT
+absent — the default when the library is not installed, and what
+`build-ios-lib.sh` / `build-android-lib.sh` pass (`USE_FLINT=0`) — the kernel
+failed to link (`undefined symbol: rat_has_algebraic_atom`), breaking `make`,
+the mobile in-process libs, and the CMake test harness. The helper is pure
+`Expr` inspection with no FLINT dependency, so its definition is now
+unconditional (the `#ifdef USE_FLINT` guard moved to the genuinely
+FLINT-dependent cancel routines below it). No behaviour change with FLINT on.
+
+## Fix: `Graphics3D`/`Plot3D` produced malformed Plotly JSON (2026-07-22)
+
+`graphics3d_to_plotly_json` (`src/graphics/graphics_json.c`) emitted **invalid
+JSON** whenever a `Graphics3D` had a color change mid-surface (which `Plot3D`
+does — it colors faces by height). The accumulated `mesh3d` vertex/face arrays
+(`x`/`y`/`z`/`i`/`j`/`k`) were closed with `]` only before the *final* flush;
+the mid-surface `FLUSH_MESH` emitted them **unclosed** (`"x":[…,2.875,"y":[…`),
+so the payload failed to parse. On mobile the in-process kernel's `serde_json`
+parse then rejected it and surfaced an error instead of a plot; the desktop
+sidecar's JSON consumer was affected the same way. Moved the array-closing into
+`FLUSH_MESH` so every flush (mid or final) is well-formed. Verified: the
+`Plot3D[Sin[x] Cos[y], …]` payload is now valid JSON (one self-consistent
+`mesh3d`: 2304 verts / 1152 faces) and the surface renders on the Android
+emulator with the interactive 3D modebar. Added a `Plot3D` example to the demo
+"Function Plots" notebook (`frontend/src/lib/canvas.ts`) as a live 3D showcase
+and regression check.
+
 ## Mobile notebook: graphics rendering, safe-area insets, touch gestures (2026-07-21)
 
 Three fixes to the mobile notebook (iOS/Android; shared `kernel_ffi.rs`

--- a/frontend/src/lib/canvas.ts
+++ b/frontend/src/lib/canvas.ts
@@ -103,6 +103,8 @@ export function loadStartupContent() {
     { cells: [{ type: 'section', source: 'Filled Plots' }] },
     { cells: [{ type: 'code',    source: 'Plot[Sin[x] + Sin[5 x], {x, 0, 4 Pi}, Filling -> Axis]' }] },
     { cells: [{ type: 'code',    source: 'Plot[Exp[-x^2/2]/Sqrt[2 Pi], {x, -4, 4}, Filling -> Axis]' }] },
+    { cells: [{ type: 'section', source: '3D Plots' }] },
+    { cells: [{ type: 'code',    source: 'Plot3D[Sin[x] Cos[y], {x, 0, 3}, {y, 0, 3}]' }] },
   ]);
 
   // Cluster 2 — Algebra & Numbers

--- a/src/graphics/graphics_json.c
+++ b/src/graphics/graphics_json.c
@@ -643,6 +643,11 @@ char* graphics3d_to_plotly_json(const Expr* g) {
         rgba_str(mc, sizeof(mc), mesh_r, mesh_g_val, mesh_b_color, mesh_opacity); \
         if (!first_trace) buf_cat(&data_buf, ","); \
         first_trace = 0; \
+        /* Close the vertex/face arrays HERE so every flush is well-formed — a \
+         * color change mid-surface flushes an in-progress block, not just the \
+         * final one. (The next block is re-primed with "[" below.) */ \
+        buf_cat(&mesh_x, "]"); buf_cat(&mesh_y, "]"); buf_cat(&mesh_z, "]"); \
+        buf_cat(&mesh_i, "]"); buf_cat(&mesh_j, "]"); buf_cat(&mesh_k, "]"); \
         buf_cat(&data_buf, "{\"type\":\"mesh3d\","); \
         buf_cat(&data_buf, "\"x\":"); buf_cat(&data_buf, mesh_x.buf); \
         buf_cat(&data_buf, ",\"y\":"); buf_cat(&data_buf, mesh_y.buf); \
@@ -762,9 +767,7 @@ char* graphics3d_to_plotly_json(const Expr* g) {
         }
     }
 
-    /* Flush any remaining mesh. */
-    buf_cat(&mesh_x, "]"); buf_cat(&mesh_y, "]"); buf_cat(&mesh_z, "]");
-    buf_cat(&mesh_i, "]"); buf_cat(&mesh_j, "]"); buf_cat(&mesh_k, "]");
+    /* Flush any remaining mesh (FLUSH_MESH closes the arrays itself). */
     FLUSH_MESH();
 #undef FLUSH_MESH
 

--- a/src/rat.c
+++ b/src/rat.c
@@ -1404,10 +1404,15 @@ static int pick_best_tower_generator(const Expr* arg, const QATower* t) {
     return best_idx;
 }
 
-#ifdef USE_FLINT
 /* True if `e` contains an algebraic-number atom: I, Sqrt[..], Complex[..], or
  * Power[base, p/q] with a non-integer rational exponent.  Distinguishes an
- * over-an-extension fraction from a plain rational one. */
+ * over-an-extension fraction from a plain rational one.
+ *
+ * Defined unconditionally: it is pure Expr inspection with no FLINT dependency,
+ * and it is called from FLINT-independent paths (lines ~740, ~2012). Keeping it
+ * inside `#ifdef USE_FLINT` left those calls referencing an undefined static in
+ * a USE_FLINT=0 build (the default when FLINT is absent, and what the mobile
+ * cross-builds use), breaking the link. */
 static bool rat_has_algebraic_atom(const Expr* e) {
     if (!e) return false;
     if (e->type == EXPR_SYMBOL) return e->data.symbol.name == SYM_I;
@@ -1428,6 +1433,7 @@ static bool rat_has_algebraic_atom(const Expr* e) {
     return false;
 }
 
+#ifdef USE_FLINT
 /* Cancel a single fraction rigorously over a detected algebraic-extension field
  * (Q(sqrt d), Q(zeta_n), radical tower) using the FLINT engine: g = gcd(num,den)
  * then num/g, den/g by exact division. Returns NULL — deferring to the classical

--- a/tests/test_plot3d.c
+++ b/tests/test_plot3d.c
@@ -9,8 +9,28 @@
 #include "symtab.h"
 #include "core.h"
 #include "test_utils.h"
+#include "graphics_json.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+
+/* Bracket balance of a JSON string, ignoring brackets inside "quoted" strings.
+ * A negative return means a premature close; nonzero at end means unbalanced —
+ * either way the JSON is malformed. Catches the mesh3d "unclosed array" bug. */
+static int json_brackets_balanced(const char* s) {
+    int depth = 0, in_str = 0;
+    for (; *s; s++) {
+        if (in_str) {
+            if (*s == '\\' && s[1]) { s++; continue; }
+            if (*s == '"') in_str = 0;
+            continue;
+        }
+        if (*s == '"') in_str = 1;
+        else if (*s == '[' || *s == '{') depth++;
+        else if (*s == ']' || *s == '}') { if (--depth < 0) return -1; }
+    }
+    return depth;
+}
 
 void test_plot3d_returns_graphics3d_head(void) {
     assert_eval_eq("Head[Plot3D[x + y, {x, -1, 1}, {y, -1, 1}]]", "Graphics3D", 0);
@@ -317,6 +337,31 @@ void test_plot3d_plot_label_stored_in_options(void) {
         "\"My Surface\"", 0);
 }
 
+/* Regression: a Plot3D surface colours its faces and then draws a wireframe,
+ * so a colour change mid-Graphics3D flushes the accumulated mesh3d block. That
+ * mid-flush previously emitted the vertex/face arrays WITHOUT their closing
+ * ']', producing invalid JSON ("x":[...,"y":[...) that failed to parse — no
+ * plot on mobile. The payload must be well-formed (balanced brackets) and
+ * carry a mesh3d trace. */
+void test_plot3d_plotly_json_is_well_formed(void) {
+    struct Expr* g = evaluate(parse_expression(
+        "Plot3D[Sin[x] Cos[y], {x, 0, 3}, {y, 0, 3}]"));
+    if (!g) { printf("FAIL: Plot3D did not evaluate\n"); exit(1); }
+    char* json = graphics3d_to_plotly_json(g);
+    if (!json) { printf("FAIL: graphics3d_to_plotly_json returned NULL\n"); expr_free(g); exit(1); }
+    if (json_brackets_balanced(json) != 0) {
+        printf("FAIL: mesh3d Plotly JSON has unbalanced brackets (malformed)\n");
+        exit(1);
+    }
+    if (!strstr(json, "\"type\":\"mesh3d\"")) {
+        printf("FAIL: no mesh3d trace in Plot3D payload\n");
+        exit(1);
+    }
+    free(json);
+    expr_free(g);
+    printf("test_plot3d_plotly_json_is_well_formed passed\n");
+}
+
 int main(void) {
     setenv("MATHILDA_NO_GRAPHICS_WINDOW", "1", 1);
     symtab_init();
@@ -342,6 +387,7 @@ int main(void) {
     TEST(test_plot3d_region_function_2arg_form);
     TEST(test_plot3d_plot_range_stored_in_options);
     TEST(test_plot3d_plot_label_stored_in_options);
+    TEST(test_plot3d_plotly_json_is_well_formed);
 
     printf("All Plot3D tests passed!\n");
     symtab_clear();


### PR DESCRIPTION
## Summary
`Plot3D` / `Graphics3D` rendered nothing on mobile (an error, not a chart). Root cause was a malformed Plotly payload; a second, pre-existing build break had to be fixed to build the change on a FLINT-less setup.

## Changes
**1. Malformed `mesh3d` JSON** (`src/graphics/graphics_json.c`)
A `Graphics3D` that changes colour mid-surface — which `Plot3D` does (faces coloured by height, then a wireframe) — flushes the accumulated `mesh3d` block at the colour change. That mid-surface `FLUSH_MESH` emitted the vertex/face arrays (`x`/`y`/`z`/`i`/`j`/`k`) **without their closing `]`** (only the *final* flush closed them), producing invalid JSON: `"x":[…,2.875,"y":[…`. On mobile the in-process kernel's `serde_json` parse rejected it and surfaced an error instead of a plot; the desktop sidecar's JSON consumer hit the same thing. Fix: close the arrays **inside** `FLUSH_MESH` so every flush is well-formed.

**2. FLINT-less build break** (`src/rat.c`)
`rat_has_algebraic_atom()` — pure `Expr` inspection, no FLINT dependency — was defined inside `#ifdef USE_FLINT` yet called from FLINT-independent paths, so a `USE_FLINT=0` build (the default without FLINT, and what `build-ios-lib.sh`/`build-android-lib.sh` use) failed to link (`undefined symbol`). This blocked building the fix at all. Moved the guard past the helper so it's always defined; the FLINT-only cancel routines stay guarded. No behaviour change with FLINT on.

**3. Demo + test**
- `frontend/src/lib/canvas.ts`: a `Plot3D[Sin[x] Cos[y], …]` example in the "Function Plots" notebook (live 3D showcase + repro).
- `tests/test_plot3d.c`: regression test asserting the `mesh3d` payload has balanced brackets and a `mesh3d` trace.

## Testing
- `plot3d_tests` (incl. the new `test_plot3d_plotly_json_is_well_formed`) **passes** — the rat.c fix also unblocked the CMake harness, which failed on the same symbol.
- Host: the `Plot3D` payload now parses as valid JSON (one self-consistent `mesh3d`: 2304 verts / 1152 faces).
- **On-device (Android emulator, API 34):** `Plot3D[Sin[x] Cos[y]]` renders the full blue mesh surface with wireframe, labelled axes, and the interactive 3D modebar (rotate/zoom/pan). 2D plots and touch-pan unaffected.

## Follow-ups (pre-existing, not addressed here)
- The 3D wireframe emits one 2-point `scatter3d` trace per mesh edge (~1100 traces for a default `Plot3D`); it renders fine but could be coalesced into fewer traces for performance.
- A benign CSP warning blocks one Plotly `data:` modebar image; the plot/modebar still render.

## JIRA Ticket
n/a