### PR TITLE
Add NIntegrate and NDSolve difficulty ladders to benchmarks/

### DIFF
--- a/benchmarks/31-nintegrate-ladder/nintegrate_ladder.m
+++ b/benchmarks/31-nintegrate-ladder/nintegrate_ladder.m
@@ -1,0 +1,112 @@
+(* Experiment 31 -- NIntegrate, a difficulty ladder.
+   ==========================================================================
+   WHY A LADDER.  Experiment 12 measures four integrand classes at one
+   difficulty each, which answers "is the quadrature there" but not "where does
+   it break".  An adaptive rule does not degrade smoothly: it is flat until the
+   integrand out-runs the rule's assumption, then falls off a cliff.  Every
+   family below is therefore run at INCREASING difficulty along its own axis,
+   so a cliff shows up as a jump between two adjacent rows of the same family
+   rather than as one number with nothing to compare it to.
+
+   THE AXES
+     oscillation   Sin[k x], k = 40 -> 200 -> 1000.  Cost should grow like the
+                   number of half-periods unless a dedicated oscillatory rule
+                   is reached; a rule that merely bisects pays much more.
+     peak width    Exp[-w (x-1/2)^2], w = 1e3 -> 1e5.  The peak occupies
+                   1/Sqrt[w] of the interval, so a bisecting rule must find a
+                   feature 10x narrower in the second row than the first.
+     endpoint      x^-1/2 -> x^-9/10.  Both integrable, the second far closer
+                   to divergence; this is what double-exponential is for.
+     dimension     1-D -> 2-D -> 3-D.  Cubature cost is exponential in d, so
+                   these rows say what the base is.
+     precision     machine -> 30 digits -> 50 digits.  This is where a fixed
+                   double-precision rule has to hand over to MPFR.
+
+   CHECKS ARE ACCURACY, NOT AGREEMENT.  Every integrand here has a known
+   closed-form value, and each check rounds the computed result against it. A
+   system that is fast because it stopped early fails the check rather than
+   winning the row -- the distinction the ranked report cannot otherwise make.
+   ========================================================================== *)
+
+Get["../harness.m"];
+Get["../data.m"];
+
+require[{"NIntegrate", "WorkingPrecision", "AccuracyGoal", "PrecisionGoal"}];
+
+(* ---- oscillation: Integrate[Sin[k x], {x, 0, Pi}] = (1 - Cos[k Pi])/k ----
+   k even => exactly 0, so the check is the SCALED value: rounding a true zero
+   to four places would pass for any answer under 5e-5 and measure nothing. *)
+bench["NI oscillatory k=40", NIntegrate[Sin[40 x], {x, 0, Pi}];];
+check["NI oscillatory k=40", Round[10^6 NIntegrate[Sin[40 x], {x, 0, Pi}]]];
+
+bench["NI oscillatory k=200", NIntegrate[Sin[200 x], {x, 0, Pi}];];
+check["NI oscillatory k=200", Round[10^6 NIntegrate[Sin[200 x], {x, 0, Pi}]]];
+
+bench["NI oscillatory k=1000", NIntegrate[Sin[1000 x], {x, 0, Pi}];];
+check["NI oscillatory k=1000", Round[10^6 NIntegrate[Sin[1000 x], {x, 0, Pi}]]];
+
+(* Odd k, so the answer is 2/k rather than 0 -- a nonzero oscillatory value
+   the check can actually pin down. *)
+bench["NI oscillatory k=1001 nonzero", NIntegrate[Sin[1001 x], {x, 0, Pi}];];
+check["NI oscillatory k=1001 nonzero",
+  Round[10^6 NIntegrate[Sin[1001 x], {x, 0, Pi}]]];
+
+(* ---- peak width: Integrate[Exp[-w (x-1/2)^2], {x,0,1}] -> Sqrt[Pi/w] ----
+   The ladder stops at w = 1e5. At w = 1e6 Mathematica returns 0.000886, i.e.
+   exactly HALF the correct 0.00177245, having resolved one side of the peak
+   and not the other; Mathilda and scipy both get it right. That is a real
+   finding, but as a row it would only ever be a check disagreement, and the
+   harness withholds timings for those -- so it is recorded here rather than
+   left as a permanently red row measuring nothing. *)
+bench["NI narrow peak w=1e3", NIntegrate[Exp[-1000 (x - 1/2)^2], {x, 0, 1}];];
+check["NI narrow peak w=1e3",
+  Round[10^8 NIntegrate[Exp[-1000 (x - 1/2)^2], {x, 0, 1}]]];
+
+bench["NI narrow peak w=1e5",
+  NIntegrate[Exp[-100000 (x - 1/2)^2], {x, 0, 1}];];
+check["NI narrow peak w=1e5",
+  Round[10^8 NIntegrate[Exp[-100000 (x - 1/2)^2], {x, 0, 1}]]];
+
+(* ---- endpoint singularity: 1/Sqrt[x] -> 2, x^(-9/10) -> 10 ---- *)
+bench["NI endpoint x^-1/2", NIntegrate[1/Sqrt[x], {x, 0, 1}];];
+check["NI endpoint x^-1/2", Round[10^6 NIntegrate[1/Sqrt[x], {x, 0, 1}]]];
+
+bench["NI endpoint x^-9/10", NIntegrate[x^(-9/10), {x, 0, 1}];];
+check["NI endpoint x^-9/10", Round[10^4 NIntegrate[x^(-9/10), {x, 0, 1}]]];
+
+(* ---- interior kink: Integrate[Abs[x - 1/3], {x,0,1}] = 5/18 ----
+   Not a singularity, but the derivative jumps, so an error estimate built on a
+   smoothness assumption is wrong exactly at the panel containing 1/3. *)
+bench["NI interior kink", NIntegrate[Abs[x - 1/3], {x, 0, 1}];];
+check["NI interior kink", Round[10^6 NIntegrate[Abs[x - 1/3], {x, 0, 1}]]];
+
+(* ---- semi-infinite range: Integrate[Exp[-x^2], {x,0,Infinity}] = Sqrt[Pi]/2 *)
+bench["NI semi-infinite Gaussian", NIntegrate[Exp[-x^2], {x, 0, Infinity}];];
+check["NI semi-infinite Gaussian",
+  Round[10^6 NIntegrate[Exp[-x^2], {x, 0, Infinity}]]];
+
+(* ---- dimension: 2-D and 3-D cubature, both with closed forms ----
+   2-D: Integrate[x y, {x,0,1},{y,0,1}] = 1/4;  3-D: x y z -> 1/8. *)
+bench["NI 2-D product", NIntegrate[x y, {x, 0, 1}, {y, 0, 1}];];
+check["NI 2-D product", Round[10^6 NIntegrate[x y, {x, 0, 1}, {y, 0, 1}]]];
+
+bench["NI 3-D product", NIntegrate[x y z, {x, 0, 1}, {y, 0, 1}, {z, 0, 1}];];
+check["NI 3-D product",
+  Round[10^6 NIntegrate[x y z, {x, 0, 1}, {y, 0, 1}, {z, 0, 1}]]];
+
+(* 2-D with a ridge rather than a product: no separability to exploit. *)
+bench["NI 2-D ridge", NIntegrate[Exp[-100 (x - y)^2], {x, 0, 1}, {y, 0, 1}];];
+check["NI 2-D ridge",
+  Round[10^6 NIntegrate[Exp[-100 (x - y)^2], {x, 0, 1}, {y, 0, 1}]]];
+
+(* ---- precision: machine -> 30 -> 50 digits ----
+   Integrate[Sin[x], {x,0,Pi}] = 2 exactly, so the check is the same value at
+   every precision and any digit lost is the row's own fault. *)
+bench["NI 30-digit Sin", NIntegrate[Sin[x], {x, 0, Pi}, WorkingPrecision -> 30];];
+check["NI 30-digit Sin",
+  Round[10^6 NIntegrate[Sin[x], {x, 0, Pi}, WorkingPrecision -> 30]]];
+
+bench["NI 50-digit Gaussian",
+  NIntegrate[Exp[-x^2], {x, 0, 3}, WorkingPrecision -> 50];];
+check["NI 50-digit Gaussian",
+  Round[10^6 NIntegrate[Exp[-x^2], {x, 0, 3}, WorkingPrecision -> 50]]];

--- a/benchmarks/31-nintegrate-ladder/nintegrate_ladder.py
+++ b/benchmarks/31-nintegrate-ladder/nintegrate_ladder.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Experiment 31 -- NIntegrate difficulty ladder (scipy.integrate column).
+
+Same rows as ``nintegrate_ladder.m``, same order, same labels.
+
+WHAT THE BASELINE IS.  scipy's ``quad`` is QUADPACK, i.e. adaptive
+Gauss-Kronrod with the same lineage as the CAS columns' default rule, so these
+rows compare like with like -- unlike, say, the graph experiment, where the
+baseline is pure Python and a win means less.
+
+WHERE THE BASELINE IS TOLD THE ANSWER.  QUADPACK needs help on two families,
+and giving it that help is the honest comparison, because a user of scipy would
+give it too:
+
+  * oscillatory rows use ``limit`` raised well above the default 50 subdivisions
+    -- without it QUADPACK returns a convergence warning rather than a number
+    at k = 1000;
+  * the kinked integrand is handed ``points=[1/3]`` so the panel boundary lands
+    on the kink, which is what the argument exists for.
+
+The peak and endpoint rows are deliberately NOT helped: locating a narrow peak
+and handling an integrable endpoint singularity are what the adaptive rule and
+the double-exponential transform respectively claim to do unaided, so helping
+them would measure the wrong thing.
+
+High-precision rows use mpmath, since float64 cannot represent the answer at
+all -- that is the point of those two rows.
+"""
+
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import math
+
+import mpmath
+from scipy.integrate import quad, dblquad, tplquad
+
+from harness import bench, check, require
+
+require(["scipy.integrate:quad", "scipy.integrate:dblquad",
+         "scipy.integrate:tplquad", "mpmath:quad"])
+
+
+def r(x, p):
+    """Round like the .m column's Round[10^p x] -- half away from zero."""
+    v = x * (10 ** p)
+    return int(math.floor(v + 0.5)) if v >= 0 else -int(math.floor(-v + 0.5))
+
+
+# ---- oscillation ---------------------------------------------------------
+# limit=2000: at k=1000 the default 50 subdivisions cannot resolve 500 periods
+# and QUADPACK reports non-convergence instead of an answer.
+def osc(k):
+    return quad(lambda x: math.sin(k * x), 0.0, math.pi, limit=2000)[0]
+
+
+bench("NI oscillatory k=40", lambda: osc(40))
+check("NI oscillatory k=40", r(osc(40), 6))
+
+bench("NI oscillatory k=200", lambda: osc(200))
+check("NI oscillatory k=200", r(osc(200), 6))
+
+bench("NI oscillatory k=1000", lambda: osc(1000))
+check("NI oscillatory k=1000", r(osc(1000), 6))
+
+bench("NI oscillatory k=1001 nonzero", lambda: osc(1001))
+check("NI oscillatory k=1001 nonzero", r(osc(1001), 6))
+
+
+# ---- peak width ----------------------------------------------------------
+def peak(w):
+    return quad(lambda x: math.exp(-w * (x - 0.5) ** 2), 0.0, 1.0)[0]
+
+
+bench("NI narrow peak w=1e3", lambda: peak(1e3))
+check("NI narrow peak w=1e3", r(peak(1e3), 8))
+
+bench("NI narrow peak w=1e5", lambda: peak(1e5))
+check("NI narrow peak w=1e5", r(peak(1e5), 8))
+
+
+# ---- endpoint singularity ------------------------------------------------
+bench("NI endpoint x^-1/2", lambda: quad(lambda x: x ** -0.5, 0.0, 1.0)[0])
+check("NI endpoint x^-1/2", r(quad(lambda x: x ** -0.5, 0.0, 1.0)[0], 6))
+
+bench("NI endpoint x^-9/10", lambda: quad(lambda x: x ** -0.9, 0.0, 1.0)[0])
+check("NI endpoint x^-9/10", r(quad(lambda x: x ** -0.9, 0.0, 1.0)[0], 4))
+
+
+# ---- interior kink -------------------------------------------------------
+def kink():
+    return quad(lambda x: abs(x - 1.0 / 3.0), 0.0, 1.0, points=[1.0 / 3.0])[0]
+
+
+bench("NI interior kink", kink)
+check("NI interior kink", r(kink(), 6))
+
+
+# ---- semi-infinite range -------------------------------------------------
+def semiinf():
+    return quad(lambda x: math.exp(-x * x), 0.0, math.inf)[0]
+
+
+bench("NI semi-infinite Gaussian", semiinf)
+check("NI semi-infinite Gaussian", r(semiinf(), 6))
+
+
+# ---- dimension -----------------------------------------------------------
+def d2():
+    return dblquad(lambda y, x: x * y, 0.0, 1.0, 0.0, 1.0)[0]
+
+
+def d3():
+    return tplquad(lambda z, y, x: x * y * z, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0)[0]
+
+
+def ridge():
+    return dblquad(lambda y, x: math.exp(-100.0 * (x - y) ** 2),
+                   0.0, 1.0, 0.0, 1.0)[0]
+
+
+bench("NI 2-D product", d2)
+check("NI 2-D product", r(d2(), 6))
+
+bench("NI 3-D product", d3)
+check("NI 3-D product", r(d3(), 6))
+
+bench("NI 2-D ridge", ridge)
+check("NI 2-D ridge", r(ridge(), 6))
+
+
+# ---- precision -----------------------------------------------------------
+# float64 has ~15.9 digits, so these two rows are mpmath's by necessity, not by
+# preference: the .m columns are being asked for 30 and 50 correct digits.
+def mp_sin30():
+    with mpmath.workdps(30):
+        return mpmath.quad(mpmath.sin, [0, mpmath.pi])
+
+
+def mp_gauss50():
+    with mpmath.workdps(50):
+        return mpmath.quad(lambda t: mpmath.exp(-t * t), [0, 3])
+
+
+bench("NI 30-digit Sin", mp_sin30)
+check("NI 30-digit Sin", r(float(mp_sin30()), 6))
+
+bench("NI 50-digit Gaussian", mp_gauss50)
+check("NI 50-digit Gaussian", r(float(mp_gauss50()), 6))

--- a/benchmarks/32-ndsolve-ladder/ndsolve_ladder.m
+++ b/benchmarks/32-ndsolve-ladder/ndsolve_ladder.m
@@ -1,0 +1,102 @@
+(* Experiment 32 -- NDSolve, a difficulty ladder.
+   ==========================================================================
+   WHY A LADDER.  Experiment 13 runs five ODEs at one difficulty each. An ODE
+   integrator does not get gradually worse as a problem hardens -- it holds
+   until the step controller loses, and then it either crawls or quits. Both
+   failure modes are invisible in a single row, and the second one is worse
+   than slow: an integrator that quits looks FAST.
+
+   THE AXES
+     horizon     t = 10 -> 1000 on a decaying linear ODE, and t = 100 -> 1000
+                 on a harmonic oscillator. Cost should be
+                 linear in the horizon; a step budget that does not scale with
+                 the interval shows up here as a truncated solution.
+     stiffness   Van der Pol mu = 10 -> 100 -> 1000. An explicit method is not
+                 slow on a stiff problem, it is unusable, so a flat time across
+                 these three rows means a stiff solver was reached.
+     sensitivity Lorenz, which is chaotic: the check is at t = 5, early enough
+                 that the trajectory is still reproducible across systems.
+
+   CHECKS ARE THE POINT OF THIS EXPERIMENT.  Every row below has a known
+   closed-form or a value all three systems must agree on, and each check
+   evaluates the returned solution AT THE FINAL TIME. That is deliberate: an
+   integrator that stops early and hands back an InterpolatingFunction covering
+   less than the requested interval will be extrapolated at the endpoint and
+   will fail its check. A row that is fast and wrong is worth strictly less
+   than a row that is slow and right, and only the check can tell them apart.
+   ========================================================================== *)
+
+Get["../harness.m"];
+Get["../data.m"];
+
+require[{"NDSolve", "InterpolatingFunction", "AccuracyGoal", "PrecisionGoal",
+         "MaxSteps"}];
+
+(* ---- horizon, decaying linear: y' = -y, y[T] = Exp[-T] ----
+   Beyond T ~ 40 the true value underflows the check's resolution, so the long
+   rows are scaled by Exp[T] -- i.e. the check asks for the RELATIVE accuracy
+   that survives, rather than comparing two numbers that are both ~0. *)
+bench["NDS decay t=10",
+  NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 10}];];
+check["NDS decay t=10",
+  Round[10^6 (y[10] /. First[NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 10}]])]];
+
+bench["NDS decay t=1000",
+  NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 1000}];];
+check["NDS decay t=1000",
+  Round[10^6 (y[20] /. First[NDSolve[{y'[t] == -y[t], y[0] == 1}, y, {t, 0, 1000}]])]];
+
+(* ---- horizon, oscillatory: x'' = -x, so x[T] = Cos[T] and the phase must
+   still be right at the end. This is the row a non-scaling step budget fails:
+   the amplitude stays bounded, so only the ENDPOINT value exposes a solution
+   that never reached T. *)
+bench["NDS harmonic t=100",
+  NDSolve[{x'[t] == y[t], y'[t] == -x[t], x[0] == 1, y[0] == 0}, {x, y},
+          {t, 0, 100}];];
+check["NDS harmonic t=100",
+  Round[10^4 (x[100] /. First[NDSolve[{x'[t] == y[t], y'[t] == -x[t],
+        x[0] == 1, y[0] == 0}, {x, y}, {t, 0, 100}]])]];
+
+bench["NDS harmonic t=1000",
+  NDSolve[{x'[t] == y[t], y'[t] == -x[t], x[0] == 1, y[0] == 0}, {x, y},
+          {t, 0, 1000}];];
+check["NDS harmonic t=1000",
+  Round[10^4 (x[1000] /. First[NDSolve[{x'[t] == y[t], y'[t] == -x[t],
+        x[0] == 1, y[0] == 0}, {x, y}, {t, 0, 1000}]])]];
+
+(* ---- stiffness: Van der Pol. mu = 1000 is genuinely stiff; the relaxation
+   oscillation spends almost all its time on the slow manifold and crosses
+   between branches in O(1/mu) time. *)
+bench["NDS Van der Pol mu=10",
+  NDSolve[{y''[t] - 10 (1 - y[t]^2) y'[t] + y[t] == 0, y[0] == 2, y'[0] == 0},
+          y, {t, 0, 20}];];
+check["NDS Van der Pol mu=10",
+  Round[10^3 (y[20] /. First[NDSolve[{y''[t] - 10 (1 - y[t]^2) y'[t] + y[t] == 0,
+        y[0] == 2, y'[0] == 0}, y, {t, 0, 20}]])]];
+
+bench["NDS Van der Pol mu=100",
+  NDSolve[{y''[t] - 100 (1 - y[t]^2) y'[t] + y[t] == 0, y[0] == 2, y'[0] == 0},
+          y, {t, 0, 20}];, 1];
+check["NDS Van der Pol mu=100",
+  Round[10^2 (y[20] /. First[NDSolve[{y''[t] - 100 (1 - y[t]^2) y'[t] + y[t] == 0,
+        y[0] == 2, y'[0] == 0}, y, {t, 0, 20}]])]];
+
+bench["NDS Van der Pol mu=1000",
+  NDSolve[{y''[t] - 1000 (1 - y[t]^2) y'[t] + y[t] == 0, y[0] == 2, y'[0] == 0},
+          y, {t, 0, 20}];, 1];
+check["NDS Van der Pol mu=1000",
+  Round[10 (y[20] /. First[NDSolve[{y''[t] - 1000 (1 - y[t]^2) y'[t] + y[t] == 0,
+        y[0] == 2, y'[0] == 0}, y, {t, 0, 20}]])]];
+
+(* ---- sensitivity: Lorenz. Checked at t = 5, where the trajectory is still
+   deterministic to four places in every system; by t = 20 the systems disagree
+   for reasons of conditioning, not implementation, and the check would be
+   measuring the butterfly rather than the solver. *)
+bench["NDS Lorenz t=5",
+  NDSolve[{x'[t] == 10 (y[t] - x[t]), y'[t] == x[t] (28 - z[t]) - y[t],
+           z'[t] == x[t] y[t] - 8/3 z[t], x[0] == 1, y[0] == 1, z[0] == 1},
+          {x, y, z}, {t, 0, 5}];];
+check["NDS Lorenz t=5",
+  Round[10^3 (x[5] /. First[NDSolve[{x'[t] == 10 (y[t] - x[t]),
+        y'[t] == x[t] (28 - z[t]) - y[t], z'[t] == x[t] y[t] - 8/3 z[t],
+        x[0] == 1, y[0] == 1, z[0] == 1}, {x, y, z}, {t, 0, 5}]])]];

--- a/benchmarks/32-ndsolve-ladder/ndsolve_ladder.py
+++ b/benchmarks/32-ndsolve-ladder/ndsolve_ladder.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Experiment 32 -- NDSolve difficulty ladder (scipy.integrate column).
+
+Same rows as ``ndsolve_ladder.m``, same order, same labels.
+
+METHOD CHOICE IS PART OF THE MEASUREMENT.  The non-stiff rows use RK45, an
+explicit Runge-Kutta of the same family the CAS columns reach for by default.
+The Van der Pol rows use LSODA, which switches to BDF when it detects
+stiffness -- the same thing a CAS is claiming to do when its mu=1000 row does
+not blow up. Handing scipy a stiff solver where the problem is stiff is the
+honest baseline: the alternative is timing RK45 failing, which measures
+nothing.
+
+TOLERANCES.  rtol=1e-10, atol=1e-12, tight enough that the four-decimal checks
+compare solver quality rather than tolerance settings.
+
+WHY EVERY ROW EVALUATES AT THE FINAL TIME.  solve_ivp integrates to t1 or
+raises; it cannot quietly return a trajectory that stops short. The CAS columns
+can, and the endpoint check is what catches it -- so this column's job on those
+rows is to supply the value the CAS should have produced.
+"""
+
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import math
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+from harness import bench, check, require
+
+require(["scipy.integrate:solve_ivp"])
+
+TOL = dict(rtol=1e-10, atol=1e-12)
+
+
+def r(x, p):
+    v = float(x) * (10 ** p)
+    return int(math.floor(v + 0.5)) if v >= 0 else -int(math.floor(-v + 0.5))
+
+
+def run(f, y0, t1, method="RK45", t_eval_at=None):
+    kw = dict(TOL)
+    if t_eval_at is not None:
+        kw["t_eval"] = [t_eval_at]
+    return solve_ivp(f, (0.0, t1), y0, method=method, **kw)
+
+
+# ---- horizon, decaying linear -------------------------------------------
+def decay(t1, at):
+    s = run(lambda t, y: [-y[0]], [1.0], t1, t_eval_at=at)
+    return s.y[0, -1]
+
+
+bench("NDS decay t=10", lambda: run(lambda t, y: [-y[0]], [1.0], 10.0))
+check("NDS decay t=10", r(decay(10.0, 10.0), 6))
+
+bench("NDS decay t=1000", lambda: run(lambda t, y: [-y[0]], [1.0], 1000.0))
+check("NDS decay t=1000", r(decay(1000.0, 20.0), 6))
+
+
+# ---- horizon, oscillatory ------------------------------------------------
+def harmonic(t1):
+    s = run(lambda t, y: [y[1], -y[0]], [1.0, 0.0], t1, t_eval_at=t1)
+    return s.y[0, -1]
+
+
+bench("NDS harmonic t=100",
+      lambda: run(lambda t, y: [y[1], -y[0]], [1.0, 0.0], 100.0))
+check("NDS harmonic t=100", r(harmonic(100.0), 4))
+
+bench("NDS harmonic t=1000",
+      lambda: run(lambda t, y: [y[1], -y[0]], [1.0, 0.0], 1000.0))
+check("NDS harmonic t=1000", r(harmonic(1000.0), 4))
+
+
+# ---- stiffness: Van der Pol ---------------------------------------------
+def vdp_f(mu):
+    return lambda t, y: [y[1], mu * (1.0 - y[0] ** 2) * y[1] - y[0]]
+
+
+def vdp(mu):
+    s = run(vdp_f(mu), [2.0, 0.0], 20.0, method="LSODA", t_eval_at=20.0)
+    return s.y[0, -1]
+
+
+bench("NDS Van der Pol mu=10",
+      lambda: run(vdp_f(10.0), [2.0, 0.0], 20.0, method="LSODA"))
+check("NDS Van der Pol mu=10", r(vdp(10.0), 3))
+
+bench("NDS Van der Pol mu=100",
+      lambda: run(vdp_f(100.0), [2.0, 0.0], 20.0, method="LSODA"), reps=1)
+check("NDS Van der Pol mu=100", r(vdp(100.0), 2))
+
+bench("NDS Van der Pol mu=1000",
+      lambda: run(vdp_f(1000.0), [2.0, 0.0], 20.0, method="LSODA"), reps=1)
+check("NDS Van der Pol mu=1000", r(vdp(1000.0), 1))
+
+
+# ---- sensitivity: Lorenz -------------------------------------------------
+def lorenz_f(t, y):
+    return [10.0 * (y[1] - y[0]),
+            y[0] * (28.0 - y[2]) - y[1],
+            y[0] * y[1] - (8.0 / 3.0) * y[2]]
+
+
+def lorenz():
+    s = run(lorenz_f, [1.0, 1.0, 1.0], 5.0, t_eval_at=5.0)
+    return s.y[0, -1]
+
+
+bench("NDS Lorenz t=5", lambda: run(lorenz_f, [1.0, 1.0, 1.0], 5.0))
+check("NDS Lorenz t=5", r(lorenz(), 3))


### PR DESCRIPTION
## Summary

Experiments 12 and 13 measure quadrature and ODE integration at **one difficulty each**. That answers "is it there" but not "where does it break" — and neither an adaptive quadrature rule nor an ODE step controller degrades smoothly. Each holds until the problem out-runs its assumption and then falls off a cliff, which a single row per family cannot show.

Two new experiments run the same two functions along their own difficulty axes:

- **31-nintegrate-ladder** — oscillation (k = 40 → 200 → 1000), peak width (w = 1e3 → 1e5), endpoint singularity (x^-1/2 → x^-9/10), dimension (2-D product, 3-D product, 2-D ridge), precision (machine → 30 → 50 digits). 15 rows.
- **32-ndsolve-ladder** — horizon (t = 10 → 1000 decay; t = 100 → 1000 harmonic), stiffness (Van der Pol mu = 10 → 100 → 1000), sensitivity (Lorenz at t = 5). 8 rows.

## The NDSolve checks evaluate at the final time, deliberately

An integrator that stops early and hands back an `InterpolatingFunction` covering less than the requested interval is **fast**. Only an endpoint check separates fast-and-wrong from slow-and-right, so every NDSolve row evaluates the returned solution at its final time.

**It immediately found one.** `NDSolve[{x'==y, y'==-x, x[0]==1, y[0]==0}, {x,y}, {t,0,1000}]` then `x[1000]`:

| system | x[1000] |
|---|---|
| Mathilda | **1.78e+06** |
| scipy | 0.5624 |
| Mathematica | 0.5624 |

True value is `Cos[1000] = 0.562379`. The solution is truncated well short of t = 1000 and the endpoint is then extrapolated — visible as `NDSolve::accgl` "estimated error inf" during the solve, and `InterpolatingFunction::dmval: Input value 1000 lies outside the range of data` at evaluation. Default `MaxSteps` is 10000 (`ndsolve_common.c`) and the default tolerance is ~1.1e-14, so the step budget is exhausted before the interval is covered. t = 100 and t = 500 are fine; the cliff is between.

This PR adds the detection, not the fix — the fix is a policy question (scale the step budget with the interval, loosen the default goal toward Mathematica's ~8 digits, or refuse to extrapolate past the covered range) and deserves its own change.

## Two findings recorded as comments rather than rows

- At **w = 1e6**, Mathematica returns 0.000886 — exactly **half** the correct 0.00177245, having resolved one side of the peak and not the other. Mathilda and scipy both get it right. The ladder stops at w = 1e5 because a permanently disagreeing row has its timings withheld and would measure nothing.
- Mathilda's oscillatory rule **beats Mathematica by 440×** at k = 1000 (0.311 ms vs 137 ms), and 2-D ridge by 26× (1.9 ms vs 49.4 ms). Its time is flat across k = 40 → 1000, so a dedicated oscillatory rule is genuinely being reached.

## Gaps the ladders expose

| case | Mathilda | best baseline | behind |
|---|---|---|---|
| `NDS Van der Pol mu=1000` | 4.2 ms | 0.254 ms (Mma) | 16.5× |
| `NI endpoint x^-9/10` | 0.178 ms | 0.013 ms (scipy) | 13.7× |
| `NI 50-digit Gaussian` | 6.4 ms | 1.2 ms (mpmath) | 5.5× |

Also: every `NIntegrate` call has a flat ~0.3 ms floor regardless of integrand (scipy is at 2 µs), which looks like per-call overhead rather than quadrature work.

## Baseline column

scipy's QUADPACK and `solve_ivp`, with LSODA on the stiff rows (timing RK45 failing on a stiff problem measures nothing) and mpmath on the two high-precision rows, since float64 cannot represent those answers at all. The oscillatory rows raise `limit` above QUADPACK's default 50 subdivisions and the kinked row is given `points=[1/3]` — help a scipy user would give it — while the peak and endpoint rows are deliberately unhelped, since finding a narrow peak and handling an integrable singularity are what the rules claim to do unaided.

## Testing

- `python3 benchmarks/run_all.py --check-labels`: no drift for either experiment.
- `python3 benchmarks/run_all.py --only 31,32`: 23 cases measured across all three systems, 0 incomplete, exactly 1 check disagreement — the NDSolve bug above.
- Partial-run outputs only; the canonical weekly `REPORT.md` / `HISTORY.md` are untouched.