### PR TITLE
Dispatch small machine matrices to LAPACK, not the symbolic path

### DIFF
--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -1557,3 +1557,36 @@ whole point of interval arithmetic. v0.032.
   wrong answer before the fix.
 
 Leak-clean (zero valgrind delta); `check-c99` clean; compiles with `USE_MPFR=0`.
+
+## Det / Inverse / LinearSolve: small machine matrices reach LAPACK (perf)
+
+`benchmarks/` experiment 22 exists to ask "does LAPACK get reached at all?" for
+small matrices, and the answer was no. The NDArray guard on each builtin is
+`linalg_call_has_ndarray` — *is this already a buffer* — and a 6×6 is 36
+elements, far below the packing threshold, so it is a plain nested List, misses
+the guard, and runs the generic symbolic path. This is the roadmap item recorded
+in that experiment's header.
+
+New `linalg_pack_machine_operand` / `..._call1` / `..._call2`
+(`src/linalg/ndlinalg.c`) pack a plain List of machine reals into an f64 buffer
+and re-dispatch, so the question asked becomes *is this a matrix of machine
+numbers*.
+
+| case | before | after |
+|---|---|---|
+| `Det` 6×6 × 5000 | 1.21 s | 0.0025 s |
+| `Inverse` 6×6 × 2000 | 0.566 s | 0.0019 s |
+| `LinearSolve` 6×6 × 2000 | 0.495 s | 0.0022 s |
+| `Inverse` 3×3 × 5000 | 0.170 s | 0.0028 s |
+
+**Exact input is untouched.** The helper declines unless the operand sniffs to
+`NDT_FLOAT64`, so an all-Integer or all-Rational matrix — which would otherwise
+pack to an int64 buffer or land on a float path — keeps the exact answer it is
+owed: `Det[spdIntMatrix[6]]` still returns `19019139649223/74649600`. The
+two-argument form declines unless *both* operands are machine-real, rather than
+half-converting a mixed call. Machine results were checked against the exact
+computation numericalised (`Det` 254779.0 both ways; `Inverse` and `LinearSolve`
+totals likewise).
+
+`Dot` 6×6 (88× behind) is unchanged: it has no `linalg_call_has_ndarray` guard
+and reaches its buffers by another route, so it needs its own look.

--- a/src/linalg/det.c
+++ b/src/linalg/det.c
@@ -42,6 +42,17 @@ Expr* laplace_det(Expr** flat, int original_n, int n, int row, int* cols) {
 Expr* builtin_det(Expr* res) {
     if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 1) return NULL;
     if (linalg_call_has_ndarray(res)) return ndla_det(res);
+
+    /* A machine-real matrix too small to have been packed reaches the same fast
+     * path here. Without it a 6x6 Det runs the generic path: 1.28 s over 5000
+     * repeats against 0.0012 s packed, for the identical value. */
+    Expr* packed_call = linalg_pack_machine_call1(res);
+    if (packed_call) {
+        Expr* fast = ndla_det(packed_call);
+        expr_free(packed_call);
+        if (fast) return fast;
+    }
+
     Expr* arg = res->data.function.args[0];
 
     int64_t dims[64];

--- a/src/linalg/inv.c
+++ b/src/linalg/inv.c
@@ -547,6 +547,17 @@ static Expr* inverse_cofactor(Expr* arg, int n) {
 Expr* builtin_inverse(Expr* res) {
     if (res->type != EXPR_FUNCTION) return NULL;
     if (linalg_call_has_ndarray(res)) return ndla_inverse(res);
+
+    /* Small machine-real matrix: pack and take the same path. See
+     * linalg_pack_machine_operand -- a 6x6 is below the packing threshold, so
+     * "is it already a buffer" misses it and the generic path runs. */
+    Expr* packed_call = linalg_pack_machine_call1(res);
+    if (packed_call) {
+        Expr* fast = ndla_inverse(packed_call);
+        expr_free(packed_call);
+        if (fast) return fast;
+    }
+
     size_t argc = res->data.function.arg_count;
     if (argc < 1 || argc > 2) return NULL;
 

--- a/src/linalg/linsolve.c
+++ b/src/linalg/linsolve.c
@@ -1105,6 +1105,17 @@ Expr* builtin_rowreduce(Expr* res) {
 Expr* builtin_linearsolve(Expr* res) {
     if (res->type != EXPR_FUNCTION) return NULL;
     if (linalg_call_has_ndarray(res)) return ndla_linearsolve(res);
+
+    /* Small machine-real system: pack both operands and take the same path.
+     * See linalg_pack_machine_operand -- a 6x6 sits below the packing
+     * threshold, so the "already a buffer" guard never fires for it. */
+    Expr* packed_call = linalg_pack_machine_call2(res);
+    if (packed_call) {
+        Expr* fast = ndla_linearsolve(packed_call);
+        expr_free(packed_call);
+        if (fast) return fast;
+    }
+
     size_t argc = res->data.function.arg_count;
     if (argc < 2 || argc > 3) return NULL;
 

--- a/src/linalg/ndlinalg.c
+++ b/src/linalg/ndlinalg.c
@@ -20,6 +20,7 @@
 #include "ndlinalg.h"
 #include "numarray.h"
 #include "ndarray.h"
+#include "pack.h"
 #include "lapack.h"
 #include "eval.h"
 #include "print.h"
@@ -40,6 +41,65 @@ bool linalg_call_has_ndarray(const Expr* res)
         if (is_ndarray(res->data.function.args[i])) return true;
     }
     return false;
+}
+
+/* Pack a plain List operand of machine reals, so that a call assembled from
+ * SMALL matrices still reaches the NDArray path.
+ *
+ * linalg_call_has_ndarray asks "is this already a buffer", and a matrix below
+ * the packing threshold never is: a 6x6 is 36 elements, well under it, so it
+ * stays a nested List and the generic symbolic path runs. That is the whole of
+ * the gap in benchmarks/ experiment 22 -- Det on a 6x6 costs 1.28 s over 5000
+ * repeats unpacked and 0.0012 s packed, for the identical value. The question
+ * worth asking is "is this a matrix of machine numbers", which is this.
+ *
+ * Deliberately REAL machine buffers only: pack_force sniffs the dtype, and an
+ * all-Integer or all-Rational matrix would either pack to an int64 buffer or
+ * decline, in both cases putting an exact matrix on a floating-point path whose
+ * answer is not the exact one Det and Inverse owe it. Anything that does not
+ * sniff to NDT_FLOAT64 is handed back unpacked.
+ *
+ * Returns a freshly owned copy of `arg` as a packed array, or NULL to decline.
+ * Never mutates or frees `arg`. */
+Expr* linalg_pack_machine_operand(const Expr* arg)
+{
+    if (!arg || is_ndarray(arg)) return NULL;
+    Expr* packed = pack_force(expr_copy((Expr*)arg), false, NDT_FLOAT64);
+    if (!packed) return NULL;
+    if (!is_ndarray(packed) || packed->data.ndarray.dtype != NDT_FLOAT64) {
+        expr_free(packed);
+        return NULL;
+    }
+    return packed;
+}
+
+/* The same, for a whole one-argument call: returns a rebuilt `head[packed]`
+ * ready to hand to an ndla_* fast path, or NULL to decline. The caller owns the
+ * result and frees it; `res` is untouched. */
+Expr* linalg_pack_machine_call1(const Expr* res)
+{
+    if (!res || res->type != EXPR_FUNCTION || res->data.function.arg_count != 1)
+        return NULL;
+    Expr* packed = linalg_pack_machine_operand(res->data.function.args[0]);
+    if (!packed) return NULL;
+    Expr* args[1] = { packed };
+    return expr_new_function(expr_copy((Expr*)res->data.function.head), args, 1);
+}
+
+/* Two-argument form, for LinearSolve[m, v] and Dot[a, b]. BOTH operands must be
+ * machine-real -- a mixed call (one packed, one exact) would hand the fast path
+ * an operand pair whose natural result is not the exact one the generic path
+ * would produce, so it is declined rather than half-converted. */
+Expr* linalg_pack_machine_call2(const Expr* res)
+{
+    if (!res || res->type != EXPR_FUNCTION || res->data.function.arg_count != 2)
+        return NULL;
+    Expr* a = linalg_pack_machine_operand(res->data.function.args[0]);
+    if (!a) return NULL;
+    Expr* b = linalg_pack_machine_operand(res->data.function.args[1]);
+    if (!b) { expr_free(a); return NULL; }
+    Expr* args[2] = { a, b };
+    return expr_new_function(expr_copy((Expr*)res->data.function.head), args, 2);
 }
 
 /*

--- a/src/linalg/ndlinalg.h
+++ b/src/linalg/ndlinalg.h
@@ -39,6 +39,23 @@ extern "C" {
  * that is an EXPR_NDARRAY. This is the cheap predicate each builtin guards on. */
 bool linalg_call_has_ndarray(const Expr* res);
 
+/* Pack a plain List of machine REALS into an f64 buffer, so a small matrix --
+ * below the packing threshold, hence never "already a buffer" -- still reaches
+ * the NDArray fast paths. Declines (NULL) for anything already packed,
+ * unpackable, or not sniffing to NDT_FLOAT64, which keeps exact Integer and
+ * Rational matrices on the exact paths they are owed. The caller owns the
+ * result; the argument is neither mutated nor freed. */
+Expr* linalg_pack_machine_operand(const Expr* arg);
+
+/* linalg_pack_machine_operand for a one-argument call: returns a rebuilt
+ * `head[packed]` to hand to an ndla_* fast path, or NULL to decline. */
+Expr* linalg_pack_machine_call1(const Expr* res);
+
+/* Two-argument form (LinearSolve[m, v], Dot[a, b]). Declines unless BOTH
+ * operands are machine-real, so a mixed exact/machine call keeps its exact
+ * path rather than being half-converted. */
+Expr* linalg_pack_machine_call2(const Expr* res);
+
 /* Universal fallback: rebuild `res` with every top-level NDArray argument
  * replaced by its nested-List form and evaluate the result. Returns a freshly
  * owned Expr* (the evaluated call), or NULL if the rebuilt call cannot be


### PR DESCRIPTION
## Summary

Experiment 22 in `benchmarks/` exists to ask "does LAPACK get reached at all?" for small matrices. It did not — this is the roadmap item recorded in that experiment's own header.

Each linalg builtin guards its NDArray path on `linalg_call_has_ndarray` — *is this **already** a buffer*. A 6×6 matrix is 36 elements, far below the packing threshold, so it stays a plain nested List, misses the guard, and runs the generic symbolic path. `Det` on a 6×6 cost 1.21 s over 5000 repeats; the same matrix pre-packed cost 0.0025 s, for an identical value.

## Changes

Add `linalg_pack_machine_operand` plus `..._call1` / `..._call2` (`src/linalg/ndlinalg.c`), which pack a plain List of machine reals into an f64 buffer and re-dispatch — changing the question asked to *is this a matrix of machine numbers*. Wired into `Det`, `Inverse` and `LinearSolve`.

| case | before | after | vs best baseline now |
|---|---|---|---|
| `Det` 6×6 × 5000 | 1.21 s | 0.0025 s | **0.51×** |
| `Inverse` 3×3 × 5000 | 0.170 s | 0.0028 s | **0.57×** |
| `LinearSolve` 6×6 × 2000 | 0.495 s | 0.0022 s | **0.63×** |
| `Inverse` 6×6 × 2000 | 0.566 s | 0.0019 s | **0.82×** |

Those four rows move out of the ranked gaps and into AHEAD — faster than both Mathematica and Python. `Eigenvalues` 6×6 follows at 0.62× for free.

## Exact input is untouched

The helper declines unless the operand sniffs to `NDT_FLOAT64`, so an all-Integer or all-Rational matrix — which would otherwise pack to an int64 buffer or land on a float path — keeps the exact answer it is owed: `Det[spdIntMatrix[6]]` still returns `19019139649223/74649600`, and `Inverse` still returns Rationals. The two-argument form declines unless *both* operands are machine-real, rather than half-converting a mixed call.

## Testing

- Machine results checked against the exact computation numericalised: `Det` 254779.0 both ways; `Inverse` and `LinearSolve` totals likewise.
- `tests/test_linalg.c`, `tests/test_fit.c`, `tests/test_graph.c` pass; `make check-c99` clean.
- Full `bench-gap` re-run: SLOWER 90 → 82, AHEAD 86 → 97, check disagreements unchanged at 3.

## Not covered

`Dot` 6×6 (85× behind) is unchanged: it has no `linalg_call_has_ndarray` guard and reaches its buffers by another route, so it needs its own look.