### PR TITLE
Make the Clip benchmark row like-for-like, and speed up exact-bounds lists

### DIFF
--- a/benchmarks/27-elementwise-binary/elementwise_binary.m
+++ b/benchmarks/27-elementwise-binary/elementwise_binary.m
@@ -31,10 +31,20 @@ bench["MapThread[Max] over 4x10^6", MapThread[Max, {a, b}];];
 check["MapThread[Max] over 4x10^6",
   Total[MapThread[Max, {{1, 5, 3}, {4, 2, 6}}]]];
 
-(* Clip is the same compare-and-select against constants rather than an array. *)
-bench["Clip to [0.25, 0.75] over 4x10^6", Clip[a, {1/4, 3/4}];];
+(* Clip is the same compare-and-select against constants rather than an array.
+   The bounds are MACHINE REALS, deliberately. Written as the exact {1/4, 3/4}
+   this row measured something else entirely: an exact bound is preserved at
+   every clipped position, so Clip[reals, {1/4,3/4}] returns a MIXED list --
+   {1/4, 0.5, 3/4}, Rationals intact -- which by definition cannot be a packed
+   buffer, while the numpy column clips float64 to float64. That is the same
+   exact-vs-float64 mismatch experiment 20 documents for Fit, and it cost 700x:
+   0.193 s against 0.000256 s for the identical clamp with {0.25, 0.75}, where
+   Mathilda is ~3.7x FASTER than numpy. The exact-bounds cost is real but it is
+   the price of exactness, not a kernel defect, and it is not what this
+   experiment measures. *)
+bench["Clip to [0.25, 0.75] over 4x10^6", Clip[a, {0.25, 0.75}];];
 check["Clip to [0.25, 0.75] over 4x10^6",
-  Round[10^6 N[Total[Clip[{0., 1/2, 1.}, {1/4, 3/4}]]]]];
+  Round[10^6 N[Total[Clip[{0., 1/2, 1.}, {0.25, 0.75}]]]]];
 
 (* A three-operand expression: tests whether temporaries are avoided. *)
 bench["a b + a over 4x10^6", a b + a;];

--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -1557,3 +1557,44 @@ whole point of interval arithmetic. v0.032.
   wrong answer before the fix.
 
 Leak-clean (zero valgrind delta); `check-c99` clean; compiles with `USE_MPFR=0`.
+
+## Clip: a like-for-like benchmark row, and a faster exact-bounds list path
+
+`benchmarks/` experiment 27 reported `Clip` over 4×10⁶ elements at 587× behind
+numpy. The row was written `Clip[a, {1/4, 3/4}]` — **exact Rational bounds**.
+
+An exact bound is preserved at every clipped position, so
+`Clip[{0.1, 0.5, 0.9}, {1/4, 3/4}]` returns `{1/4, 0.5, 3/4}` with the Rationals
+intact, not `{0.25, 0.5, 0.75}`. That is correct and matches Mathematica — and
+it means the result is a MIXED exact/inexact list, which by definition cannot be
+a packed buffer, while the numpy column clips float64 to float64. Same
+exact-vs-float64 mismatch that experiment 20 already documents for `Fit`.
+
+Written like-for-like the row inverts completely:
+
+| bounds | Mathilda | Mathematica | Python | vs best |
+|---|---|---|---|---|
+| `{1/4, 3/4}` exact | 193 ms | — | — | 587× behind |
+| `{0.25, 0.75}` machine | **0.257 ms** | 2.1 ms | 0.980 ms | **0.26×** |
+
+So Mathilda is ~3.8× faster than numpy and ~8× faster than Mathematica on the
+clamp itself. The row now uses machine bounds; the exact-bounds cost is recorded
+in a comment there rather than left as a permanently misleading number.
+
+Separately, `builtin_clip`'s list-threading path gained a fast path for
+`Clip[reals, {lo, hi}]` with finite real bounds: it compares in C and emits
+either the element or a copy of the bound, instead of building a whole
+`Clip[x_i, {lo,hi}]` call per element — deep-copying the bounds list each time —
+and running the evaluator on it. On 4×10⁶ plain-list elements with exact bounds,
+0.121 s → 0.037 s (3.3×).
+
+Deliberately narrow: two-argument form only, `EXPR_REAL` elements only (an exact
+element could compare differently against a rational bound once both are
+doubles), and finite real bounds only. Infinity, complex, symbolic bounds and
+the `{vmin, vmax}` form all fall through to the general path. Semantics verified
+unchanged, including the Rational-preserving case above.
+
+The packed path (`ndstruct_clip`) with exact bounds is unchanged: its cost is
+4×10⁶ boxed Exprs, which the mixed result genuinely requires. Building that list
+directly instead of materialising and re-evaluating was measured at 3% and not
+worth the code.

--- a/src/core.c
+++ b/src/core.c
@@ -1635,6 +1635,58 @@ Expr* builtin_clip(Expr* res) {
         && x->data.function.head->data.symbol.name == SYM_List) {
         size_t n = x->data.function.arg_count;
         Expr** out = (n > 0) ? malloc(sizeof(Expr*) * n) : NULL;
+
+        /* Fast path for the overwhelmingly common shape: Clip[reals, {lo, hi}]
+         * with finite real bounds. The general loop below builds a whole
+         * Clip[x_i, {lo,hi}] call per element -- deep-copying the bounds List
+         * for every one -- and runs the evaluator on it. Over 4x10^6 elements
+         * that is the difference between 0.12 s and machine-speed, and the
+         * benchmark's own row uses EXACT bounds {1/4, 3/4}, which is precisely
+         * the case that cannot reach the packed ndstruct_clip path above.
+         *
+         * Semantics are preserved exactly, including the part that makes the
+         * buffer path unavailable: a clamped element becomes a COPY OF THE
+         * BOUND, so Clip[{0.1,0.5,0.9},{1/4,3/4}] still returns
+         * {1/4, 0.5, 3/4} with the Rationals intact, not {0.25, 0.5, 0.75}.
+         *
+         * Deliberately narrow. Only argc == 2 (no vmin/vmax replacements), only
+         * EXPR_REAL elements (an exact element could compare differently
+         * against a rational bound once both are doubles), and only bounds that
+         * are finite reals -- Infinity, complex and symbolic bounds all fall
+         * through to the general path, which handles them. */
+        if (argc == 2 && n > 0) {
+            Expr* iv = res->data.function.args[1];
+            double lo, hi;
+            if (iv->type == EXPR_FUNCTION
+                && iv->data.function.head->type == EXPR_SYMBOL
+                && iv->data.function.head->data.symbol.name == SYM_List
+                && iv->data.function.arg_count == 2
+                && clip_classify_infinity(iv->data.function.args[0]) == 0
+                && clip_classify_infinity(iv->data.function.args[1]) == 0
+                && clip_to_double_value(iv->data.function.args[0], &lo)
+                && clip_to_double_value(iv->data.function.args[1], &hi)
+                && lo <= hi) {
+                Expr* lo_e = iv->data.function.args[0];
+                Expr* hi_e = iv->data.function.args[1];
+                size_t i = 0;
+                for (; i < n; i++) {
+                    Expr* el = x->data.function.args[i];
+                    if (el->type != EXPR_REAL) break;      /* exact: general path */
+                    double v = el->data.real;
+                    out[i] = (v < lo) ? expr_copy(lo_e)
+                           : (v > hi) ? expr_copy(hi_e)
+                                      : expr_copy(el);
+                }
+                if (i == n) {
+                    Expr* fast = expr_new_function(expr_new_symbol(SYM_List), out, n);
+                    free(out);
+                    return fast;
+                }
+                /* Bailed part-way: discard and let the general loop redo it. */
+                for (size_t k = 0; k < i; k++) expr_free(out[k]);
+            }
+        }
+
         for (size_t i = 0; i < n; i++) {
             Expr** call_args = malloc(sizeof(Expr*) * argc);
             call_args[0] = expr_copy(x->data.function.args[i]);


### PR DESCRIPTION
## The row was measuring exactness, not clamping

Experiment 27 reported `Clip` over 4×10⁶ elements at **587× behind numpy**. The row was written `Clip[a, {1/4, 3/4}]` — **exact Rational bounds**.

An exact bound is preserved at every clipped position:

```
Clip[{0.1, 0.5, 0.9}, {1/4, 3/4}]  ->  {1/4, 0.5, 3/4}   heads {Rational, Real, Rational}
Clip[{0.1, 0.5, 0.9}, {0.25, 0.75}] ->  {0.25, 0.5, 0.75} heads {Real, Real, Real}
```

That is correct, and matches Mathematica. But it means the result is a **mixed exact/inexact list**, which by definition cannot be a packed buffer — while the numpy column clips float64 to float64. It is the same exact-vs-float64 mismatch that experiment 20's own comment documents for `Fit` ("two different problems, and the first run of this experiment reported 239000x because of it, not because of any defect").

Written like-for-like, the row inverts:

| bounds | Mathilda | Mathematica | Python | vs best |
|---|---|---|---|---|
| `{1/4, 3/4}` exact | 193 ms | — | — | 587× behind |
| `{0.25, 0.75}` machine | **0.257 ms** | 2.1 ms | 0.980 ms | **0.26×** |

Mathilda is ~3.8× faster than numpy and ~8× faster than Mathematica on the clamp itself. The row now uses machine bounds, with the exact-bounds cost recorded in a comment rather than left as a permanently misleading number. The label is unchanged, so there is no `.m`/`.py` drift.

## A real, smaller speedup for the case it was exercising

`builtin_clip`'s list-threading path built an entire `Clip[x_i, {lo,hi}]` call per element — deep-copying the bounds list every time — and ran the evaluator on it. It now compares in C and emits either the element or a copy of the bound.

**4×10⁶ plain-list elements with exact bounds: 0.121 s → 0.037 s (3.3×)**, with the Rational-preserving semantics above intact.

Deliberately narrow: two-argument form only, `EXPR_REAL` elements only (an exact element could compare differently against a rational bound once both are doubles), finite real bounds only. `Infinity`, complex, symbolic bounds and the `{vmin, vmax}` form all fall through to the general path.

## What I did not change

The packed path (`ndstruct_clip`) with exact bounds. Its cost is 4×10⁶ boxed `Expr`s, which the mixed result genuinely requires — that is a floor, not a defect. I did implement building the mixed list straight from the buffer instead of materialising it and re-evaluating; it measured **3%**, so I reverted it rather than add code for noise.

## Testing

`clip_tests` passes. `core_tests` fails identically on clean `main` (same `test_quotient` assertion on `Complex[6, -6]`), verified by stashing and rebuilding. Experiment 27 re-run: 0 check disagreements, the Clip row moves 587.6× → 0.26×.