### PR TITLE
Send machine matrices built as plain lists down the SVD path

### DIFF
--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -1557,3 +1557,38 @@ whole point of interval arithmetic. v0.032.
   wrong answer before the fix.
 
 Leak-clean (zero valgrind delta); `check-c99` clean; compiles with `USE_MPFR=0`.
+
+## PseudoInverse / LeastSquares: machine matrices reach the SVD path (perf)
+
+`PseudoInverse` already had the right rule — a machine matrix takes the SVD path,
+because the exact pipeline "rationalises every entry, row-reduces over Q and
+inverts two Gram matrices", which its own comment calls unusable for machine
+input. The guard implementing that rule tested `linalg_call_has_ndarray`, i.e.
+whether the argument was ALREADY a packed buffer. A matrix built structurally —
+by `DesignMatrix`, `Table`, `Transpose`, or written as a literal — is a plain
+List-of-Lists, so it failed the guard and rationalised anyway.
+
+The cost was steep and, worse, looked like a scaling law rather than a switch:
+
+| `LeastSquares[m, v]`, m × 3 float64 | before | after |
+|---|---|---|
+| 625 | 0.008 s | 0.00015 s |
+| 1250 | 0.035 s | 0.00027 s |
+| 2500 | 6.17 s | 0.00061 s |
+| 5000 | **58.4 s** | **0.0012 s** |
+
+`builtin_pseudoinverse` now numericalises a machine-precision inexact matrix and
+offers it for packing before falling through to the exact pipeline. Two details
+matter:
+
+- **Numericalise first.** Packing refuses a mixed Integer/Real list, and a design
+  matrix is exactly that: the constant basis function contributes an exact
+  `Integer 1` column beside Real ones. Widening to Real is the contagion the
+  computation already performs — the exact pipeline numericalises its own result
+  at the same `prec_bits` — so no value changes.
+- **Machine precision only.** Above 53 bits the exact pipeline is what carries the
+  extra digits; an f64 SVD would silently drop them, so that input is untouched.
+
+`pack_offer` keeps the usual element threshold, so matrices too small to pack stay
+on the exact path and return bit-identical results. `tests/test_fit.c` and
+`tests/test_linalg.c` pass unchanged.

--- a/src/linalg/inv.c
+++ b/src/linalg/inv.c
@@ -41,6 +41,7 @@
 
 #include "inv.h"
 #include "pack.h"
+#include "ndarray.h"
 #include "linalg.h"
 #include "ndlinalg.h"
 #include "linsolve.h"
@@ -934,11 +935,47 @@ Expr* builtin_pseudoinverse(Expr* res) {
      * approximate matrices yield approximate answers at the input precision
      * while still benefiting from a well-defined rank in the row reduction. */
     CommonInexactInfo info = common_scan_inexact(arg);
-    Expr* a_rat = NULL;
     long prec_bits = 53;
+    if (info.has_inexact) prec_bits = info.min_bits ? info.min_bits : 53;
+
+    /* A machine matrix that arrived as a plain List-of-Lists is packed here and
+     * sent down the same SVD path, instead of into the exact pipeline below.
+     * The note above says that pipeline is unusable for a machine matrix, but
+     * the guard for it recognised only an ALREADY-packed argument -- so every
+     * machine matrix built structurally (DesignMatrix, Table, Transpose, a
+     * literal) missed it and rationalised anyway: LeastSquares on a 5000x3
+     * float64 design matrix spent 58 s multiplying rationals in GMP.
+     * pack_offer never changes a value and declines cheaply, so a matrix that
+     * cannot pack simply falls through.
+     *
+     * Machine precision only. Above 53 bits the exact pipeline is what carries
+     * the extra digits, and an f64 SVD would silently drop them. */
+    if (info.has_inexact && prec_bits <= 53) {
+        /* Numericalise before offering: packing refuses a MIXED Integer/Real
+         * list, and a design matrix is exactly that -- the constant basis
+         * function contributes an exact Integer 1 column beside Real ones.
+         * Widening those to Reals is the contagion this computation already
+         * performs (the exact pipeline's own result is numericalised at the
+         * same prec_bits), so no value changes. pack_offer keeps the usual
+         * threshold, leaving matrices too small to pack on the exact path with
+         * results identical to before. */
+        Expr* mach = common_numericalize_result(arg, prec_bits);
+        if (mach) {
+            Expr* packed = pack_offer(mach);           /* consumes `mach` */
+            if (is_ndarray(packed)) {
+                Expr* fast = ndla_pseudoinverse_direct(packed, tol_automatic,
+                                                       tol_value);
+                expr_free(packed);
+                if (fast) return fast;
+            } else {
+                expr_free(packed);
+            }
+        }
+    }
+
+    Expr* a_rat = NULL;
     Expr* matrix_to_use = arg;
     if (info.has_inexact) {
-        prec_bits = info.min_bits ? info.min_bits : 53;
         a_rat = common_rationalize_input(arg, prec_bits);
         matrix_to_use = a_rat;
     }


### PR DESCRIPTION
## Summary

`PseudoInverse` already had the right rule, and says so in its own comment: a machine matrix takes the SVD path, because the exact pipeline "rationalises every entry, row-reduces over Q and inverts two Gram matrices" — which that comment calls unusable for machine input.

The guard implementing the rule tested `linalg_call_has_ndarray`, i.e. whether the argument was **already** a packed buffer. A matrix built structurally — by `DesignMatrix`, `Table`, `Transpose`, or written as a literal — is a plain List-of-Lists, so it failed the guard and rationalised anyway.

`LeastSquares` on a 5000×3 float64 design matrix therefore spent **58 s** multiplying rationals in GMP. The cost also looked like a scaling law rather than a switch, which is how it hid:

| `LeastSquares[m, v]`, m × 3 float64 | before | after |
|---|---|---|
| 625 | 0.008 s | 0.00015 s |
| 1250 | 0.035 s | 0.00027 s |
| 2500 | 6.17 s | 0.00061 s |
| 5000 | **58.4 s** | **0.0012 s** |

Timing is linear in rows again.

## Changes

`builtin_pseudoinverse` numericalises a machine-precision inexact matrix and offers it for packing before falling through to the exact pipeline. Two details matter:

- **Numericalise first.** Packing refuses a mixed Integer/Real list, and a design matrix is exactly that — the constant basis function contributes an exact `Integer 1` column beside Real ones. Widening to Real is the contagion the computation already performs (the exact pipeline numericalises its own result at the same `prec_bits`), so no value changes.
- **Machine precision only.** Above 53 bits the exact pipeline is what carries the extra digits; an f64 SVD would silently drop them, so that input is untouched.

`pack_offer` keeps the usual element threshold, so matrices too small to pack stay on the exact path and return bit-identical results.

## Testing

- `tests/test_fit.c` and `tests/test_linalg.c` pass unchanged.
- `make check-c99` and `make check-packed-aware` clean.
- Profiled before/after: the GMP `__gmpn_*` frames under `builtin_pseudoinverse` → `builtin_dot` are gone.
- Fit results verified against the benchmark's own check value (`Round[10^4 (fit /. t -> 3)]` = 70000).
- Compared the full test suite against clean `origin/main`: the same 10 tests fail on both (`eigen_tests`, `bench_pack`, `integrate_*`, `ratcanon_*`, `intrat`, `factorlist`), so they are pre-existing; `primenu_tests` is flaky (pass/fail/pass on one binary). No new failures.