### PR TITLE
Stop NDSolve's Automatic step budget from truncating the interval

### DIFF
--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -1557,3 +1557,47 @@ whole point of interval arithmetic. v0.032.
   wrong answer before the fix.
 
 Leak-clean (zero valgrind delta); `check-c99` clean; compiles with `USE_MPFR=0`.
+
+## NDSolve: the Automatic step budget no longer truncates the interval (fix)
+
+`NDSolve[{x'==y, y'==-x, x[0]==1, y[0]==0}, {x,y}, {t,0,1000}]` then `x[1000]`
+returned **1.78e6**. The true value is `Cos[1000] = 0.5624`, which is what both
+scipy and Mathematica return.
+
+The default `MaxSteps` budget was the literal 10000, independent of the interval.
+A harmonic oscillator over `{t, 0, 1000}` at the default 8-digit goal needs
+~60000 adaptive steps, so the driver stopped at 10000, returned an
+`InterpolatingFunction` covering only the part it had reached, and evaluating at
+the requested endpoint then **extrapolated** off the end of the data. Visible as
+`NDSolve::accgl` "estimated error inf" during the solve and
+`InterpolatingFunction::dmval` at evaluation — but invisible in a timing, because
+quitting early is *fast*. `t = 100` and `t = 500` were fine; the cliff sat
+between.
+
+New `ND_AUTO_MAX_STEPS` (2,000,000, in `ndsolve_common.h`) is the budget used
+when `MaxSteps` is Automatic, i.e. when the user never asked for a wall. It is a
+runaway backstop rather than a resolution knob, and a large one is safe because
+exhausting it is not how a divergent problem ends: the driver's independent
+step-size-underflow guard (`ND_ERR_STEPSIZE` / `ND_ERR_NONCONV`) is what catches
+a blow-up or a Newton failure. `MaxSteps` is only reached by a problem making
+real progress that simply needs more steps than a fixed guess allowed.
+
+An **explicit** `MaxSteps -> n` is still a hard wall — a user who names a budget
+is asking to be stopped at it. `MaxSteps -> 100` on the row above still truncates
+and still warns, unchanged.
+
+Correctness here is nearly free: `harmonic t=1000` goes from 0.0050 s (wrong) to
+0.0067 s (right).
+
+| | before | after |
+|---|---|---|
+| `x[1000]`, harmonic over {t,0,1000} | 1.78e6 | 0.562378 (true 0.562379) |
+
+The multistep fixed-step heuristic in `nd_fixed_step` deliberately keeps the old
+10000: that number picks the step *size* for an Adams/BDF march, and widening it
+would silently multiply the node count of every such solve. Only the runaway wall
+moved.
+
+`tests/test_ndsolve.c`, `test_ndsolve_classical.c`, `test_ndsolve_compile.c`,
+`test_ndsolve_pde.c` and `test_nint.c` all pass. Benchmark experiment 32's check
+disagreement count goes 1 -> 0.

--- a/src/numerical_calculus/ndsolve_adams.c
+++ b/src/numerical_calculus/ndsolve_adams.c
@@ -136,7 +136,7 @@ NdStatus nd_multistep_adams(NdProblem* P, const NdOpts* o, NdSolution* sol) {
     if (!nd_rhs_real(P, P->t0, P->Y0, f0)) { free(f0); return ND_ERR_SAMPLE; }
     nd_solution_push(sol, P->t0, P->Y0, f0);
     free(f0);
-    int64_t budget = (o->max_steps > 0) ? o->max_steps : 10000;
+    int64_t budget = (o->max_steps > 0) ? o->max_steps : ND_AUTO_MAX_STEPS;
     NdStatus st = ND_OK;
     if (P->tmax > P->t0) st = adams_dir(P, o, sol, tol, P->tmax, &budget);
     if (P->tmin < P->t0) { NdStatus s2 = adams_dir(P, o, sol, tol, P->tmin, &budget);

--- a/src/numerical_calculus/ndsolve_common.c
+++ b/src/numerical_calculus/ndsolve_common.c
@@ -811,6 +811,10 @@ double nd_fixed_step(NdProblem* P, const NdOpts* o, NdTol tol, double dir) {
      * of steps before reaching the endpoint and the result extrapolates). */
     double digits = (tol.rtol > 0.0) ? -log10(tol.rtol) : 8.0;
     double target = 500.0 * pow(10.0, digits / 4.0);   /* grows with accuracy */
+    /* Deliberately NOT ND_AUTO_MAX_STEPS. This budget picks the fixed step for
+     * the multistep march -- a resolution knob -- and widening it here would
+     * silently multiply the node count of every Adams/BDF solve. The runaway
+     * wall is separate, and is the one that moved. */
     double budget = (o->max_steps > 0) ? (double)o->max_steps : 10000.0;
     double budget_cap = 0.9 * budget;                  /* leave headroom       */
     if (target < 500.0) target = 500.0;
@@ -833,7 +837,7 @@ NdStatus nd_integrate(NdProblem* P, const NdStepper* S, const NdOpts* o, NdSolut
         nd_solution_sort(sol);
         return ms;
     }
-    int64_t max_steps = (o->max_steps > 0) ? o->max_steps : 10000;
+    int64_t max_steps = (o->max_steps > 0) ? o->max_steps : ND_AUTO_MAX_STEPS;
 
     double* Y0 = malloc(sizeof(double) * d);
     double* f0 = malloc(sizeof(double) * d);

--- a/src/numerical_calculus/ndsolve_common.h
+++ b/src/numerical_calculus/ndsolve_common.h
@@ -194,6 +194,28 @@ bool nd_jacobian_real(NdProblem* P, double t, const double* Y, double* Jout);
 /* ------------------------------------------------------------------ *
  *  Options                                                            *
  * ------------------------------------------------------------------ */
+/* Step budget used when MaxSteps is Automatic, i.e. when the user did not ask
+ * for a wall. It is a runaway backstop, NOT a resolution knob.
+ *
+ * It used to be 10000, and that number silently produced WRONG ANSWERS on any
+ * routine long-horizon solve. A harmonic oscillator over {t, 0, 1000} at the
+ * default 8-digit goal needs ~60000 adaptive steps; the driver stopped at
+ * 10000, returned an InterpolatingFunction covering only the part it reached,
+ * and evaluating at t = 1000 then EXTRAPOLATED off the end -- x[1000] came back
+ * as 1.78e6 where Cos[1000] = 0.5624. Both scipy and Mathematica answer 0.5624.
+ * The failure is invisible in a timing: quitting early is fast.
+ *
+ * A large backstop is safe here because exhausting it is not how a divergent
+ * problem ends. The driver has an independent step-size-underflow guard
+ * (ND_ERR_STEPSIZE / ND_ERR_NONCONV) that fires when the controller collapses,
+ * which is what actually catches a blow-up or a Newton failure. MaxSteps is
+ * only reached by a problem that is making real progress and simply needs more
+ * steps than a fixed guess allowed.
+ *
+ * An EXPLICIT MaxSteps -> n stays a hard wall, exactly as before: a user who
+ * names a budget is asking to be stopped at it. */
+#define ND_AUTO_MAX_STEPS ((int64_t)2000000)
+
 typedef struct {
     const char* method;        /* interned method name, or NULL = Automatic   */
     Expr*       method_subopts;/* borrowed List of Rule suboptions, or NULL   */
@@ -201,7 +223,7 @@ typedef struct {
     long        wp_bits;       /* working precision in bits (MPFR)            */
     double      acc_goal;      /* digits; -1 = Automatic; HUGE_VAL = Infinity  */
     double      prec_goal;     /* digits; -1 = Automatic; HUGE_VAL = Infinity  */
-    int64_t     max_steps;     /* -1 = Automatic                             */
+    int64_t     max_steps;     /* -1 = Automatic (see ND_AUTO_MAX_STEPS)     */
     double      max_step_size; /* <= 0 => unbounded                          */
     double      max_step_fraction; /* default 1/10                           */
     double      starting_step; /* <= 0 => automatic (Hairer)                 */

--- a/src/numerical_calculus/ndsolve_implicit.c
+++ b/src/numerical_calculus/ndsolve_implicit.c
@@ -289,7 +289,7 @@ NdStatus nd_multistep_bdf(NdProblem* P, const NdOpts* o, NdSolution* sol) {
     if (!nd_rhs_real(P, P->t0, P->Y0, f0)) { free(f0); return ND_ERR_SAMPLE; }
     nd_solution_push(sol, P->t0, P->Y0, f0);
     free(f0);
-    int64_t budget = (o->max_steps > 0) ? o->max_steps : 10000;
+    int64_t budget = (o->max_steps > 0) ? o->max_steps : ND_AUTO_MAX_STEPS;
     NdStatus st = ND_OK;
     if (P->tmax > P->t0) st = bdf_dir(P, o, sol, tol, P->tmax, &budget);
     if (P->tmin < P->t0) { NdStatus s2 = bdf_dir(P, o, sol, tol, P->tmin, &budget);

--- a/src/numerical_calculus/ndsolve_mpfr.c
+++ b/src/numerical_calculus/ndsolve_mpfr.c
@@ -674,7 +674,7 @@ static NdStatus mpfr_integrate(NdProblem* P, const NdOpts* o, const NdStepper* S
     else {
         P->tol.rtol = tol.rtol; P->tol.atol = tol.atol;
         mpsol_push(sol, t0m, Y0, f0);
-        int64_t budget = (o->max_steps > 0) ? o->max_steps : 10000;
+        int64_t budget = (o->max_steps > 0) ? o->max_steps : ND_AUTO_MAX_STEPS;
         if (P->tmax > P->t0)
             st = implicit ? mpfr_bdf_dir(P, o, sol, tol, P->tmax, bits, &budget)
                           : mpfr_dir(P, o, sol, tol, adaptive, P->tmax, bits, &budget);


### PR DESCRIPTION
## The bug

```
NDSolve[{x'==y, y'==-x, x[0]==1, y[0]==0}, {x,y}, {t,0,1000}];  x[1000]
```

| system | x[1000] |
|---|---|
| **Mathilda** | **1.78e+06** |
| scipy | 0.5624 |
| Mathematica | 0.5624 |

True value is `Cos[1000] = 0.562379`.

The default `MaxSteps` budget was the literal `10000`, independent of the interval being integrated. That problem needs ~60000 adaptive steps at the default 8-digit goal, so the driver stopped at 10000, returned an `InterpolatingFunction` covering only the part it had reached, and evaluating at the requested endpoint **extrapolated off the end of the data**.

It surfaced as `NDSolve::accgl` "estimated error inf" during the solve and `InterpolatingFunction::dmval` at evaluation — but never as a slow row, because **quitting early is fast**. `t = 100` and `t = 500` were fine; the cliff sat between them.

Found by the new experiment 32 ladder (#46), whose NDSolve checks evaluate at the final time precisely to catch this.

## The fix

Add `ND_AUTO_MAX_STEPS` (2,000,000) and use it as the budget wherever `MaxSteps` is Automatic — the adaptive driver, Adams, the implicit steppers, and the MPFR path.

A large backstop is safe because **exhausting it is not how a divergent problem ends**. The driver has an independent step-size-underflow guard (`ND_ERR_STEPSIZE` / `ND_ERR_NONCONV`) that fires when the controller collapses, and that is what actually catches a blow-up or a Newton failure. `MaxSteps` is only reached by a problem that is making real progress and simply needs more steps than a fixed guess allowed.

An **explicit** `MaxSteps -> n` remains a hard wall — a user who names a budget is asking to be stopped at it. `MaxSteps -> 100` on the row above still truncates and still warns, unchanged.

`nd_fixed_step` deliberately keeps the old `10000`: there the budget picks the step *size* for an Adams/BDF march — a resolution knob — and widening it would silently multiply the node count of every multistep solve. Only the runaway wall moved.

## Cost

Correctness is nearly free here.

| | before | after |
|---|---|---|
| `x[1000]` value | 1.78e6 | 0.562378 |
| `harmonic t=1000` time | 0.0050 s (wrong) | 0.0067 s (right) |

Other ladder rows are unmoved: `decay t=1000` 0.0002 s, `Lorenz t=5` 0.0004 s, `vdP mu=1000` 0.0070 s.

## Testing

- `test_ndsolve`, `test_ndsolve_classical`, `test_ndsolve_compile`, `test_ndsolve_pde`, `test_nint` — all pass.
- `run_all.py --only 31,32`: check disagreements **1 → 0**, 23 cases, 0 incomplete.
- Verified `MaxSteps -> 100` still walls (returns the truncated solution and warns), so explicit budgets are untouched.

Depends on nothing; #46 adds the benchmark that detects it but this stands alone.