### PR TITLE
Advance loop iterators without going through the evaluator

### DIFF
--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -1557,3 +1557,36 @@ whole point of interval arithmetic. v0.032.
   wrong answer before the fix.
 
 Leak-clean (zero valgrind delta); `check-c99` clean; compiles with `USE_MPFR=0`.
+
+## Do / Table: advance the iterator without the evaluator (perf)
+
+A range loop advanced its iterator by building `Plus[curr, step]` and calling
+`evaluate()` on it — three `Expr` allocations plus a full evaluator dispatch per
+step, to compute `i+1`. That was almost the whole cost of a loop:
+
+| case | before | after |
+|---|---|---|
+| `Do[Null, {i, 200000}]` | 0.0256 s | 0.0034 s (7.5×) |
+| `Table[i, {i, 100000}]` | 0.0155 s | 0.0038 s (4.1×) |
+| `Do[Sin[N[i]], {i, 100000}]` | 0.0264 s | 0.0142 s (1.9×) |
+| `Table[i*1.0, {i, 100000}]` | 0.0268 s | 0.0142 s (1.9×) |
+| `Table[Sin[N[i]], {i, 100000}]` | 0.0275 s | 0.0176 s (1.6×) |
+
+New `iter_step_add` (`iter.c`, declared in `iter.h`) adds machine Integer or
+machine Real pairs directly and returns NULL for everything else — BigInt,
+Rational, MPFR, a symbolic step, or an integer sum that would overflow — so
+those keep the evaluator path and bit-identical values. Used at both advance
+sites in `builtin_do` (normal and `Continue`) and in `Table`'s.
+
+Exactness is unchanged: `Table[i, {i, 0, 1, 1/3}]` still yields
+`{0, 1/3, 2/3, 1}` with Rational heads, real steps stay Real,
+`Sum[1/i, {i, 1, 5}]` is still `137/60`, `Product[i, {i, 1, 6}]` still `720`,
+and `Continue`/`Break`/`Return` and nested loops behave as before.
+
+**Unrelated pre-existing bug found while testing:**
+`Table[i, {i, 9223372036854775805, 9223372036854775807}]` returns 1,000,001
+elements instead of 3 — on clean `main` too, verified by stashing this change.
+The termination test is a `double` (`val`) that cannot represent the int64
+boundary, and the refresh block handles only Integer, Real and Rational, so
+once `curr_e` promotes to BigInt `val` freezes. The fix belongs with the
+termination test, not the advance.

--- a/src/iter.c
+++ b/src/iter.c
@@ -46,6 +46,7 @@
 #include "arithmetic.h"
 #include "sym_names.h"
 #include "assoc.h"
+#include "checked_int.h"
 #include "numloop.h"
 #include <string.h>
 #include <stdlib.h>
@@ -182,6 +183,31 @@ bool iter_spec_resolve_numeric(const IterSpec* s, bool allow_inf,
 
     if (*di_val == 0) return false;        /* zero step never terminates */
     return true;
+}
+
+/* curr + step for a machine-numeric iterator, without going through the
+ * evaluator.
+ *
+ * A range loop advanced its iterator by building Plus[curr, step] and calling
+ * evaluate() on it -- three Expr allocations and a full evaluator dispatch per
+ * step, to compute i+1. Isolated measurement on `Do[Null, {i, 200000}]`:
+ * 0.0251 s with the evaluator, 0.0034 s with the add below. 7.3x of the whole
+ * loop, and the same cost is paid by Table, Sum and Product.
+ *
+ * Declines (NULL) for BigInt, Rational, MPFR or a symbolic step, so those keep
+ * the evaluator path and bit-identical values. An integer sum that would
+ * overflow also declines, leaving BigInt promotion to that path. */
+Expr* iter_step_add(const Expr* curr, const Expr* step) {
+    if (curr->type == EXPR_INTEGER && step->type == EXPR_INTEGER) {
+        int64_t sum;
+        /* ci_add_i64 returns TRUE on overflow (it is __builtin_add_overflow),
+         * so a true result is the decline. */
+        if (ci_add_i64(curr->data.integer, step->data.integer, &sum)) return NULL;
+        return expr_new_integer(sum);
+    }
+    if (curr->type == EXPR_REAL && step->type == EXPR_REAL)
+        return expr_new_real(curr->data.real + step->data.real);
+    return NULL;
 }
 
 Rule* iter_spec_shadow(Expr* var) {
@@ -452,10 +478,13 @@ Expr* builtin_do(Expr* res) {
             if (f == ITER_FLOW_CONTINUE)   {
                 /* Still advance the iterator before re-testing the loop. */
                 expr_free(eval_expr);
-                Expr* next_args[2] = { expr_copy(curr_e), expr_copy(di_e) };
-                Expr* next_expr = expr_new_function(expr_new_symbol(SYM_Plus), next_args, 2);
-                Expr* next_e = evaluate(next_expr);
-                expr_free(next_expr);
+                Expr* next_e = iter_step_add(curr_e, di_e);
+                if (!next_e) {
+                    Expr* next_args[2] = { expr_copy(curr_e), expr_copy(di_e) };
+                    Expr* next_expr = expr_new_function(expr_new_symbol(SYM_Plus), next_args, 2);
+                    next_e = evaluate(next_expr);
+                    expr_free(next_expr);
+                }
                 expr_free(curr_e);
                 curr_e = next_e;
                 if (!is_real) {
@@ -471,10 +500,13 @@ Expr* builtin_do(Expr* res) {
             expr_free(eval_expr);
 
             /* Normal end-of-iteration: step curr_e and val forward. */
-            Expr* next_args[2] = { expr_copy(curr_e), expr_copy(di_e) };
-            Expr* next_expr = expr_new_function(expr_new_symbol(SYM_Plus), next_args, 2);
-            Expr* next_e = evaluate(next_expr);
-            expr_free(next_expr);
+            Expr* next_e = iter_step_add(curr_e, di_e);
+            if (!next_e) {
+                Expr* next_args[2] = { expr_copy(curr_e), expr_copy(di_e) };
+                Expr* next_expr = expr_new_function(expr_new_symbol(SYM_Plus), next_args, 2);
+                next_e = evaluate(next_expr);
+                expr_free(next_expr);
+            }
             expr_free(curr_e);
             curr_e = next_e;
 

--- a/src/iter.h
+++ b/src/iter.h
@@ -73,4 +73,15 @@ bool iter_spec_resolve_numeric(const IterSpec* s, bool allow_inf,
 Rule* iter_spec_shadow(Expr* var);
 void  iter_spec_restore(Expr* var, Rule* saved_own);
 
+/* curr + step for a machine-numeric iterator, without going through the
+ * evaluator. Advancing by building Plus[curr, step] and calling evaluate() costs
+ * three Expr allocations and a full evaluator dispatch per step, to compute i+1;
+ * on `Do[Null, {i, 200000}]` that was 0.0251 s against 0.0034 s for the add.
+ *
+ * Returns NULL -- meaning "use the evaluator" -- for BigInt, Rational, MPFR or a
+ * symbolic step, so those keep bit-identical values, and for an integer sum that
+ * would overflow, leaving BigInt promotion to that path. Borrows both operands;
+ * the result is owned by the caller. */
+Expr* iter_step_add(const Expr* curr, const Expr* step);
+
 #endif

--- a/src/list/table.c
+++ b/src/list/table.c
@@ -1,6 +1,7 @@
 #include "list_common.h"
 #include "table.h"
 #include "compile/autocompile.h"
+#include "iter.h"
 #include "../pack.h"
 
 Expr* builtin_table(Expr* res) {
@@ -148,10 +149,13 @@ Expr* builtin_table(Expr* res) {
             results[results_count++] = eval_expr;
 
             if (!ac) {   /* advance the exact running value (unused when compiling) */
-                Expr* next_args[2] = { expr_copy(curr_e), expr_copy(di_e) };
-                Expr* next_expr = expr_new_function(expr_new_symbol(SYM_Plus), next_args, 2);
-                Expr* next_e = evaluate(next_expr);
-                expr_free(next_expr);
+                Expr* next_e = iter_step_add(curr_e, di_e);
+                if (!next_e) {
+                    Expr* next_args[2] = { expr_copy(curr_e), expr_copy(di_e) };
+                    Expr* next_expr = expr_new_function(expr_new_symbol(SYM_Plus), next_args, 2);
+                    next_e = evaluate(next_expr);
+                    expr_free(next_expr);
+                }
                 expr_free(curr_e);
                 curr_e = next_e;
             }


### PR DESCRIPTION
## Summary

A range loop stepped its iterator by building `Plus[curr, step]` and calling `evaluate()` on it — **three `Expr` allocations plus a full evaluator dispatch per iteration**, to compute `i+1`. On `Do[Null, {i, 200000}]` that was 0.0251 s of the 0.0256 s the whole loop took.

| case | before | after |
|---|---|---|
| `Do[Null, {i, 200000}]` | 0.0256 s | **0.0034 s** (7.5×) |
| `Table[i, {i, 100000}]` | 0.0155 s | **0.0038 s** (4.1×) |
| `Do[Sin[N[i]], {i, 100000}]` | 0.0264 s | 0.0142 s (1.9×) |
| `Table[i*1.0, {i, 100000}]` | 0.0268 s | 0.0142 s (1.9×) |
| `Table[Sin[N[i]], {i, 100000}]` | 0.0275 s | 0.0176 s (1.6×) |

## Changes

`iter_step_add` (in `iter.c`, declared in `iter.h`) adds machine Integer or machine Real pairs directly. It returns NULL — meaning "use the evaluator" — for BigInt, Rational, MPFR, a symbolic step, and for an integer sum that would overflow, so BigInt promotion still happens on the path that has always done it.

Wired into both advance sites in `builtin_do` (the normal path and the `Continue` path) and into `Table`'s.

## Exactness

This is the risk with a change like this, so it was checked explicitly rather than assumed:

| input | result |
|---|---|
| `Table[i, {i, 0, 1, 1/3}]` | `{0, 1/3, 2/3, 1}`, heads `{Integer, Rational, Rational, Integer}` |
| `Table[i, {i, 0., 1., 0.25}]` | `{0., 0.25, 0.5, 0.75, 1.}` |
| `Table[i, {i, 5, 1, -1}]` | `{5, 4, 3, 2, 1}` |
| `Table[i, {i, 1, 2, 0.5}]` | `{1., 1.5, 2.}` |
| `Sum[1/i, {i, 1, 5}]` | `137/60` |
| `Product[i, {i, 1, 6}]` | `720` |
| `Sum[i, {i, 0, 1, 1/4}]` | `5/2` |
| `Do` accumulate / `Continue` / `Break` / `Return` | 5050 / 6 / 6 / 300 |
| nested `Table` | `{{1,2,3},{2,4,6},{3,6,9}}` |

## Testing

`iter_tests`, `eval_tests`, `regression_tests`, `sum_tests` (64), `product_tests` (201) all pass. `ctest -R "list|table|iter|eval|regression|range|numloop|compile"` has one failure, `factorlist_tests`, which reproduces identically on clean `main`. `make check-c99` clean.

## A separate pre-existing bug this surfaced

`Table[i, {i, 9223372036854775805, 9223372036854775807}]` returns **1,000,001 elements instead of 3** — on clean `main` as well, verified by stashing this change and rebuilding.

The termination test is a `double` (`val`) that cannot represent the int64 boundary, and the `val` refresh handles only Integer, Real and Rational — so once `curr_e` promotes to BigInt, `val` freezes and the loop runs to a cap. Untouched here, since the fix belongs with the termination test rather than the advance, but it deserves its own issue.