### PR TITLE
Pack small machine matrices in Dot when neither operand is a buffer

### DIFF
--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -1557,3 +1557,31 @@ whole point of interval arithmetic. v0.032.
   wrong answer before the fix.
 
 Leak-clean (zero valgrind delta); `check-c99` clean; compiles with `USE_MPFR=0`.
+
+## Dot: pack small machine matrices when NEITHER operand is a buffer (perf)
+
+`dot2` already packs a plain List operand so a product can take the buffer
+path, but only when the *other* operand is already an `NDArray`. When neither
+is — which is every product of matrices small enough to sit below the packing
+threshold — nothing was packed and the Times/Plus-per-element loop ran: 216
+symbolic multiplies per 6×6 product.
+
+| case | before | after |
+|---|---|---|
+| `m6 . m6`, 6×6 × 10000 | 334 ms | 7.8 ms |
+
+The both-plain branch is deliberately not behind `pack_any_created()`. That
+guard spares a session which never packs anything from paying a probe, but here
+nothing has been packed *by definition* — a session doing small-matrix algebra
+never trips it, so the guard would permanently disable the path it is meant to
+protect. Declining stays O(1): `pack_force`'s sniff bails at the first
+non-machine element, so a symbolic `Dot` costs one pointer test.
+
+Both operands must pack or neither is used, so a mixed machine/exact pair keeps
+the exact path. Verified: machine `Total[Flatten[m6.m6]]` = 566.713 equals the
+exact computation numericalised; `(ex.ex)[[1,1]]` still returns `232169/3600` as
+a Rational; symbolic, mixed, vector·vector and matrix·vector are unchanged.
+
+This is the row PR #45 (`perf/small-matrix-lapack`) explicitly left undone —
+`Dot` has no `linalg_call_has_ndarray` guard and reaches its buffers by this
+different route.

--- a/src/linalg/dot.c
+++ b/src/linalg/dot.c
@@ -193,11 +193,32 @@ Expr* dot2(Expr* a, Expr* b, bool* error_printed) {
      * one pointer test. */
     Expr* tmp_a = NULL;
     Expr* tmp_b = NULL;
-    if (pack_any_created()) {
-        if (a->type == EXPR_NDARRAY && b->type != EXPR_NDARRAY)
+    if (a->type == EXPR_NDARRAY && b->type != EXPR_NDARRAY) {
+        if (pack_any_created()) tmp_b = dot_pack_operand(b);
+    } else if (b->type == EXPR_NDARRAY && a->type != EXPR_NDARRAY) {
+        if (pack_any_created()) tmp_a = dot_pack_operand(a);
+    } else if (a->type != EXPR_NDARRAY && b->type != EXPR_NDARRAY) {
+        /* NEITHER operand is packed, which is every product of matrices small
+         * enough to sit below the packing threshold. A 6x6 is 36 elements, so
+         * `m . m` on one ran the Times/Plus-per-element loop: 216 symbolic
+         * multiplies per product, 334 ms over 10000 repeats against 3.8 ms for
+         * the same product in numpy.
+         *
+         * Deliberately NOT behind pack_any_created(). That guard spares a
+         * session which never packs anything from paying a probe, but here
+         * nothing has been packed BY DEFINITION -- a session doing small-matrix
+         * algebra never trips it, so the guard would permanently disable the
+         * very path it is meant to protect. Declining is still O(1): pack_force's
+         * sniff bails at the first element that is not a machine number, so a
+         * symbolic Dot costs one pointer test.
+         *
+         * Both operands must pack or neither is used, so a mixed machine/exact
+         * pair keeps the exact path and the exact answer that goes with it. */
+        tmp_a = dot_pack_operand(a);
+        if (tmp_a) {
             tmp_b = dot_pack_operand(b);
-        else if (b->type == EXPR_NDARRAY && a->type != EXPR_NDARRAY)
-            tmp_a = dot_pack_operand(a);
+            if (!tmp_b) { expr_free(tmp_a); tmp_a = NULL; }
+        }
     }
     Expr* fa = tmp_a ? tmp_a : a;
     Expr* fb = tmp_b ? tmp_b : b;


### PR DESCRIPTION
## Summary

`dot2` already packs a plain List operand so a product can take the buffer path — but only when the **other** operand is already an `NDArray`:

```c
if (a->type == EXPR_NDARRAY && b->type != EXPR_NDARRAY)      tmp_b = dot_pack_operand(b);
else if (b->type == EXPR_NDARRAY && a->type != EXPR_NDARRAY) tmp_a = dot_pack_operand(a);
```

When **neither** is packed — which is every product of matrices small enough to sit below the packing threshold — nothing was packed and the Times/Plus-per-element loop ran: 216 symbolic multiplies per 6×6 product.

| case | before | after |
|---|---|---|
| `m6 . m6`, 6×6 × 10000 | 334 ms | **7.8 ms** (43×) |

This is the row [#45](https://github.com/stblake/mathilda/pull/45) explicitly left undone — `Dot` has no `linalg_call_has_ndarray` guard and reaches its buffers by this different route.

## Why the new branch is not behind `pack_any_created()`

That guard spares a session which never packs anything from paying a probe. But in this branch nothing has been packed **by definition** — a session doing small-matrix algebra never trips it, so the guard would permanently disable the very path it is meant to protect.

Declining is still O(1): `pack_force`'s sniff bails at the first element that is not a machine number, so a symbolic `Dot` costs one pointer test.

## Exact input keeps the exact path

Both operands must pack or neither is used, so a mixed machine/exact pair is left alone rather than half-converted.

Verified across input kinds:

| input | result |
|---|---|
| machine `Total[Flatten[m6.m6]]` | 566.713 — equals the exact computation numericalised |
| `(ex.ex)[[1,1]]` exact | `232169/3600`, head `Rational` |
| symbolic `{{a,b},{c,d}} . IdentityMatrix` | unchanged |
| mixed exact/machine | `{{1.5, 3.0}, {4.5, 6.0}}` |
| `{1.,2.,3.} . {4.,5.,6.}` | `32.` |
| matrix · vector | `{7.0, 12.0, 16.3333}` |

## Testing

- `tests/test_linalg.c` passes.
- Benchmark check value for `Dot 6x6 x 6x6 x 10000` is unchanged (5667128).