### PR TITLE
Sample NIntegrate's compiled integrand without the Expr round-trip

### DIFF
--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -1557,3 +1557,34 @@ whole point of interval arithmetic. v0.032.
   wrong answer before the fix.
 
 Leak-clean (zero valgrind delta); `check-c99` clean; compiles with `USE_MPFR=0`.
+
+## NIntegrate: sample the compiled integrand without the Expr round-trip (perf)
+
+Every sample point on the compiled machine path allocated an `Expr` for the
+abscissa, unboxed it straight back to a `double` for the compiled body, boxed
+the result into an `Expr`, and unboxed that again for the quadrature rule — two
+allocations and two frees per point, spent only to pass doubles through an
+Expr-shaped interface. A profile of `NIntegrate[Sin[200 x], {x, 0, Pi}]` is
+mostly `expr_new_real`, `expr_free` and `_free`.
+
+`ni_sample_machine` now calls the compiled body directly when one has been
+built, on both the affine and the exponential-endpoint map.
+
+| integrand | before | after |
+|---|---|---|
+| `Sin[40 x]` on [0,Pi] | 0.353 ms | 0.238 ms |
+| `Sin[200 x]` on [0,Pi] | 0.340 ms | 0.226 ms |
+| `Sin[1000 x]` on [0,Pi] | 0.408 ms | 0.325 ms |
+| `Abs[x-1/3]` on [0,1] | 0.015 ms | 0.008 ms |
+| `x^(-9/10)` on [0,1] | 0.193 ms | 0.143 ms |
+
+Declining leaves the caller on the general path, so every fallback the
+interpreter provides is preserved: a non-finite compiled result still routes to
+the interpreter, which supplies that contribution where the compiled body would
+have gone complex. `c->ac` is NULL until `ni_eval_at` lazily builds it, so the
+first sample of a call takes the general path and the rest are fast.
+
+The MPFR path is untouched, and measures unchanged (30-digit `Sin` 0.15 ms
+before and after) — high-precision sampling has its own compiled route.
+`tests/test_nint.c` passes; benchmark experiments 31 and 32 stay at 0 check
+disagreements.

--- a/src/numerical_calculus/nint.c
+++ b/src/numerical_calculus/nint.c
@@ -301,6 +301,32 @@ static Expr* ni_eval_at(NiCtx* c, Expr* value) {
     return num;
 }
 
+/* The compiled machine path WITHOUT the Expr round-trip.
+ *
+ * The general path builds an Expr for the abscissa, and ni_eval_at unboxes it
+ * straight back to a double for the compiled body, boxes the result, and the
+ * caller unboxes that again -- two allocations and two frees per sample point,
+ * spent only to pass doubles through an Expr-shaped interface. On an
+ * oscillatory integrand, which samples thousands of points per call, that
+ * churn is most of the cost: expr_new_real, expr_free and _free dominate the
+ * profile of NIntegrate[Sin[200 x], {x, 0, Pi}].
+ *
+ * Declining (false) leaves the caller on the general path, so every fallback
+ * the interpreter provides is preserved unchanged -- in particular a non-finite
+ * compiled result still routes to the interpreter, which supplies that
+ * contribution (e.g. where the compiled body would go complex).
+ *
+ * c->ac is NULL until ni_eval_at has lazily built it, so the first sample of a
+ * call takes the general path (building it) and the rest are fast. */
+static bool ni_sample_compiled(NiCtx* c, double w, double _Complex* out) {
+    if (!c->ac) return false;
+    double _Complex z;
+    if (!autocompiled_eval_complex(c->ac, &w, &z)) return false;
+    if (!isfinite(creal(z)) || !isfinite(cimag(z))) return false;
+    *out = z;
+    return true;
+}
+
 /* Machine sample callback: f at a (possibly mapped) real abscissa x. */
 static bool ni_sample_machine(void* vctx, double x, double _Complex* out) {
     NiCtx* c = (NiCtx*)vctx;
@@ -318,6 +344,10 @@ static bool ni_sample_machine(void* vctx, double x, double _Complex* out) {
          * (1 − tiny == 1) otherwise.  Evaluating the integrand there raises a
          * spurious 1/0; the tail past this horizon is negligible, so truncate. */
         if (w == c->end_a || !(jac > 0.0)) return false;
+        if (ni_sample_compiled(c, w, out)) {
+            *out *= jac;
+            return isfinite(creal(*out)) && isfinite(cimag(*out));
+        }
         Expr* num = ni_eval_at(c, expr_new_real(w));
         if (!num) return false;
         bool ok = ni_to_complex(num, out);
@@ -327,6 +357,11 @@ static bool ni_sample_machine(void* vctx, double x, double _Complex* out) {
         if (!isfinite(creal(*out)) || !isfinite(cimag(*out))) return false;
         return true;
     }
+    /* Same affine map ni_abscissa_expr applies; a real abscissa is the only one
+     * the compiled body accepts, and a complex contour point falls through. */
+    double _Complex wz = c->x_scale * x + c->x_shift;
+    if (cimag(wz) == 0.0 && ni_sample_compiled(c, creal(wz), out)) return true;
+
     Expr* num = ni_eval_at(c, ni_abscissa_expr(c, x));
     if (!num) return false;
     bool ok = ni_to_complex(num, out);


### PR DESCRIPTION
## Summary

Every sample point on the compiled machine path allocated an `Expr` for the abscissa, and `ni_eval_at` unboxed it straight back to a `double` for the compiled body, boxed the result into an `Expr`, and the caller unboxed that again — **two allocations and two frees per sample point**, spent only to pass doubles through an Expr-shaped interface.

On an oscillatory integrand, which samples thousands of points per call, that churn *is* most of the cost. A `sample(1)` profile of `NIntegrate[Sin[200 x], {x, 0, Pi}]` is dominated by `expr_new_real`, `expr_free` and `_free`.

`ni_sample_machine` now calls the compiled body directly when one has been built, on both the affine and the exponential-endpoint map.

| integrand | before | after |
|---|---|---|
| `Sin[40 x]` on [0,Pi] | 0.353 ms | 0.238 ms |
| `Sin[200 x]` on [0,Pi] | 0.340 ms | 0.226 ms |
| `Sin[1000 x]` on [0,Pi] | 0.408 ms | 0.325 ms |
| `Abs[x-1/3]` on [0,1] | 0.015 ms | 0.008 ms |
| `x^(-9/10)` on [0,1] | 0.193 ms | 0.143 ms |

## Fallbacks are preserved

Declining (returning false) leaves the caller on the existing general path, so every fallback the interpreter provides still happens — in particular a non-finite compiled result still routes to the interpreter, which supplies that contribution where the compiled body would have gone complex. The finiteness checks are the same ones, in the same order.

`c->ac` is NULL until `ni_eval_at` lazily builds it, so the first sample of a call takes the general path (building it) and every later one is fast — no change to when compilation happens.

## Not touched

The MPFR path, which has its own compiled route (`ac_prec`) and is gated on `spec.mode == MACHINE` for `c->ac`. It measures unchanged: 30-digit `Sin` is 0.15 ms before and after.

## Testing

- `tests/test_nint.c` and `tests/test_ndsolve.c` pass.
- `run_all.py --only 31,32`: 23 cases, **0 check disagreements** — the values are identical, only the boxing is gone.
- Timings repeated across runs; the first run of a fresh process is cold and misleading (it made `NI smooth` look 5× worse and `WP30` 13× worse until repeated — both are in fact unchanged).