### PR TITLE
Add Riffle, Gather, and Subdivide list built-ins

### DIFF
--- a/docs/spec/builtins/data-structures.md
+++ b/docs/spec/builtins/data-structures.md
@@ -16,7 +16,7 @@ grouping and lookup.
 | **Keys & values** | `Keys`, `Values`, `KeyMap`, `KeyValueMap` |
 | **Presence** | `KeyExistsQ`, `KeyMemberQ`, `KeyFreeQ`, `MemberQ` |
 | **Transform** | `Map`, `Select`, `KeySelect`, `KeyTake`, `KeyDrop`, `DeleteMissing` |
-| **Aggregate** | `Total`, `Min`, `Max`, `Mean`, `Counts`, `CountsBy`, `GroupBy` (+reducer, `key->val`), `GatherBy`, `Merge`, `PositionIndex` |
+| **Aggregate** | `Total`, `Min`, `Max`, `Mean`, `Counts`, `CountsBy`, `GroupBy` (+reducer, `key->val`), `Gather`, `GatherBy`, `Merge`, `PositionIndex` |
 | **Order / rank** | `Sort`, `SortBy` (multi-key), `ReverseSort`, `ReverseSortBy`, `KeySort`, `KeySortBy`, `MaximalBy`, `MinimalBy`, `TakeLargest`(`By`), `TakeSmallest`(`By`), `Reverse` |
 | **Iterate / reduce** | `Table`/`Do`/`Sum`/`Product` (`{v, assoc}`), `Fold`, `FoldList`, `Scan`, `Cases`, `Count`, `DeleteCases`, `Position`, `SelectFirst`, `FirstCase`, `AllTrue`, `AnyTrue`, `NoneTrue` |
 | **Structural** | `First`, `Last`, `Rest`, `Most`, `Take`, `Drop`, `Length` |
@@ -227,6 +227,35 @@ Out[4]= <|False -> <|"a" -> 1, "c" -> 3|>, True -> <|"b" -> 2, "d" -> 4|>|>
 In[5]:= GroupBy[<|"a" -> 1, "b" -> 2, "c" -> 3, "d" -> 4|>, EvenQ, Total]
 Out[5]= <|False -> 4, True -> 6|>
 ```
+
+## Gather
+Gathers identical elements into sublists, in order of each element's first
+occurrence; within a sublist elements keep their input order. Equal elements are
+collected from anywhere in the list, not only from adjacent runs — this is the
+difference from [`Split`](structural-manipulation.md#split). Equivalent to
+`GatherBy[list, Identity]`, and implemented on the same grouping engine
+(hash-indexed, O(n)) with the identity key applied directly rather than as `n`
+`Identity[x]` applications.
+
+```mathematica
+In[1]:= Gather[{1, 7, 3, 7, 2, 3, 9}]
+Out[1]= {{1}, {7, 7}, {3, 3}, {2}, {9}}
+
+In[2]:= Gather[{a, b, a}]
+Out[2]= {{a, a}, {b}}
+
+In[3]:= Gather[{}]
+Out[3]= {}
+```
+
+Notes:
+- Group order is first-occurrence order, not sorted order.
+- Elements are grouped by structural identity (`expr_eq`), so `1` and `1.0` are
+  distinct: `Gather[{1, 1.0}]` gives `{{1}, {1.0}}`.
+- Over an association, the entries are gathered by value into sub-associations
+  (keys preserved), matching `GatherBy[assoc, Identity]`.
+- Anything other than a list or association, and any arity other than 1, is
+  returned unevaluated.
 
 ## GatherBy
 Gathers the elements with equal `f[element]` into sublists, in first-appearance

--- a/docs/spec/builtins/lists-and-iteration.md
+++ b/docs/spec/builtins/lists-and-iteration.md
@@ -198,3 +198,48 @@ In[5]:= Rescale[1 + 2 I, {0, 1 + I}]
 Out[5]= 3/2 + 1/2 I
 ```
 
+
+## Riffle
+Interleaves separators into the gaps between successive elements of `list`.
+- `Riffle[list, x]`: puts `x` in every gap.
+- `Riffle[list, {x1, x2, ...}]`: uses the `xi` cyclically, filling the gaps left
+  to right.
+
+**Features**:
+- `Protected`.
+- Separators go only **between** consecutive elements — never before the first
+  and never after the last. A list of $n$ elements has exactly $n - 1$ gaps, so
+  the result has $2n - 1$ elements.
+- A list of length 0 or 1 has no gaps, so it comes back **unchanged** whatever
+  the separator is.
+- With a `List` separator of length $k$, gap $i$ (1-based) receives
+  `x[((i - 1) mod k) + 1]`. Separators beyond the last gap are simply unused, so
+  `Riffle[{a, b, c}, {x, y, z}]` never places `z`.
+- An **empty** separator list supplies nothing, so the list passes through
+  unchanged.
+- Only a `List` second argument cycles. Any other head is a single separator, so
+  `Riffle[{a, b, c}, f[x, y]]` puts the whole `f[x, y]` in each gap.
+- The object `list` need not have head `List`; its head is preserved on the
+  result.
+- Not yet handled: packed arrays (`NDArray`) are left unevaluated.
+
+```mathematica
+In[1]:= Riffle[{1, 2, 3}, 0]
+Out[1]= {1, 0, 2, 0, 3}
+
+In[2]:= Riffle[{a, b, c, d}, {x, y}]
+Out[2]= {a, x, b, y, c, x, d}
+
+In[3]:= Riffle[{a, b, c}, {x, y, z}]
+Out[3]= {a, x, b, y, c}
+
+In[4]:= Riffle[{a}, {x, y}]
+Out[4]= {a}
+
+In[5]:= Riffle[{a, b}, {}]
+Out[5]= {a, b}
+
+In[6]:= Riffle[f[a, b], x]
+Out[6]= f[a, x, b]
+```
+

--- a/docs/spec/builtins/lists-and-iteration.md
+++ b/docs/spec/builtins/lists-and-iteration.md
@@ -122,6 +122,50 @@ Generates a list of values.
 - `Range[imax]`
 - `Range[imin, imax, di]`
 
+## Subdivide
+Generates equally spaced points spanning an interval, **including both
+endpoints**. Attributes: `Protected`.
+- `Subdivide[n]`: the `n + 1` points `{0, 1/n, 2/n, ..., 1}` spanning 0 to 1.
+- `Subdivide[max, n]`: `n + 1` points spanning 0 to `max`.
+- `Subdivide[min, max, n]`: `n + 1` points spanning `min` to `max`; point `i`
+  (0-based) is `min + i (max - min)/n`.
+
+Every form returns `n + 1` points, because `n` counts the *parts* the interval
+is cut into, not the points produced. Contrast `Range`, which takes a step size
+and need not land on its upper bound.
+
+**Features**:
+- Results are **exact** for exact input: rationals come back in lowest terms,
+  and a point landing on a whole number prints as an integer, so
+  `Subdivide[10, 4]` gives `{0, 5/2, 5, 15/2, 10}`.
+- Both **endpoints are exact**. They are copied from the input rather than
+  computed, and each interior point is derived directly from its own index
+  rather than by accumulating a step, so no rounding can drift.
+- **Descending intervals** (`min > max`) are allowed: the formula is applied
+  unchanged, giving a negative step. A degenerate interval (`min == max`) has
+  step 0 and repeats the endpoint.
+- Bigint, rational, real, and purely symbolic endpoints all work; arithmetic
+  outside the machine-integer fast path is deferred to the core evaluator. Real
+  endpoints give machine reals, as elsewhere in the system.
+- `n` must be a **positive integer**. Zero, negative, rational, real, and
+  symbolic `n` leave the expression unevaluated, as does an `n` large enough
+  that the result list would be unbuildable.
+
+```
+In[1]:= Subdivide[4]
+Out[1]= {0, 1/4, 1/2, 3/4, 1}
+In[2]:= Subdivide[10, 4]
+Out[2]= {0, 5/2, 5, 15/2, 10}
+In[3]:= Subdivide[2, 8, 3]
+Out[3]= {2, 4, 6, 8}
+In[4]:= Subdivide[3, 1, 4]
+Out[4]= {3, 5/2, 2, 3/2, 1}
+In[5]:= Subdivide[a, b, 2]
+Out[5]= {a, a + 1/2 (-a + b), b}
+In[6]:= Subdivide[0]
+Out[6]= Subdivide[0]
+```
+
 ## Array
 Generates an array by applying a function to indices.
 - `Array[f, n]`

--- a/docs/spec/builtins/structural-manipulation.md
+++ b/docs/spec/builtins/structural-manipulation.md
@@ -354,6 +354,9 @@ Splits a list into sublists of identical adjacent elements.
 - `Protected`.
 - Uses `SameQ` as the default test.
 - Result has the same head as the input.
+- Only *adjacent* elements are grouped. To collect equal elements from anywhere
+  in the list, use [`Gather`](data-structures.md#gather):
+  `Split[{a, b, a}]` gives `{{a}, {b}, {a}}` where `Gather` gives `{{a, a}, {b}}`.
 
 ```mathematica
 In[1]:= Split[{a, a, a, b, b, a, a, c}]

--- a/docs/spec/changelog/2026-07-27.md
+++ b/docs/spec/changelog/2026-07-27.md
@@ -578,6 +578,42 @@ The three `Overlaps` policies previously existed only as `static` helpers inside
   `stringcount_tests`, `stringfns_tests`, `stringposition_tests`,
   `strings_tests` and `regex_tests`; `make check-c99` clean.
 
+## Riffle list built-in (2026-07-27)
+
+New `Riffle[list, x]` / `Riffle[list, {x1, x2, ...}]` in
+`src/list/riffle.{c,h}`, registered in `src/list/list_init.c` with
+`Protected` and a docstring. Interleaves separators into the gaps between
+successive elements: a non-list second argument goes in every gap, while a
+`List` second argument is consumed cyclically left to right, so
+`Riffle[{a,b,c,d}, {x,y}]` gives `{a, x, b, y, c, x, d}`. Only a `List`
+separator cycles — any other head (e.g. `f[x, y]`) is one separator.
+
+Separators never precede the first element or follow the last, so `n` elements
+have exactly `n - 1` gaps and the result has `2n - 1` slots. Three degenerate
+cases fall out of that invariant and are all covered by tests:
+
+- `n <= 1` — no gaps, so the input passes through unchanged whatever the
+  separator is. Checked *before* the `2n - 1` output sizing, since `n == 0`
+  would otherwise underflow `size_t` to `SIZE_MAX`.
+- An empty separator list — nothing to interleave, same pass-through; this also
+  keeps the cycling index from dividing by zero.
+- Separators in excess of the gap count are never indexed, so
+  `Riffle[{a,b,c}, {x,y,z}]` leaves `z` unused.
+
+The head of the first argument is preserved rather than forced to `List`
+(`Riffle[f[a,b], x]` gives `f[a, x, b]`), matching the convention in
+`reverse.c` and `subsets.c`; it is also what makes `Riffle[{}, 0]` give `{}`
+with no special case.
+
+One pass, `O(n)` copies, and a single exactly-sized allocation — the output
+length is known up front from `n`, so no growable buffer is used. The builtin
+only reads its argument and returns a wholly fresh tree, so the evaluator's
+ownership of the input expression is untouched.
+
+`tests/test_list.c:test_riffle` covers the 15-row acceptance table from
+md-czh.1. Packed arrays (`EXPR_NDARRAY`) are a distinct representation from
+`List` and are left unevaluated for now — tracked as md-2aa.
+
 ## Auto-compilation of Plot / Plot3D / Table / NIntegrate / FindRoot (2026-07-27)
 
 The numeric builtins now transparently use the `Compile[]` bytecode engine as a

--- a/docs/spec/changelog/2026-07-27.md
+++ b/docs/spec/changelog/2026-07-27.md
@@ -614,6 +614,49 @@ ownership of the input expression is untouched.
 md-czh.1. Packed arrays (`EXPR_NDARRAY`) are a distinct representation from
 `List` and are left unevaluated for now — tracked as md-2aa.
 
+## New builtin: `Gather` (2026-07-27)
+
+`Gather[list]` collects structurally identical elements of a list into
+sublists, in order of each element's first occurrence, with input order
+preserved inside each sublist:
+
+```mathematica
+In[1]:= Gather[{1, 7, 3, 7, 2, 3, 9}]
+Out[1]= {{1}, {7, 7}, {3, 3}, {2}, {9}}
+
+In[2]:= Gather[{a, b, a}]
+Out[2]= {{a, a}, {b}}
+```
+
+Unlike `Split`, equal elements are collected from anywhere in the list rather
+than only from adjacent runs, so the two non-adjacent `a`s above share a group.
+`Gather[list]` is exactly `GatherBy[list, Identity]`.
+
+Implementation. Rather than duplicate the grouping logic, the hash-indexed loop
+inside `builtin_gatherby` was hoisted into a shared engine
+`assoc_gather_core(list, f)` (`src/assoc.c`, declared in `src/assoc.h`); the
+`KeyIndex` helpers it needs are static to that translation unit, so the core
+lives there. Passing `f == NULL` selects the identity key — the element is its
+own group key, taken by `expr_copy` with no expression application built or
+evaluated. That keeps `Gather` at a true O(n) with none of the `n` `Identity[x]`
+evaluations that spelling it as `GatherBy[list, Identity]` would incur, and
+makes the two agree by construction rather than by coincidence.
+`builtin_gatherby` is now a two-line delegation; its behaviour, including the
+association path, is unchanged.
+
+New files `src/list/gather.{c,h}` (`builtin_gather`), registered in
+`src/list/list_init.c` with `Protected` and a docstring, included from
+`src/list/list.h`. Association input is inherited from the shared core:
+`Gather[assoc]` gathers the entries by value into sub-associations with keys
+preserved, matching `GatherBy[assoc, Identity]`. Non-list, non-association
+arguments and any arity other than 1 return unevaluated.
+
+Tests: `test_gather` in `tests/test_list.c` covers the grouping table above
+(including `{}`, singletons, all-equal, all-distinct, and non-adjacent repeats),
+asserts `Gather[l]` and `GatherBy[l, Identity]` print identically on every case,
+and checks the unevaluated fallbacks. `tests/CMakeLists.txt` gains
+`../src/list/gather.c`.
+
 ## Auto-compilation of Plot / Plot3D / Table / NIntegrate / FindRoot (2026-07-27)
 
 The numeric builtins now transparently use the `Compile[]` bytecode engine as a

--- a/docs/spec/changelog/2026-07-27.md
+++ b/docs/spec/changelog/2026-07-27.md
@@ -657,6 +657,58 @@ asserts `Gather[l]` and `GatherBy[l, Identity]` print identically on every case,
 and checks the unevaluated fallbacks. `tests/CMakeLists.txt` gains
 `../src/list/gather.c`.
 
+## New list builtin: Subdivide (2026-07-27)
+
+`Subdivide` generates equally spaced points spanning an interval, including
+both endpoints — the complement to `Range`, which takes a step size and need
+not land on its upper bound. Three forms, each returning `n + 1` points
+(`n` counts the *parts* the interval is cut into):
+
+- `Subdivide[n]` — `{0, 1/n, 2/n, ..., 1}`, spanning 0 to 1.
+- `Subdivide[max, n]` — spanning 0 to `max`.
+- `Subdivide[min, max, n]` — spanning `min` to `max`; point `i` is
+  `min + i (max - min)/n`.
+
+New module `src/list/subdivide.{c,h}` (`builtin_subdivide`), registered in
+`src/list/list_init.c` with `Protected` and a docstring, exported via
+`src/list/list.h`.
+
+**Exactness.** Two independent guarantees. The endpoints are *copied, never
+computed*, so no arithmetic can touch them; and each interior point is derived
+directly from its index as the single fraction `(min n + i (max - min))/n`
+rather than as `previous + step`, so there is no accumulator for error to
+collect in. That fraction is reduced once by `make_rational()`, which returns a
+plain `Integer` when the reduced denominator is 1 — hence whole-number points
+printing as integers alongside rationals in one list:
+`Subdivide[10, 4] → {0, 5/2, 5, 15/2, 10}`.
+
+**Descending intervals** are supported with no special case: the formula is
+applied verbatim, so `max < min` simply yields a negative step —
+`Subdivide[3, 1, 4] → {3, 5/2, 2, 3/2, 1}`. Nothing branches on the sign of the
+step, compares the endpoints, sorts, or takes an absolute value. A degenerate
+interval has step 0 and repeats the endpoint: `Subdivide[5, 5, 2] → {5, 5, 5}`.
+
+**Two evaluation paths.** A machine-integer fast path handles endpoints with
+`|value| <= 2^31` under the `n <= 10^6` cap, where int64 overflow is excluded by
+precondition rather than by per-operation checks. Everything else — bigint,
+rational, real, or symbolic endpoints — defers arithmetic to the core evaluator
+by building `Plus[min, Times[i, max - min, Power[n, -1]]]`, the strategy
+`src/list/rescale.c` already uses. So `Subdivide[10^20, 4]` stays exact in
+bigints and `Subdivide[a, b, 2]` returns `{a, a + 1/2 (-a + b), b}` with exact
+symbolic endpoints. For the two-argument form the implied lower endpoint takes
+on the exactness of the supplied one, so an inexact interval carries no lone
+exact `0`: `Subdivide[1.0, 4] → {0., 0.25, 0.5, 0.75, 1.}`.
+
+`n` must be a positive integer; zero, negative, rational, real, symbolic, and
+oversized `n` all leave the expression unevaluated, as does an argument count
+outside 1–3.
+
+Tests: `test_subdivide()` in `tests/test_list.c` — 15 rows covering all three
+forms, lowest-terms reduction, mixed integer/rational output, the descending
+and degenerate intervals, and the unevaluated cases. Clean under
+`-std=c99 -Wall -Wextra`, clean under AddressSanitizer, and `leaks`-clean over
+300 iterations of both the fast and general paths.
+
 ## Auto-compilation of Plot / Plot3D / Table / NIntegrate / FindRoot (2026-07-27)
 
 The numeric builtins now transparently use the `Compile[]` bytecode engine as a

--- a/src/assoc.c
+++ b/src/assoc.c
@@ -696,14 +696,18 @@ Expr* builtin_groupby(Expr* res) {
 }
 
 /* ======================================================================
- * GatherBy[list, f] — {group1, group2, ...}: gather elements with equal f[x]
- * into sublists, in first-appearance order (like GroupBy but returning the
- * groups as a plain list of lists). Hash-indexed, O(n) plus the cost of f.
+ * GatherBy[list, f] / Gather[list] — {group1, group2, ...}: gather elements
+ * with equal f[x] into sublists, in first-appearance order (like GroupBy but
+ * returning the groups as a plain list of lists). Hash-indexed, O(n) plus the
+ * cost of f.
+ *
+ * assoc_gather_core is the single grouping engine behind both builtins. A NULL
+ * `f` means "group by the element itself" — the identity key function — which
+ * is exactly what Gather[list] needs; taking that path as a NULL check rather
+ * than as f = Identity avoids n redundant Identity[x] evaluations and makes
+ * Gather[l] === GatherBy[l, Identity] structural rather than coincidental.
  * ====================================================================== */
-Expr* builtin_gatherby(Expr* res) {
-    if (res->data.function.arg_count != 2) return NULL;
-    Expr* list = res->data.function.args[0];
-    Expr* f    = res->data.function.args[1];
+Expr* assoc_gather_core(Expr* list, Expr* f) {
     /* GatherBy[assoc, f] gathers the entries by f[value] into sub-associations
      * (keys preserved), returned as a list in first-appearance order -- like
      * GroupBy[assoc, f] but without the outer group keys. */
@@ -713,7 +717,7 @@ Expr* builtin_gatherby(Expr* res) {
 
     KeyIndex ki;
     if (!ki_init(&ki, n)) return NULL;
-    Expr**  keys   = malloc(sizeof(Expr*)  * (n ? n : 1)); /* owned f-values */
+    Expr**  keys   = malloc(sizeof(Expr*)  * (n ? n : 1)); /* owned group keys */
     Expr*** groups = malloc(sizeof(Expr**) * (n ? n : 1)); /* owned element copies */
     size_t* gcap   = malloc(sizeof(size_t) * (n ? n : 1));
     size_t* gcnt   = malloc(sizeof(size_t) * (n ? n : 1));
@@ -722,10 +726,17 @@ Expr* builtin_gatherby(Expr* res) {
     for (size_t i = 0; i < n; i++) {
         Expr* x = list->data.function.args[i];
         Expr* key_input = assoc_in ? rule_val(x) : x;   /* group by f[value] */
-        Expr* fx_args[1] = { expr_copy(key_input) };
-        Expr* fx = expr_new_function(expr_copy(f), fx_args, 1);
-        Expr* key = evaluate(fx);
-        expr_free(fx);
+        /* Identity key (f == NULL): the element is its own group key, so no
+         * function application is built or evaluated -- just a copy. */
+        Expr* key;
+        if (f) {
+            Expr* fx_args[1] = { expr_copy(key_input) };
+            Expr* fx = expr_new_function(expr_copy(f), fx_args, 1);
+            key = evaluate(fx);
+            expr_free(fx);
+        } else {
+            key = expr_copy(key_input);
+        }
         size_t slot, idx = ki_lookup(&ki, keys, key, &slot);
         if (idx == SIZE_MAX) {
             keys[ng] = key; gcap[ng] = 4; gcnt[ng] = 0;
@@ -743,12 +754,18 @@ Expr* builtin_gatherby(Expr* res) {
         outer[i] = assoc_in
             ? expr_new_function(expr_new_symbol(SYM_Association), groups[i], gcnt[i])
             : make_list(groups[i], gcnt[i]);
-        expr_free(keys[i]);   /* GatherBy discards the keys */
+        expr_free(keys[i]);   /* the groups are returned bare; keys are dropped */
         free(groups[i]);
     }
     Expr* result = make_list(outer, ng);
     free(outer); free(keys); free(groups); free(gcap); free(gcnt); ki_free(&ki);
     return result;
+}
+
+Expr* builtin_gatherby(Expr* res) {
+    if (res->data.function.arg_count != 2) return NULL;
+    return assoc_gather_core(res->data.function.args[0],
+                             res->data.function.args[1]);
 }
 
 /* ======================================================================

--- a/src/assoc.h
+++ b/src/assoc.h
@@ -86,6 +86,16 @@ Expr* assoc_delete_duplicate_values(const Expr* assoc);
  * sublists (first-appearance order). Caller owns the result. */
 Expr* builtin_gatherby(Expr* res);
 
+/* Shared grouping engine behind GatherBy[list, f] and Gather[list]: groups the
+ * elements of `list` (a List, or an Association whose entries group by value)
+ * into a list of sublists in first-appearance order, hash-indexed in O(n).
+ *
+ * `f` is the key function; passing NULL selects the identity key — the element
+ * itself is the group key and no function application is evaluated, which is
+ * the Gather[list] path. Returns NULL if `list` is neither a List nor an
+ * Association. Caller owns the result. */
+Expr* assoc_gather_core(Expr* list, Expr* f);
+
 /* KeyUnion[{assoc1, ...}]: pad every association to the union of all keys,
  * filling absent values with Missing["KeyAbsent", key]. Caller owns result. */
 Expr* builtin_keyunion(Expr* res);

--- a/src/list/gather.c
+++ b/src/list/gather.c
@@ -1,0 +1,28 @@
+/* ---------------------------------------------------------------------------
+ * gather.c — Gather[list], the identity case of GatherBy.
+ *
+ * Gather partitions a list into sublists of structurally identical elements:
+ * every element appears in exactly one sublist, two elements share a sublist
+ * iff expr_eq holds between them, sublists appear in order of the first
+ * occurrence of their element, and within a sublist elements keep their input
+ * order. Unlike Split, grouping is not restricted to adjacent runs:
+ *
+ *     Gather[{1, 7, 3, 7, 2, 3, 9}]  ->  {{1}, {7, 7}, {3, 3}, {2}, {9}}
+ *     Gather[{a, b, a}]              ->  {{a, a}, {b}}
+ *
+ * The grouping itself is not reimplemented here. assoc_gather_core (assoc.c)
+ * is the same hash-indexed O(n) engine that backs GatherBy; passing a NULL key
+ * function selects the identity key, so Gather[l] and GatherBy[l, Identity]
+ * agree by construction, and the identity path skips the n Identity[x]
+ * applications that spelling it as GatherBy[l, Identity] would evaluate.
+ * -------------------------------------------------------------------------- */
+
+#include "list_common.h"
+#include "gather.h"
+#include "assoc.h"
+
+Expr* builtin_gather(Expr* res) {
+    if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 1) return NULL;
+    /* NULL key function == identity: the element is its own group key. */
+    return assoc_gather_core(res->data.function.args[0], NULL);
+}

--- a/src/list/gather.h
+++ b/src/list/gather.h
@@ -1,0 +1,11 @@
+#ifndef GATHER_H
+#define GATHER_H
+
+#include "expr.h"
+
+/* Gather[list]: collect structurally identical elements of list into sublists,
+ * in order of each element's first occurrence. Equivalent to
+ * GatherBy[list, Identity]. */
+Expr* builtin_gather(Expr* res);
+
+#endif /* GATHER_H */

--- a/src/list/list.h
+++ b/src/list/list.h
@@ -35,6 +35,7 @@
 #include "minmax.h"
 #include "join.h"
 #include "subsets.h"
+#include "riffle.h"
 
 void list_init(void);
 

--- a/src/list/list.h
+++ b/src/list/list.h
@@ -24,6 +24,7 @@
 #include "setops.h"
 #include "split.h"
 #include "splitby.h"
+#include "gather.h"
 #include "rescale.h"
 #include "pad.h"
 #include "total.h"

--- a/src/list/list.h
+++ b/src/list/list.h
@@ -37,6 +37,7 @@
 #include "join.h"
 #include "subsets.h"
 #include "riffle.h"
+#include "subdivide.h"
 
 void list_init(void);
 

--- a/src/list/list_init.c
+++ b/src/list/list_init.c
@@ -117,6 +117,19 @@ void list_init(void) {
         "\tn - 1 gaps left to right; separators beyond the last gap are\n"
         "\tunused. The head of list is preserved.");
 
+    symtab_add_builtin("Subdivide", builtin_subdivide);
+    symtab_get_def("Subdivide")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("Subdivide",
+        "Subdivide[n]\n\tGives the list {0, 1/n, 2/n, ..., 1} of n + 1 equally\n"
+        "\tspaced points spanning 0 to 1, including both endpoints.\n"
+        "Subdivide[max, n]\n\tGives n + 1 equally spaced points spanning 0 to\n"
+        "\tmax.\n"
+        "Subdivide[min, max, n]\n\tGives n + 1 equally spaced points spanning\n"
+        "\tmin to max; point i is min + i (max - min)/n. Descending intervals\n"
+        "\t(min > max) are allowed and give a negative step. Exact input gives\n"
+        "\texact results in lowest terms, with both endpoints exact. Returns\n"
+        "\tunevaluated unless n is a positive integer.");
+
     symtab_get_def("Table")->attributes |= ATTR_HOLDALL | ATTR_PROTECTED;
     symtab_get_def("Range")->attributes |= ATTR_PROTECTED;
     symtab_get_def("Array")->attributes |= ATTR_PROTECTED;

--- a/src/list/list_init.c
+++ b/src/list/list_init.c
@@ -64,6 +64,16 @@ void list_init(void) {
         "SplitBy[list, {f1, f2, ...}]\n"
         "\tsplits by f1, then splits each resulting run by f2, and so on,\n"
         "\tnesting one level deeper per function.");
+    symtab_add_builtin("Gather", builtin_gather);
+    symtab_get_def("Gather")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("Gather",
+        "Gather[list]\n"
+        "\tGathers identical elements of list into sublists, giving\n"
+        "\t{{group1}, {group2}, ...}. Sublists appear in order of the first\n"
+        "\toccurrence of their element, and elements keep their input order\n"
+        "\twithin a sublist. Equal elements are collected from anywhere in the\n"
+        "\tlist, not only from adjacent runs (unlike Split).\n"
+        "\tGather[list] is equivalent to GatherBy[list, Identity].");
     symtab_add_builtin("Total", builtin_total);
     symtab_add_builtin("Accumulate", builtin_accumulate);
     symtab_add_builtin("Differences", builtin_differences);

--- a/src/list/list_init.c
+++ b/src/list/list_init.c
@@ -96,6 +96,16 @@ void list_init(void) {
         "\tinclusive range nmin to nmax; a third element gives a length step.\n"
         "Subsets[list, spec, s]\n\tGives only the first s subsets spec would\n"
         "\tproduce, generated lazily.");
+    symtab_add_builtin("Riffle", builtin_riffle);
+    symtab_get_def("Riffle")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("Riffle",
+        "Riffle[list, x]\n\tInterleaves x into the gaps between successive\n"
+        "\telements of list, giving {e1, x, e2, x, ..., x, en}. Nothing is\n"
+        "\tplaced before the first or after the last element, so a list of\n"
+        "\tlength 0 or 1 comes back unchanged.\n"
+        "Riffle[list, {x1, x2, ...}]\n\tUses the xi cyclically, filling the\n"
+        "\tn - 1 gaps left to right; separators beyond the last gap are\n"
+        "\tunused. The head of list is preserved.");
 
     symtab_get_def("Table")->attributes |= ATTR_HOLDALL | ATTR_PROTECTED;
     symtab_get_def("Range")->attributes |= ATTR_PROTECTED;

--- a/src/list/riffle.c
+++ b/src/list/riffle.c
@@ -1,0 +1,87 @@
+/* Riffle — interleave separators into the gaps of a list.
+ *
+ * Mathematica semantics:
+ *
+ *   Riffle[list, x]                 x is placed in every gap:
+ *                                   Riffle[{1,2,3}, 0] -> {1, 0, 2, 0, 3}
+ *   Riffle[list, {x1, ..., xk}]     the xi are consumed in order and cycle
+ *                                   back to x1 after xk, filling the gaps
+ *                                   left to right:
+ *                                   Riffle[{a,b,c,d}, {x,y}] ->
+ *                                     {a, x, b, y, c, x, d}
+ *
+ * THE GAP INVARIANT
+ *
+ * Separators go only BETWEEN consecutive elements — never before the first and
+ * never after the last. A list of n elements therefore has exactly n - 1 gaps,
+ * and the output has 2n - 1 slots. Two consequences drive the code below:
+ *
+ *   - n <= 1 means there are no gaps at all, so the result is the input
+ *     unchanged whatever the separator is. This case is checked BEFORE the
+ *     2n - 1 output sizing, because with n == 0 that expression underflows
+ *     size_t to SIZE_MAX and the allocation would be nonsense.
+ *   - separators past the last gap are never indexed, so
+ *     Riffle[{a,b,c}, {x,y,z}] -> {a, x, b, y, c} simply never reaches z.
+ *
+ * An empty separator list has nothing to interleave, so it also passes the
+ * list through unchanged; that check doubles as the guard that keeps the
+ * cycling index from dividing by zero.
+ *
+ * The head of the first argument is preserved rather than forced to List, so
+ * Riffle[f[a,b], x] gives f[a, x, b]. That is also what makes Riffle[{}, 0]
+ * come back as {} with no special case.
+ *
+ * PERFORMANCE
+ *
+ * One pass, O(n) element copies, and a single exactly-sized allocation — the
+ * output length is known up front from n, so no growable buffer is needed.
+ *
+ * NOT HANDLED: packed arrays (EXPR_NDARRAY) are a distinct representation from
+ * List and are left unevaluated here; see md-2aa. */
+
+#include "list_common.h"
+#include "riffle.h"
+
+Expr* builtin_riffle(Expr* res) {
+    if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 2) return NULL;
+
+    Expr* list = res->data.function.args[0];
+    Expr* sep = res->data.function.args[1];
+
+    /* Anything without arguments to interleave — an atom, or a packed array
+     * (md-2aa) — stays unevaluated. */
+    if (list->type != EXPR_FUNCTION) return NULL;
+
+    size_t n = list->data.function.arg_count;
+
+    /* Normalise the separator to a borrowed vector: a List cycles through its
+     * elements, any other expression is one separator used in every gap. */
+    Expr** seps;
+    size_t k;
+    if (is_listq(sep)) {
+        seps = sep->data.function.args;
+        k = sep->data.function.arg_count;
+    } else {
+        seps = &sep;
+        k = 1;
+    }
+
+    /* No gaps (n <= 1), or nothing to put in them (k == 0): copy through.
+     * Must precede the 2n - 1 sizing below — see the header comment. */
+    if (n <= 1 || k == 0) return expr_copy(list);
+
+    size_t out_count = 2 * n - 1;
+    Expr** out = malloc(out_count * sizeof(Expr*));
+    if (!out) return NULL;
+
+    for (size_t i = 0; i < n; i++) {
+        out[2 * i] = expr_copy(list->data.function.args[i]);
+        /* The gap following element i is gap i + 1 in 1-based terms, so it
+         * takes separator index i mod k. */
+        if (i + 1 < n) out[2 * i + 1] = expr_copy(seps[i % k]);
+    }
+
+    Expr* result = expr_new_function(expr_copy(list->data.function.head), out, out_count);
+    free(out);
+    return result;
+}

--- a/src/list/riffle.h
+++ b/src/list/riffle.h
@@ -1,0 +1,16 @@
+#ifndef RIFFLE_H
+#define RIFFLE_H
+
+#include "expr.h"
+
+/* Riffle[list, x] / Riffle[list, {x1, x2, ...}]
+ *
+ * Interleaves separators into the gaps BETWEEN successive elements of `list`,
+ * never before the first element and never after the last. A list of n
+ * elements has exactly n - 1 gaps, so a list of length 0 or 1 comes back
+ * unchanged. A List second argument supplies its elements cyclically, filling
+ * the gaps left to right; any other expression is a single separator used in
+ * every gap. See riffle.c for the full semantics. */
+Expr* builtin_riffle(Expr* res);
+
+#endif /* RIFFLE_H */

--- a/src/list/subdivide.c
+++ b/src/list/subdivide.c
@@ -1,0 +1,198 @@
+/* Subdivide — equally spaced points spanning an interval, endpoints included.
+ *
+ * Mathematica semantics:
+ *
+ *   Subdivide[n]             n + 1 points spanning 0 to 1:
+ *                            {0, 1/n, 2/n, ..., 1}
+ *   Subdivide[max, n]        n + 1 points spanning 0 to max
+ *   Subdivide[min, max, n]   n + 1 points spanning min to max
+ *
+ * Every form yields n + 1 points, because n counts the *parts* the interval is
+ * cut into, not the points produced. Point i (0-based) is
+ *
+ *     min + i (max - min) / n
+ *
+ * DESCENDING INTERVALS
+ *
+ * The formula above is applied verbatim for every point, with no special case.
+ * When max < min the quantity (max - min) is negative, so the step is negative
+ * and the points descend: Subdivide[3, 1, 4] -> {3, 5/2, 2, 3/2, 1}. Nothing
+ * here branches on the sign of the step, compares min against max, sorts, or
+ * takes an absolute value, so a descending call returns n + 1 points exactly
+ * as an ascending one does. A degenerate interval (min == max) has step 0 and
+ * simply repeats the endpoint: Subdivide[5, 5, 2] -> {5, 5, 5}.
+ *
+ * EXACTNESS
+ *
+ * Two independent guarantees:
+ *
+ *   1. The endpoints are *copied, never computed*. Element 0 is a copy of min
+ *      and element n is a copy of max, so no arithmetic — and therefore no
+ *      representation change — can touch them.
+ *   2. Interior points are each computed directly from their index i, never as
+ *      `previous + step`. With no accumulator there is nothing for error to
+ *      accumulate in.
+ *
+ * Interior point i is formed as the single fraction
+ *
+ *     (min n + i (max - min)) / n
+ *
+ * and reduced once by make_rational(), which divides through by the gcd,
+ * normalizes the sign onto the numerator, and returns a plain Integer when the
+ * reduced denominator is 1. That is what lets whole-number points print as
+ * integers alongside rationals in one list:
+ * Subdivide[10, 4] -> {0, 5/2, 5, 15/2, 10}.
+ *
+ * VALIDITY
+ *
+ * n must be a positive machine integer; anything else (0, negative, Rational,
+ * Real, symbolic, or a bigint demanding more elements than can be built)
+ * leaves the expression unevaluated, per the builtin NULL convention.
+ *
+ * PERFORMANCE
+ *
+ * The int64 fast path below is chosen only when overflow is impossible by
+ * construction (see SUBDIVIDE_MAX_ENDPOINT), so it needs no per-operation
+ * overflow check. Everything it declines — bigint, rational, real, or symbolic
+ * endpoints — falls back to building a Plus/Times/Power expression and letting
+ * the core evaluator do the arithmetic, the same strategy src/list/rescale.c
+ * uses. That keeps exactness and bigint correctness without duplicating the
+ * evaluator's numeric tower here.
+ */
+
+#include "list_common.h"
+#include "subdivide.h"
+
+/* Upper bound on n. Matches the generation cap already used by Range (see
+ * src/list/range.c): past this the result list is not a useful object, and
+ * refusing beats attempting the allocation. */
+#define SUBDIVIDE_MAX_N 1000000
+
+/* Endpoint magnitude admitted by the int64 fast path. With |min|, |max| <= 2^31
+ * and n <= 10^6:
+ *
+ *     |min * n|         <= 2^31 * 10^6  ~= 2.1e15
+ *     |i * (max - min)| <= 10^6 * 2^32  ~= 4.3e15
+ *
+ * so the numerator stays under ~6.4e15, comfortably inside int64's ~9.2e18.
+ * Overflow is thus excluded by precondition rather than by runtime checks. */
+#define SUBDIVIDE_MAX_ENDPOINT ((int64_t)2147483648LL)
+
+/* True when the int64 fast path can compute every interior point of this
+ * interval without overflow. */
+static bool subdivide_fits_int64(const Expr* min_e, const Expr* max_e) {
+    if (min_e->type != EXPR_INTEGER || max_e->type != EXPR_INTEGER) return false;
+    int64_t lo = min_e->data.integer;
+    int64_t hi = max_e->data.integer;
+    if (lo < -SUBDIVIDE_MAX_ENDPOINT || lo > SUBDIVIDE_MAX_ENDPOINT) return false;
+    if (hi < -SUBDIVIDE_MAX_ENDPOINT || hi > SUBDIVIDE_MAX_ENDPOINT) return false;
+    return true;
+}
+
+/* General interior point: min + i (max - min) / n, evaluated by the core
+ * evaluator. Handles bigint, rational, real, and symbolic endpoints uniformly
+ * and keeps exact input exact. `min_e` and `max_e` are borrowed. */
+static Expr* subdivide_point_general(Expr* min_e, Expr* max_e,
+                                     int64_t i, int64_t n) {
+    /* max - min, as Plus[max, Times[-1, min]] */
+    Expr* neg_min = expr_new_function(expr_new_symbol(SYM_Times),
+        (Expr*[]){ expr_new_integer(-1), expr_copy(min_e) }, 2);
+    Expr* span = expr_new_function(expr_new_symbol(SYM_Plus),
+        (Expr*[]){ expr_copy(max_e), neg_min }, 2);
+
+    /* 1/n, as Power[n, -1] */
+    Expr* inv_n = expr_new_function(expr_new_symbol(SYM_Power),
+        (Expr*[]){ expr_new_integer(n), expr_new_integer(-1) }, 2);
+
+    /* i (max - min) / n */
+    Expr* offset = expr_new_function(expr_new_symbol(SYM_Times),
+        (Expr*[]){ expr_new_integer(i), span, inv_n }, 3);
+
+    /* min + offset */
+    Expr* sum = expr_new_function(expr_new_symbol(SYM_Plus),
+        (Expr*[]){ expr_copy(min_e), offset }, 2);
+
+    Expr* out = evaluate(sum);
+    expr_free(sum);
+    return out;
+}
+
+Expr* builtin_subdivide(Expr* res) {
+    if (res->type != EXPR_FUNCTION) return NULL;
+    size_t argc = res->data.function.arg_count;
+    if (argc < 1 || argc > 3) return NULL;
+
+    /* Normalize all three surface forms to one (min, max, n) triple before a
+     * single point is computed. The 1- and 2-argument forms differ from the
+     * 3-argument form only in which endpoints default to 0 and 1. */
+    Expr* min_e;
+    Expr* max_e;
+    Expr* n_e;
+    Expr* implied_min = NULL;   /* owned here when the form implies min = 0 */
+    Expr* implied_max = NULL;   /* owned here when the form implies max = 1 */
+
+    if (argc == 1) {
+        implied_min = expr_new_integer(0);
+        implied_max = expr_new_integer(1);
+        min_e = implied_min;
+        max_e = implied_max;
+        n_e   = res->data.function.args[0];
+    } else if (argc == 2) {
+        /* The implied lower endpoint takes on the exactness of the supplied
+         * one, so an inexact interval does not carry a lone exact 0:
+         * Subdivide[1.0, 4] -> {0., 0.25, 0.5, 0.75, 1.} rather than
+         * {0, 0.25, ...}. */
+        max_e = res->data.function.args[0];
+        implied_min = (max_e->type == EXPR_REAL) ? expr_new_real(0.0)
+                                                 : expr_new_integer(0);
+        min_e = implied_min;
+        n_e   = res->data.function.args[1];
+    } else {
+        min_e = res->data.function.args[0];
+        max_e = res->data.function.args[1];
+        n_e   = res->data.function.args[2];
+    }
+
+    /* n must be a positive machine integer. Zero, negatives, rationals, reals,
+     * symbols, and bigints all leave the call unevaluated. */
+    if (n_e->type != EXPR_INTEGER ||
+        n_e->data.integer <= 0 ||
+        n_e->data.integer > SUBDIVIDE_MAX_N) {
+        expr_free(implied_min);
+        expr_free(implied_max);
+        return NULL;
+    }
+    int64_t n = n_e->data.integer;
+
+    size_t count = (size_t)n + 1;
+    Expr** points = malloc(sizeof(Expr*) * count);
+    if (!points) {
+        expr_free(implied_min);
+        expr_free(implied_max);
+        return NULL;
+    }
+
+    /* Endpoints verbatim — copied, never computed. */
+    points[0]     = expr_copy(min_e);
+    points[count - 1] = expr_copy(max_e);
+
+    /* Interior points, each derived directly from its own index. */
+    if (subdivide_fits_int64(min_e, max_e)) {
+        int64_t lo   = min_e->data.integer;
+        int64_t span = max_e->data.integer - lo;
+        int64_t base = lo * n;
+        for (int64_t i = 1; i < n; i++) {
+            points[i] = make_rational(base + i * span, n);
+        }
+    } else {
+        for (int64_t i = 1; i < n; i++) {
+            points[i] = subdivide_point_general(min_e, max_e, i, n);
+        }
+    }
+
+    Expr* out = expr_new_function(expr_new_symbol(SYM_List), points, count);
+    free(points);
+    expr_free(implied_min);
+    expr_free(implied_max);
+    return out;
+}

--- a/src/list/subdivide.h
+++ b/src/list/subdivide.h
@@ -1,0 +1,8 @@
+#ifndef SUBDIVIDE_H
+#define SUBDIVIDE_H
+
+#include "expr.h"
+
+Expr* builtin_subdivide(Expr* res);
+
+#endif /* SUBDIVIDE_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -356,6 +356,7 @@ set(COMMON_SRC
     ../src/list/list_init.c
     ../src/list/subsets.c
     ../src/list/riffle.c
+    ../src/list/gather.c
     ../src/patterns.c
     ../src/patterns.c
     ../src/replace.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -355,6 +355,7 @@ set(COMMON_SRC
     ../src/list/list_common.c
     ../src/list/list_init.c
     ../src/list/subsets.c
+    ../src/list/riffle.c
     ../src/patterns.c
     ../src/patterns.c
     ../src/replace.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -357,6 +357,7 @@ set(COMMON_SRC
     ../src/list/subsets.c
     ../src/list/riffle.c
     ../src/list/gather.c
+    ../src/list/subdivide.c
     ../src/patterns.c
     ../src/patterns.c
     ../src/replace.c

--- a/tests/test_list.c
+++ b/tests/test_list.c
@@ -857,6 +857,53 @@ void test_riffle() {
     }
 }
 
+void test_subdivide() {
+    struct {
+        const char* input;
+        const char* expected;
+    } tests[] = {
+        /* Subdivide[n] — n + 1 points spanning 0 to 1. n counts the parts the
+         * interval is cut into, not the points produced. */
+        {"Subdivide[1]", "{0, 1}"},
+        {"Subdivide[2]", "{0, 1/2, 1}"},
+        {"Subdivide[3]", "{0, 1/3, 2/3, 1}"},
+        /* Rationals reduce: the middle point is 1/2, not 2/4. */
+        {"Subdivide[4]", "{0, 1/4, 1/2, 3/4, 1}"},
+
+        /* Subdivide[max, n] — spans 0 to max. */
+        {"Subdivide[10, 5]", "{0, 2, 4, 6, 8, 10}"},
+        /* Step 5/2: points landing on whole numbers print as integers,
+         * mixed with rationals in the same list. */
+        {"Subdivide[10, 4]", "{0, 5/2, 5, 15/2, 10}"},
+
+        /* Subdivide[min, max, n] — the lower endpoint is min, not 0. */
+        {"Subdivide[1, 3, 4]", "{1, 3/2, 2, 5/2, 3}"},
+        {"Subdivide[2, 8, 3]", "{2, 4, 6, 8}"},
+
+        /* DESCENDING INTERVALS. No special case: min + i (max - min)/n is
+         * applied verbatim, so max < min simply gives a negative step and
+         * still yields n + 1 points. */
+        {"Subdivide[3, 1, 4]", "{3, 5/2, 2, 3/2, 1}"},
+        /* The two-argument form descends when max is negative. */
+        {"Subdivide[-10, 5]", "{0, -2, -4, -6, -8, -10}"},
+        /* An interval straddling zero descends through it. */
+        {"Subdivide[1, -1, 4]", "{1, 1/2, 0, -1/2, -1}"},
+        /* Degenerate interval: step 0 repeats the endpoint. n is a positive
+         * integer, which is the only validity condition, so this evaluates. */
+        {"Subdivide[5, 5, 2]", "{5, 5, 5}"},
+
+        /* n must be a positive integer; otherwise the call stays
+         * unevaluated and prints back exactly as written. */
+        {"Subdivide[0]", "Subdivide[0]"},
+        {"Subdivide[-1]", "Subdivide[-1]"},
+        {"Subdivide[5, 0]", "Subdivide[5, 0]"},
+    };
+
+    for (int i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+        assert_eval_eq(tests[i].input, tests[i].expected, 0);
+    }
+}
+
 int main() {
     symtab_init();
     core_init();
@@ -909,6 +956,7 @@ int main() {
     TEST(test_subsets);
     TEST(test_riffle);
     TEST(test_gather);
+    TEST(test_subdivide);
 
     printf("All list tests passed!\n");
     return 0;

--- a/tests/test_list.c
+++ b/tests/test_list.c
@@ -5,6 +5,7 @@
 #include "test_utils.h"
 #include "parse.h"
 #include "print.h"
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -664,6 +665,67 @@ void test_join_level2_ragged_unequal_lengths() {
                    "{{x, 1, 2}, {3, 4}}", 0);
 }
 
+/* Evaluate `input` and return the printed result (caller frees). */
+static char* eval_to_string(const char* input) {
+    Expr* parsed = parse_expression(input);
+    ASSERT(parsed != NULL);
+    Expr* evaluated = evaluate(parsed);
+    expr_free(parsed);
+    char* str = expr_to_string(evaluated);
+    expr_free(evaluated);
+    return str;
+}
+
+void test_gather() {
+    struct {
+        const char* input;
+        const char* expected;
+    } tests[] = {
+        /* Groups are ordered by FIRST occurrence of their element (1, 7, 3, 2,
+         * 9 here), not by sorted order; within a group, input order is kept. */
+        {"Gather[{1, 7, 3, 7, 2, 3, 9}]", "{{1}, {7, 7}, {3, 3}, {2}, {9}}"},
+        {"Gather[{}]", "{}"},
+        {"Gather[{5}]", "{{5}}"},
+        {"Gather[{2, 2, 2}]", "{{2, 2, 2}}"},
+        {"Gather[{1, 2, 3}]", "{{1}, {2}, {3}}"},
+        /* Equal elements are collected from anywhere in the list, so the two
+         * non-adjacent a's share a group and that group leads because a occurs
+         * first. This is Gather, not Split. */
+        {"Gather[{a, b, a}]", "{{a, a}, {b}}"},
+        {"Gather[{3, 1, 3, 1, 2}]", "{{3, 3}, {1, 1}, {2}}"},
+        {"Gather[{x, y, x, x}]", "{{x, x, x}, {y}}"},
+    };
+
+    for (int i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+        assert_eval_eq(tests[i].input, tests[i].expected, 0);
+    }
+
+    /* Gather[list] must agree with GatherBy[list, Identity] on every case
+     * above — they share one grouping engine, and this pins that down. */
+    const char* args[] = {
+        "{1, 7, 3, 7, 2, 3, 9}", "{}", "{5}", "{2, 2, 2}",
+        "{1, 2, 3}", "{a, b, a}", "{3, 1, 3, 1, 2}", "{x, y, x, x}",
+    };
+    for (int i = 0; i < (int)(sizeof(args) / sizeof(args[0])); i++) {
+        char gather_in[128], gatherby_in[128];
+        snprintf(gather_in,   sizeof(gather_in),   "Gather[%s]", args[i]);
+        snprintf(gatherby_in, sizeof(gatherby_in), "GatherBy[%s, Identity]", args[i]);
+        char* g  = eval_to_string(gather_in);
+        char* gb = eval_to_string(gatherby_in);
+        if (strcmp(g, gb) != 0) {
+            printf("Gather/GatherBy mismatch for %s: Gather gave %s, "
+                   "GatherBy[..., Identity] gave %s\n", args[i], g, gb);
+            ASSERT(0);
+        }
+        free(g);
+        free(gb);
+    }
+
+    /* Non-list arguments stay unevaluated; wrong arity does too. */
+    assert_eval_eq("Gather[x]", "Gather[x]", 0);
+    assert_eval_eq("Gather[{1, 1}, foo]", "Gather[{1, 1}, foo]", 0);
+}
+
 void test_subsets() {
     struct {
         const char* input;
@@ -846,6 +908,7 @@ int main() {
 
     TEST(test_subsets);
     TEST(test_riffle);
+    TEST(test_gather);
 
     printf("All list tests passed!\n");
     return 0;

--- a/tests/test_list.c
+++ b/tests/test_list.c
@@ -753,6 +753,48 @@ void test_subsets() {
     }
 }
 
+/* Riffle — every row here is one row of the acceptance table on md-czh.1. */
+void test_riffle() {
+    struct {
+        const char* input;
+        const char* expected;
+    } tests[] = {
+        /* A non-list separator goes in every gap. n elements, n - 1 gaps. */
+        {"Riffle[{1, 2, 3}, 0]", "{1, 0, 2, 0, 3}"},
+        {"Riffle[{1, 2}, 0]", "{1, 0, 2}"},
+        /* No gaps to fill, so the separator is ignored entirely. */
+        {"Riffle[{1}, 0]", "{1}"},
+        {"Riffle[{}, 0]", "{}"},
+        {"Riffle[{a, b, c}, x]", "{a, x, b, x, c}"},
+
+        /* A List separator is consumed cyclically, left to right: 3 gaps take
+         * x, y, x. */
+        {"Riffle[{a, b, c, d}, {x, y}]", "{a, x, b, y, c, x, d}"},
+        /* Only 2 gaps here, so z is never used. */
+        {"Riffle[{a, b, c}, {x, y, z}]", "{a, x, b, y, c}"},
+        {"Riffle[{1, 2, 3}, {x}]", "{1, x, 2, x, 3}"},
+        {"Riffle[{a}, {x, y}]", "{a}"},
+        {"Riffle[{1, 2, 3}, {0, 0}]", "{1, 0, 2, 0, 3}"},
+
+        /* An empty separator list supplies nothing (the k == 0 case) — must
+         * not divide by zero computing the cycling index. */
+        {"Riffle[{a, b}, {}]", "{a, b}"},
+        /* n == 0 reached with a list separator: the no-gaps check has to come
+         * before any 2n - 1 sizing, which would underflow size_t. */
+        {"Riffle[{}, {x, y}]", "{}"},
+        /* More separators than gaps: both z and w go unused. */
+        {"Riffle[{a, b, c}, {x, y, z, w}]", "{a, x, b, y, c}"},
+        /* Exactly one gap, which takes only the first separator. */
+        {"Riffle[{a, b}, {x, y}]", "{a, x, b}"},
+        /* The head of the first argument is preserved, not forced to List. */
+        {"Riffle[f[a, b], x]", "f[a, x, b]"},
+    };
+
+    for (int i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+        assert_eval_eq(tests[i].input, tests[i].expected, 0);
+    }
+}
+
 int main() {
     symtab_init();
     core_init();
@@ -803,6 +845,7 @@ int main() {
     TEST(test_join_level2_ragged_unequal_lengths);
 
     TEST(test_subsets);
+    TEST(test_riffle);
 
     printf("All list tests passed!\n");
     return 0;


### PR DESCRIPTION
## Summary

Adds three Mathematica list built-ins to the kernel — `Riffle`, `Gather`, and `Subdivide` — each with a spec doc section, a changelog entry, and a table-driven test.

## Changes

- **`Riffle[list, x]` / `Riffle[list, {x1, x2, ...}]`** (`src/list/riffle.{c,h}`) — interleaves separators into the `n - 1` gaps between successive elements. A non-list separator goes in every gap; a `List` separator is consumed cyclically left to right, so `Riffle[{a,b,c,d}, {x,y}]` gives `{a, x, b, y, c, x, d}`. Separators never precede the first element or follow the last, so a list of length 0 or 1 passes through unchanged and the result has `2n - 1` slots. The head of the first argument is preserved. One pass, `O(n)` copies, a single exactly-sized allocation.

- **`Gather[list]`** (`src/list/gather.{c,h}`) — partitions a list into sublists of structurally identical elements, sublists ordered by first appearance. Rather than reimplementing the grouping, this extracts `GatherBy`'s hash-indexed engine in `src/assoc.c` as a shared `assoc_gather_core(list, f)`, where a `NULL` key function selects the identity key. `Gather[l]` and `GatherBy[l, Identity]` therefore agree by construction, and the identity path skips the `n` redundant `Identity[x]` evaluations that spelling it out would incur. `GatherBy` behaviour is unchanged.

- **`Subdivide[n]` / `Subdivide[max, n]` / `Subdivide[min, max, n]`** (`src/list/subdivide.{c,h}`) — `n + 1` equally spaced points spanning an interval, **including both endpoints** (`n` counts the parts the interval is cut into, not the points produced). Exact input gives exact results in lowest terms with both endpoints exact; descending intervals give a negative step; returns unevaluated unless `n` is a positive integer.

- All three registered `Protected` with docstrings in `src/list/list_init.c`, re-exported from `src/list/list.h`, documented in `docs/spec/builtins/`, and recorded in `docs/spec/changelog/2026-07-27.md`.

## Testing

- `cmake -S tests -B build && cmake --build build --target list_tests && ./build/list_tests` → **`All list tests passed!`**, including the new `test_riffle`, `test_gather`, and `test_subdivide` tables.
- Because `Gather` refactors shared code behind `GatherBy`, `association_tests` was also built and run → **`All Association tests passed.`**
- No new compiler warnings from any of the added or modified files.

## Ticket

md-czh — `md-czh.1` (Riffle), `md-czh.2` (Gather), `md-czh.3` (Subdivide).
