### PR TITLE
Nearest[list, x]: the closest element(s), with all ties returned

### DIFF
--- a/docs/spec/builtins/lists-and-iteration.md
+++ b/docs/spec/builtins/lists-and-iteration.md
@@ -352,3 +352,36 @@ In[6]:= Riffle[f[a, b], x]
 Out[6]= f[a, x, b]
 ```
 
+## Nearest
+Gives the element of a list closest to a target value.
+- `Nearest[list, x]`: gives the element of `list` closest to `x`, as a list.
+
+**Features**:
+- `Protected`.
+- Distance is `Abs[element - x]`, so a complex element uses its modulus.
+- **All** elements tied at the minimum distance are returned, in their original
+  order: `Nearest[{1, 5, 10}, 3]` gives `{1, 5}`, not `{1}`.
+- Distances are compared by numeric value, so exact and inexact distances of
+  equal value tie: `Nearest[{0, 2.0}, 1]` gives `{0, 2.0}`.
+- An empty list gives `{}`.
+- Returns unevaluated unless every distance is a real number. A symbolic element
+  or target leaves the expression unchanged rather than being dropped from the
+  result — unlike
+  [`MinimalBy`](functional-programming.md#maximalby-minimalby), which orders
+  symbolic keys after all numbers and so silently omits them.
+- A rational with a bigint component declines, because `Abs` does not evaluate
+  one: `Nearest[{1/10^25, 1}, 0]` stays unevaluated.
+- Only the two-argument form is implemented. The `n`-nearest, radius, rule, and
+  all-pairs forms, the `NearestTo` operator form, and the `DistanceFunction`
+  option are not yet available.
+
+```mathematica
+In[1]:= Nearest[{1, 5, 10}, 3]
+Out[1]= {1, 5}
+
+In[2]:= Nearest[{10, 20, 30}, 100]
+Out[2]= {30}
+
+In[3]:= Nearest[{1, a, 3}, 2]
+Out[3]= Nearest[{1, a, 3}, 2]
+```

--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -2629,7 +2629,18 @@ path are filed separately. A packed list is materialised on the way in, since
 `Nearest` is not on `pack.c`'s `AWARE` list; a visible `NDArray` argument is not
 a `List` and stays unevaluated rather than being silently truncated.
 
+Distances that differ in exactness are compared as exact rationals rather than
+by subtracting. Subtraction widens the pair to a double and loses the exact
+operand, which made the comparator **intransitive** with plain int64 values: for
+`a = 2^60`, `b = 2.0^60`, `c = 2^60 + 1`, both `a - b` and `c - b` are `0.0`
+while `a - c` is `-1`, so `a == b`, `c == b` and `a < c` all held at once. An
+intransitive comparator feeding a sort gives order-dependent output. A double is
+exactly a rational, so lifting both sides with `mpq` is exact and total. The
+semantics are pinned against Mathematica, which agrees on both halves: `1` and
+`1.0` tie (`1.0` lifts to exactly `1`), while `0.1` and `1/10` do not —
+`Nearest[{0.9, 11/10}, 1]` is `{0.9}` there too.
+
 New: `src/list/nearest.{c,h}`. Registered in `src/list/list_init.c` with
-`Protected`. 22 acceptance rows in `tests/test_list.c::test_nearest`; leak-free
+`Protected`. 33 acceptance rows in `tests/test_list.c::test_nearest`; leak-free
 under a differential `leaks` run (zero leaked bytes at 200 and 20 000
 iterations across the success, gate-bail, exact-rational and empty paths).

--- a/docs/spec/changelog/2026-08-03.md
+++ b/docs/spec/changelog/2026-08-03.md
@@ -2572,3 +2572,64 @@ matter:
 `pack_offer` keeps the usual element threshold, so matrices too small to pack stay
 on the exact path and return bit-identical results. `tests/test_fit.c` and
 `tests/test_linalg.c` pass unchanged.
+
+## Feature: `Nearest[list, x]` (2026-08-07)
+
+The two-argument `Nearest` gives the element(s) of `list` at minimum
+`Abs[element - x]`, as a `List` in original order.
+
+All tied elements are returned: `Nearest[{1, 5, 10}, 3]` is `{1, 5}`, not `{1}`.
+The implementation follows `MinimalBy`'s two-pass shape (`src/sort.c:663-716`)
+— find the minimum, then collect every distance equal to it — rather than the
+`RankedMin` quickselect, whose comparator carries an original-index tiebreak
+(`src/sort.c:932`) that exists to make ties impossible and would therefore
+return a single element. Input order among ties falls out of the ascending
+collect pass; no tie logic was written.
+
+Distance composes the existing `internal_subtract` and `internal_abs`
+(`src/internal.h:121`, `:83`) as `comparisons.c:313-314` already does; no
+distance helper was added. Because `Abs` of a complex difference is its modulus,
+`Nearest[{3 + 4 I, 1}, 0]` gives `{1}` with no extra code.
+
+Distances are ordered by **numeric value**, not by `expr_compare`. Canonical
+order is wrong here in both directions, and each direction breaks a documented
+guarantee. It settles a value tie between different `ExprType`s on the type enum
+(`src/sort.c:376`), so `Nearest[{0, 2.0}, 1]` would answer `{0}` — distances `1`
+and `1.0` are equal but `Integer` sorts before `Real` — silently dropping a tied
+element from the one function whose contract is to return them all. And for
+atoms that are not both integer-like it compares `get_numeric_value()` doubles
+(`src/sort.c:372-377`), so `Nearest[{1/3, 1/3 + 1/10^18}, 0]` would report a tie
+between distances that differ exactly. Subtracting instead is exact where it
+must be and inexact only where the input already was: `1 - 1.0` is `0.0`, a
+genuine tie, while `1/3 - (1/3 + 1/10^18)` is the exact `Rational[-1, 10^18]`.
+`nearest_sign` reads the sign of the difference and reports *undecidable*
+separately from *zero*, which `expr_numeric_sign` (`src/arithmetic.c`) cannot —
+it returns a bare `0` for both, and recognises neither `MPFR` nor a
+bigint-component `Rational`.
+
+One known limitation, pinned by a test row rather than left silent: a rational
+with a bigint component declines. The cause is not in `Nearest` — `builtin_abs`
+does not evaluate one (`Abs[1/1000]` is `1/1000`, `Abs[1/10^25]` is
+`Abs[1/10^25]`, and `Sign` has the same gap), so the distance arrives as an
+unevaluated `Abs[...]` and the numeric gate rejects it. Fixing that belongs in
+`builtin_abs`, where it would benefit every caller.
+
+`Nearest` diverges from `MinimalBy` in one respect, deliberately: every distance
+must be a real number, or the call stays unevaluated. `MinimalBy[{1, a, 3},
+Abs[# - 2] &]` answers `{1, 3}`, dropping the symbolic element because
+`expr_compare` orders symbols after all numbers (`src/sort.c:379-380`) — a
+plausible wrong answer. Gating on the distance rather than the element covers a
+symbolic element, a symbolic target, and a non-real complex in one check. A
+symbolic *real* such as `Pi` is also rejected rather than numericalized;
+widening that to match `ranked_numeric_key` is a follow-up.
+
+Only the two-argument form lands here. The `n`-nearest, radius, rule, all-pairs,
+and `NearestTo` operator forms, the `DistanceFunction` option, and a packed fast
+path are filed separately. A packed list is materialised on the way in, since
+`Nearest` is not on `pack.c`'s `AWARE` list; a visible `NDArray` argument is not
+a `List` and stays unevaluated rather than being silently truncated.
+
+New: `src/list/nearest.{c,h}`. Registered in `src/list/list_init.c` with
+`Protected`. 22 acceptance rows in `tests/test_list.c::test_nearest`; leak-free
+under a differential `leaks` run (zero leaked bytes at 200 and 20 000
+iterations across the success, gate-bail, exact-rational and empty paths).

--- a/src/list/list.h
+++ b/src/list/list.h
@@ -35,6 +35,7 @@
 #include "listpredicates.h"
 #include "matrixq.h"
 #include "minmax.h"
+#include "nearest.h"
 #include "join.h"
 #include "subsets.h"
 #include "riffle.h"

--- a/src/list/list_init.c
+++ b/src/list/list_init.c
@@ -87,6 +87,15 @@ void list_init(void) {
     symtab_set_docstring("MinMax",
         "MinMax[list]\n\tGives {Min[list], Max[list]}. Over an association, uses\n"
         "\tthe values.");
+    symtab_add_builtin("Nearest", builtin_nearest);
+    symtab_get_def("Nearest")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("Nearest",
+        "Nearest[list, x]\n\tGives the element of list closest to x, as a list.\n"
+        "\tAll elements tied at the minimum distance Abs[element - x] are\n"
+        "\treturned, in their original order; an empty list gives {}.\n"
+        "\tReturns unevaluated unless every distance is a real number, so a\n"
+        "\tsymbolic element or target leaves the expression unchanged rather\n"
+        "\tthan dropping it from the result.");
     symtab_add_builtin("ListQ", builtin_listq);
     symtab_add_builtin("VectorQ", builtin_vectorq);
     symtab_add_builtin("MatrixQ", builtin_matrixq);

--- a/src/list/nearest.c
+++ b/src/list/nearest.c
@@ -113,6 +113,37 @@ static int nearest_sign(Expr* e, bool* ok) {
     return 0;
 }
 
+/* Lift an exactly-representable real into a canonical mpq. Handles Integer,
+ * BigInt, bigint-component Rational, and -- the point of this helper -- Real,
+ * via mpq_set_d, which is exact: a double IS a rational, m * 2^e.
+ *
+ * Shaped after mod_quot_expr_to_mpq (core.c:2569), which is static there and
+ * has no Real case. */
+static bool nearest_to_mpq(const Expr* e, mpq_t out) {
+    mpq_init(out);
+    if (e->type == EXPR_INTEGER) { mpq_set_si(out, (long)e->data.integer, 1UL); return true; }
+    if (e->type == EXPR_BIGINT)  { mpq_set_z(out, e->data.bigint); return true; }
+    if (e->type == EXPR_REAL) {
+        if (isnan(e->data.real) || isinf(e->data.real)) { mpq_clear(out); return false; }
+        mpq_set_d(out, e->data.real);          /* exact */
+        return true;
+    }
+    if (is_rational_like(e) && e->type == EXPR_FUNCTION) {
+        mpz_t num, den;
+        mpz_init(num); mpz_init(den);
+        expr_to_mpz(e->data.function.args[0], num);
+        expr_to_mpz(e->data.function.args[1], den);
+        if (mpz_sgn(den) == 0) { mpz_clears(num, den, NULL); mpq_clear(out); return false; }
+        mpq_set_num(out, num);
+        mpq_set_den(out, den);
+        mpq_canonicalize(out);
+        mpz_clears(num, den, NULL);
+        return true;
+    }
+    mpq_clear(out);
+    return false;
+}
+
 /* Order two distances by NUMERIC VALUE: -1, 0, +1. Sets *ok false when the
  * comparison cannot be decided.
  *
@@ -138,6 +169,40 @@ static int nearest_cmp(Expr* a, Expr* b, bool* ok) {
         if (isnan(a->data.real) || isnan(b->data.real)) { *ok = false; return 0; }
         return (a->data.real > b->data.real) - (a->data.real < b->data.real);
     }
+    /* MIXED EXACT / INEXACT: compare as exact rationals, never by subtracting.
+     *
+     * Subtraction here loses the exact operand's precision, because
+     * internal_subtract widens the pair to a double. That is not merely
+     * imprecise, it makes the comparator INTRANSITIVE, and an intransitive
+     * comparator feeding a sort produces order-dependent output. With plain
+     * int64 values:
+     *
+     *     a = 2^60, b = 2.0^60, c = 2^60 + 1
+     *     a - b -> 0.0   so a == b
+     *     c - b -> 0.0   so c == b
+     *     a - c -> -1    so a <  c
+     *
+     * A double is exactly a rational, so lifting both sides with mpq and
+     * comparing is exact and total. It also matches Mathematica on the two
+     * cases that pin the semantics: 1 and 1.0 still tie (1.0 lifts to exactly
+     * 1), while 0.1 and 1/10 no longer do -- and Mathematica's
+     * Nearest[{0.9, 11/10}, 1] is {0.9}, not both. */
+    bool a_exact = (a->type != EXPR_REAL);
+    bool b_exact = (b->type != EXPR_REAL);
+    if (a_exact != b_exact) {
+        mpq_t qa, qb;
+        if (nearest_to_mpq(a, qa)) {
+            if (nearest_to_mpq(b, qb)) {
+                int r = mpq_cmp(qa, qb);
+                mpq_clear(qa); mpq_clear(qb);
+                return (r > 0) - (r < 0);
+            }
+            mpq_clear(qa);
+        }
+        /* Not liftable -- an MPFR operand, or a non-finite Real. Fall through
+         * to the subtraction path, which is what handled these before. */
+    }
+
     Expr* sub_args[2] = { expr_copy(a), expr_copy(b) };
     Expr* diff = eval_and_free(internal_subtract(sub_args, 2));
     int s = nearest_sign(diff, ok);

--- a/src/list/nearest.c
+++ b/src/list/nearest.c
@@ -1,0 +1,222 @@
+/* Nearest[list, x] -- the element(s) of `list` closest to the target `x`.
+ *
+ *   Nearest[{1, 5, 10}, 3]    -> {1, 5}
+ *   Nearest[{10, 20, 30}, 100] -> {30}
+ *   Nearest[{}, 3]             -> {}
+ *
+ * Distance is Abs[element - x], composed from the existing internal_subtract
+ * and internal_abs rather than a bespoke helper, so a complex element uses its
+ * modulus for free: Nearest[{3 + 4 I, 1}, 0] is {1} because the distances are
+ * 5 and 1.
+ *
+ * ALL elements tied at the minimum distance are returned, in their original
+ * order. That requirement is what fixes the algorithm. The obvious neighbour,
+ * RankedMin (sort.c), selects with a quickselect whose comparator carries an
+ * original-index tiebreak (sort.c:932) existing precisely to make ties
+ * IMPOSSIBLE, so that exactly one element can win -- the opposite of what is
+ * needed here. The shape used instead is MinimalBy's (sort.c:663-716): one pass
+ * to find the minimum, a second to collect every distance equal to it. Input
+ * order among ties then falls out of the ascending collect pass, so there is no
+ * tie logic in this file at all.
+ *
+ * Nearest diverges from MinimalBy in exactly one respect, and deliberately.
+ * Every distance must be a real number, or the whole call stays unevaluated.
+ * MinimalBy[{1, a, 3}, Abs[# - 2] &] answers {1, 3}: expr_compare orders
+ * symbols after all numbers (sort.c:379-380), so the symbolic element is never
+ * minimal and silently vanishes from a result that still looks plausible.
+ * Gating on the DISTANCE rather than on the element covers a symbolic element,
+ * a symbolic target, and a non-real complex in a single check. A symbolic real
+ * such as Pi is rejected too -- Abs[Pi - 3] stays as Abs[-3 + Pi] -- rather
+ * than being numericalized the way RankedMin's ranked_numeric_key would.
+ *
+ * Cost: O(n) distance evaluations, O(n) comparisons, O(n) peak extra memory.
+ * The two evaluate passes per element dominate, so this is an interpreter-speed
+ * path and not a buffer path. There is no exact-hit short circuit: a later
+ * element can tie at distance 0, and dropping it would break the tie contract.
+ *
+ * Only the two-argument form lives here. The n-nearest, radius, rule,
+ * all-pairs, and NearestTo operator forms, and the DistanceFunction option, are
+ * separate follow-ups. */
+
+#include "list_common.h"
+#include "internal.h"
+#include "nearest.h"
+
+#include <math.h>       /* isnan -- C99, needs no feature-test macro */
+
+/* Abs[e - x], fully evaluated. Caller owns the result.
+ *
+ * internal_call_impl (internal.c:189-211) consumes the argument array, and when
+ * the builtin declines it returns the UNEVALUATED node rather than NULL -- so a
+ * symbolic operand comes back as Abs[...], which the caller's numeric gate then
+ * rejects. Neither call can yield NULL, so neither needs a null check. The
+ * composition and the eval_and_free wrapping follow comparisons.c:313-314,
+ * which already builds a difference this way for the Equal zero test. */
+static Expr* nearest_distance(Expr* e, Expr* x) {
+    Expr* sub_args[2] = { expr_copy(e), expr_copy(x) };
+    Expr* diff = eval_and_free(internal_subtract(sub_args, 2));
+    Expr* abs_args[1] = { diff };          /* internal_abs takes ownership */
+    return eval_and_free(internal_abs(abs_args, 1));
+}
+
+/* True for a real number this file can order exactly.
+ *
+ * Deliberately NOT list_common.h's is_real_numeric: that routes rationals
+ * through is_rational (arithmetic.c:105-117), which requires int64 numerator
+ * AND denominator, so an ordinary exact input like 1/10^25 -- a
+ * Rational[1, BigInt] -- is rejected and the whole call declines. is_rational_like
+ * (arithmetic.c:125) is the bigint-aware predicate. */
+static bool nearest_is_real_number(Expr* e) {
+    if (!e) return false;
+    if (e->type == EXPR_INTEGER || e->type == EXPR_BIGINT) return true;
+    if (e->type == EXPR_REAL) return !isnan(e->data.real);
+#ifdef USE_MPFR
+    if (e->type == EXPR_MPFR) return !mpfr_nan_p(e->data.mpfr);
+#endif
+    return is_rational_like(e);
+}
+
+/* Sign of a real number: -1, 0, +1. Sets *ok false for anything this file
+ * cannot read a sign from, which the caller turns into an unevaluated result.
+ *
+ * The *ok flag is the whole point. expr_numeric_sign (arithmetic.c) returns a
+ * bare 0 both for "genuinely zero" and for "I do not recognise this", and it
+ * recognises neither MPFR nor a bigint-component Rational -- so using it here
+ * would silently report a tie for two distances it simply could not read. */
+static int nearest_sign(Expr* e, bool* ok) {
+    *ok = true;
+    if (!e) { *ok = false; return 0; }
+    if (e->type == EXPR_INTEGER)
+        return (e->data.integer > 0) - (e->data.integer < 0);
+    if (e->type == EXPR_BIGINT) return mpz_sgn(e->data.bigint);
+    if (e->type == EXPR_REAL) {
+        if (isnan(e->data.real)) { *ok = false; return 0; }
+        return (e->data.real > 0.0) - (e->data.real < 0.0);
+    }
+#ifdef USE_MPFR
+    if (e->type == EXPR_MPFR) {
+        if (mpfr_nan_p(e->data.mpfr)) { *ok = false; return 0; }
+        return mpfr_sgn(e->data.mpfr);
+    }
+#endif
+    /* Rational[num, den], bigint components included. The denominator is
+     * conventionally positive, but both signs are read so a hand-built
+     * Rational with a negative denominator still orders correctly. */
+    if (is_rational_like(e) && e->type == EXPR_FUNCTION) {
+        bool ok_n = true, ok_d = true;
+        int sn = nearest_sign(e->data.function.args[0], &ok_n);
+        int sd = nearest_sign(e->data.function.args[1], &ok_d);
+        if (!ok_n || !ok_d) { *ok = false; return 0; }
+        return sn * sd;
+    }
+    *ok = false;
+    return 0;
+}
+
+/* Order two distances by NUMERIC VALUE: -1, 0, +1. Sets *ok false when the
+ * comparison cannot be decided.
+ *
+ * NOT expr_compare, which is a canonical total order and is wrong here in both
+ * directions. It breaks a value tie between different ExprTypes on the type
+ * enum (sort.c:376), so Nearest[{0, 2.0}, 1] would drop the 2.0 -- distances 1
+ * and 1.0 are equal in value but Integer sorts before Real -- defeating the
+ * all-ties contract this file exists to honour. And for atoms that are not both
+ * integer-like it falls back to comparing get_numeric_value() doubles
+ * (sort.c:372-377), so two exact rationals differing below double resolution
+ * compare equal and a strictly-farther element is reported as tied.
+ *
+ * Subtracting instead is exact where it must be and inexact only where the
+ * input already was: 1 - 1.0 is 0.0 (a real tie, as Mathematica has it), while
+ * 1/3 - (1/3 + 1/10^18) is the exact Rational[-1, 10^18]. */
+static int nearest_cmp(Expr* a, Expr* b, bool* ok) {
+    *ok = true;
+    /* Same-type fast paths for the two common cases, avoiding an allocation and
+     * two evaluator passes per comparison. Both are exact for their type. */
+    if (a->type == EXPR_INTEGER && b->type == EXPR_INTEGER)
+        return (a->data.integer > b->data.integer) - (a->data.integer < b->data.integer);
+    if (a->type == EXPR_REAL && b->type == EXPR_REAL) {
+        if (isnan(a->data.real) || isnan(b->data.real)) { *ok = false; return 0; }
+        return (a->data.real > b->data.real) - (a->data.real < b->data.real);
+    }
+    Expr* sub_args[2] = { expr_copy(a), expr_copy(b) };
+    Expr* diff = eval_and_free(internal_subtract(sub_args, 2));
+    int s = nearest_sign(diff, ok);
+    expr_free(diff);
+    return s;
+}
+
+Expr* builtin_nearest(Expr* res) {
+    if (res->type != EXPR_FUNCTION || res->data.function.arg_count != 2) return NULL;
+
+    Expr* list = res->data.function.args[0];
+    Expr* x    = res->data.function.args[1];
+
+    /* A PACKED list has already been materialised on the way in, because
+     * Nearest is not on pack.c's AWARE list. A VISIBLE NDArray is not, and is
+     * not a List either, so it lands here and stays unevaluated rather than
+     * being silently truncated. Following RankedMin (sort.c:1014) rather than
+     * MinimalBy, which accepts and preserves any head. */
+    if (!is_listq(list)) return NULL;
+
+    size_t n = list->data.function.arg_count;
+    Expr** elem = list->data.function.args;
+
+    /* Empty in, empty out -- checked before the gate, so Nearest[{}, a] is {}
+     * and not unevaluated. Matches MaximalBy (sort.c:684). */
+    if (n == 0) return expr_new_function(expr_new_symbol(SYM_List), NULL, 0);
+
+    Expr** dist = malloc(sizeof(Expr*) * n);
+    if (!dist) return NULL;
+
+    /* One pass to build the distances. A distance that is not a real number
+     * means there is no definite answer: free what we built and decline. */
+    for (size_t i = 0; i < n; i++) {
+        dist[i] = nearest_distance(elem[i], x);
+        if (!nearest_is_real_number(dist[i])) {
+            for (size_t j = 0; j <= i; j++) expr_free(dist[j]);
+            free(dist);
+            return NULL;
+        }
+    }
+
+    /* Two passes over nearest_cmp: find the minimum, then collect every
+     * distance equal to it. An undecidable comparison declines the whole call
+     * rather than guessing a tie. */
+    bool ok = true;
+    size_t best = 0;
+    for (size_t i = 1; i < n && ok; i++)
+        if (nearest_cmp(dist[i], dist[best], &ok) < 0 && ok) best = i;
+
+    Expr** out = ok ? malloc(sizeof(Expr*) * n) : NULL;
+    if (!out) {
+        for (size_t i = 0; i < n; i++) expr_free(dist[i]);
+        free(dist);
+        return NULL;
+    }
+
+    /* Ascending index order is what preserves input order among ties. */
+    size_t nout = 0;
+    for (size_t i = 0; i < n && ok; i++)
+        if (nearest_cmp(dist[i], dist[best], &ok) == 0 && ok)
+            out[nout++] = expr_copy(elem[i]);
+
+    for (size_t i = 0; i < n; i++) expr_free(dist[i]);
+    free(dist);
+
+    if (!ok) {
+        for (size_t i = 0; i < nout; i++) expr_free(out[i]);
+        free(out);
+        return NULL;
+    }
+
+    /* The wrapper is always List. Stated explicitly because the input head is
+     * necessarily List here, but the n-nearest follow-up keeps the same rule. */
+    Expr* head = expr_new_symbol(SYM_List);
+    Expr* result = expr_new_function(head, out, nout);
+    if (!result) {                       /* OOM: expr_new_function took nothing */
+        for (size_t i = 0; i < nout; i++) expr_free(out[i]);
+        expr_free(head);
+    }
+    free(out);
+    return result;
+}

--- a/src/list/nearest.h
+++ b/src/list/nearest.h
@@ -1,0 +1,8 @@
+#ifndef NEAREST_H
+#define NEAREST_H
+
+#include "expr.h"
+
+Expr* builtin_nearest(Expr* res);
+
+#endif /* NEAREST_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -370,6 +370,7 @@ set(COMMON_SRC
     ../src/list/riffle.c
     ../src/list/gather.c
     ../src/list/subdivide.c
+    ../src/list/nearest.c
     ../src/patterns.c
     ../src/patterns.c
     ../src/replace.c

--- a/tests/test_list.c
+++ b/tests/test_list.c
@@ -1037,6 +1037,24 @@ void test_nearest() {
         {"Nearest[{1/10^25, 1}, 0]",
          "Nearest[{1/10000000000000000000000000, 1}, 0]"},
 
+        /* MIXED EXACT / INEXACT DISTANCES are compared as exact rationals,
+         * not by subtracting. Subtraction widens the pair to a double and
+         * loses the exact operand, which made the comparator INTRANSITIVE
+         * with plain int64 values: for a = 2^60, b = 2.0^60, c = 2^60 + 1,
+         * a - b and c - b both gave 0.0 while a - c gave -1, so a == b,
+         * c == b and a < c all held at once. An intransitive comparator
+         * feeding a sort yields order-dependent output.
+         *
+         * A double is exactly a rational, so lifting both sides with mpq is
+         * exact and total. The two rows below pin the semantics against
+         * Mathematica, which agrees on both: 1 and 1.0 tie (1.0 lifts to
+         * exactly 1), 0.1 and 1/10 do not, and Nearest[{0.9, 11/10}, 1] is
+         * {0.9} there too. */
+        {"Nearest[{2^60, 2.0^60}, 2^60]", "{1152921504606846976, 1.15292e+18}"},
+        {"Nearest[{2^60 + 1, 2.0^60}, 2^60]", "{1.15292e+18}"},
+        {"Nearest[{0.9, 11/10}, 1]", "{0.9}"},
+        {"Nearest[{1/10, 0.1}, 0]", "{1/10}"},
+
         /* Arity. The 3-argument n-nearest form is a follow-up and is inert. */
         {"Nearest[{1, 5, 10}]", "Nearest[{1, 5, 10}]"},
         {"Nearest[{1, 5}, 3, 2]", "Nearest[{1, 5}, 3, 2]"},

--- a/tests/test_list.c
+++ b/tests/test_list.c
@@ -962,6 +962,106 @@ void test_subdivide() {
     }
 }
 
+void test_nearest() {
+    struct {
+        const char* input;
+        const char* expected;
+    } tests[] = {
+        /* ALL tied elements are returned, not a single minimum. Both 1 and 5
+         * sit at distance 2 from 3. This is the row the whole design turns on:
+         * a quickselect-style tiebreak (RankedMin's ranked_cmp, sort.c:932)
+         * exists to make ties impossible and would answer {1}. */
+        {"Nearest[{1, 5, 10}, 3]", "{1, 5}"},
+        {"Nearest[{4}, 100]", "{4}"},
+
+        /* Ties come back in INPUT order, not sorted order. */
+        {"Nearest[{5, 1, 10}, 3]", "{5, 1}"},
+        {"Nearest[{-5, 5}, 0]", "{-5, 5}"},
+        /* Exact rational tie: both distances are exactly 1/6. A float-keyed
+         * comparison could miss this. */
+        {"Nearest[{1/3, 2/3}, 1/2]", "{1/3, 2/3}"},
+
+        /* MIXED-TYPE TIES. Distances equal in VALUE but of different ExprType
+         * must still tie. These are the rows that fail if the comparison is
+         * expr_compare: its canonical order breaks a value tie on the type
+         * enum (sort.c:376), so Integer beats Real beats Rational and only one
+         * of the tied elements survives. */
+        {"Nearest[{0, 2.0}, 1]", "{0, 2.0}"},        /* dists 1 and 1.0   */
+        {"Nearest[{3, 1.0}, 2]", "{3, 1.0}"},        /* dists 1 and 1.0   */
+        {"Nearest[{-1, 1.0}, 0]", "{-1, 1.0}"},      /* dists 1 and 1.0   */
+        {"Nearest[{1.5, 5/2}, 2]", "{1.5, 5/2}"},    /* dists 0.5 and 1/2 */
+
+        /* The opposite direction: distances that differ below double
+         * resolution must NOT tie. expr_compare falls back to comparing
+         * get_numeric_value() doubles for atoms that are not both
+         * integer-like (sort.c:372-377), which would report both as nearest. */
+        {"Nearest[{1/3, 1/3 + 1/10^18}, 0]", "{1/3}"},
+
+        /* Bigint elements order exactly. */
+        {"Nearest[{10^25, 1}, 0]", "{1}"},
+        /* Duplicates are distinct by position, as in Subsets. */
+        {"Nearest[{1, 1, 2}, 1]", "{1, 1}"},
+        /* An exact hit does not short-circuit: a later element could still tie
+         * at distance 0, so the collect pass always runs to the end. */
+        {"Nearest[{2, 4, 6}, 4]", "{4}"},
+
+        /* Unique nearest. */
+        {"Nearest[{1, 2}, 1.4]", "{1}"},
+        {"Nearest[{10, 20, 30}, 100]", "{30}"},
+        /* Abs of a complex difference is its modulus, so the complex case
+         * falls out of the composition: 5 versus 1. */
+        {"Nearest[{3 + 4 I, 1}, 0]", "{1}"},
+
+        /* Empty in, empty out -- checked before the numeric gate, so a
+         * symbolic target on an empty list is still {}. */
+        {"Nearest[{}, 3]", "{}"},
+        {"Nearest[{}, a]", "{}"},
+
+        /* THE GATE. A non-real distance means no definite answer, so the whole
+         * call stays unevaluated. Note MinimalBy[{1, a, 3}, Abs[# - 2] &] gives
+         * {1, 3} -- expr_compare orders symbols after all numbers, so it drops
+         * the symbolic element and answers anyway. That plausible wrong answer
+         * is what this row exists to prevent. */
+        {"Nearest[{1, a, 3}, 2]", "Nearest[{1, a, 3}, 2]"},
+        {"Nearest[{1, 2, 3}, a]", "Nearest[{1, 2, 3}, a]"},
+        /* A symbolic REAL is rejected too: Abs[Pi - 3] stays as Abs[-3 + Pi].
+         * Numericalizing it (as RankedMin's ranked_numeric_key would) is a
+         * deliberate follow-up, not current behaviour. */
+        {"Nearest[{Pi, 4}, 3]", "Nearest[{Pi, 4}, 3]"},
+        /* A rational with a BIGINT component declines, for a reason that is
+         * not Nearest's: builtin_abs does not evaluate one, so the distance
+         * comes back as an unevaluated Abs[...] and the numeric gate rejects
+         * it. Abs[1/1000] is 1/1000 but Abs[1/10^25] is Abs[1/10^25], and
+         * Sign has the same gap. Pinned here so this row flips the day
+         * builtin_abs is fixed, rather than the limitation going unnoticed. */
+        {"Nearest[{1/10^25, 1}, 0]",
+         "Nearest[{1/10000000000000000000000000, 1}, 0]"},
+
+        /* Arity. The 3-argument n-nearest form is a follow-up and is inert. */
+        {"Nearest[{1, 5, 10}]", "Nearest[{1, 5, 10}]"},
+        {"Nearest[{1, 5}, 3, 2]", "Nearest[{1, 5}, 3, 2]"},
+        {"Nearest[3, 1]", "Nearest[3, 1]"},
+        /* Non-List head follows RankedMin (sort.c:1014), not MinimalBy, which
+         * accepts and preserves any head. */
+        {"Nearest[f[1, 5], 3]", "Nearest[f[1, 5], 3]"},
+        /* A visible NDArray is never materialised by the transparency gate, so
+         * is_listq is the only guard against a silently truncated answer.
+         * Unevaluated is the correct conservative result. */
+        {"Nearest[NDArray[{1., 5., 10.}], 3.]",
+         "Nearest[NDArray[{1.0, 5.0, 10.0}], 3.0]"},
+
+        /* A PACKED list, by contrast, is materialised on the way in because
+         * Nearest is not on pack.c's AWARE list. */
+        {"Nearest[Range[5], 3]", "{3}"},
+
+        {"Attributes[Nearest]", "{Protected}"},
+    };
+
+    for (int i = 0; i < (int)(sizeof(tests) / sizeof(tests[0])); i++) {
+        assert_eval_eq(tests[i].input, tests[i].expected, 0);
+    }
+}
+
 int main() {
     symtab_init();
     core_init();
@@ -1016,6 +1116,7 @@ int main() {
     TEST(test_riffle);
     TEST(test_gather);
     TEST(test_subdivide);
+    TEST(test_nearest);
 
     printf("All list tests passed!\n");
     return 0;


### PR DESCRIPTION
## Summary

Adds the two-argument `Nearest[list, x]` — the element(s) of `list` at minimum `Abs[element - x]`, returned as a `List` in original order, with **all** tied elements included.

`Nearest[{1, 5, 10}, 3]` is `{1, 5}`, not `{1}`.

## Changes

**New:** `src/list/nearest.{c,h}`, registered in `src/list/list_init.c` with `Protected` and a docstring.

**Algorithm** — `MinimalBy`'s two-pass shape (`src/sort.c:663-716`): find the minimum, then collect every distance equal to it. Deliberately *not* the `RankedMin` quickselect, whose comparator carries an original-index tiebreak (`src/sort.c:932`) that exists to make ties impossible and would return a single element. Input order among ties falls out of the ascending collect pass, so there is no tie logic in the file.

**Distance** composes the existing `internal_subtract` and `internal_abs` the way `comparisons.c:313-314` already does; no distance helper was added. Since `Abs` of a complex difference is its modulus, `Nearest[{3 + 4 I, 1}, 0]` is `{1}` with no extra code.

**Distances are ordered by numeric value, not by `expr_compare`.** Canonical order is wrong here in both directions, and each direction breaks the all-ties guarantee:

- It settles a value tie between different `ExprType`s on the type enum (`src/sort.c:376`), so `Nearest[{0, 2.0}, 1]` would answer `{0}` — distances `1` and `1.0` are equal but `Integer` sorts before `Real` — dropping a tied element from the one function whose contract is to return them all.
- For atoms not both integer-like it compares `get_numeric_value()` doubles (`src/sort.c:372-377`), so `Nearest[{1/3, 1/3 + 1/10^18}, 0]` would report a tie between distances that differ exactly.

Subtracting instead is exact where it must be and inexact only where the input already was: `1 - 1.0` is `0.0`, a genuine tie, while `1/3 - (1/3 + 1/10^18)` is the exact `Rational[-1, 10^18]`. `nearest_sign` reports *undecidable* separately from *zero*, which `expr_numeric_sign` cannot — it returns a bare `0` for both and recognises neither `MPFR` nor a bigint-component `Rational`.

**One deliberate divergence from `MinimalBy`:** every distance must be a real number, or the call stays unevaluated. `MinimalBy[{1, a, 3}, Abs[# - 2] &]` answers `{1, 3}`, dropping the symbolic element because `expr_compare` orders symbols after all numbers — a plausible wrong answer. Gating on the distance rather than the element covers a symbolic element, a symbolic target and a non-real complex in one check.

## Known limitations, pinned by test rows rather than left silent

Both flip the day the underlying behaviour changes, so they surface as a table diff:

- A symbolic real such as `Pi` declines rather than being numericalized (`ranked_numeric_key` would).
- A rational with a bigint component declines, for a reason **outside this file**: `builtin_abs` does not evaluate one. `Abs[1/1000]` is `1/1000` but `Abs[1/10^25]` is `Abs[1/10^25]`, and `Sign` has the same gap — so the distance arrives unevaluated and the gate rejects it. Worth fixing in `builtin_abs`, where every caller benefits; not done here to keep this diff to one builtin.

## Scope

Two-argument form only. The `n`-nearest, radius, rule, all-pairs and `NearestTo` operator forms and the `DistanceFunction` option are deliberately excluded.

A packed list is materialised on the way in, since `Nearest` is not on `pack.c`'s `AWARE` list. A visible `NDArray` is not a `List` and stays unevaluated rather than being silently truncated.

## Testing

33 acceptance rows in `tests/test_list.c::test_nearest`, covering ties (input order, mixed exact/inexact, exact rational, duplicates, symmetric), unique-nearest, empty lists, the eight unevaluated-gate cases, packed input and attributes.

- `list_tests` passes; 17 list/array/sort/packing binaries pass with no regression
- `make check-c99`, `make check-packed-aware`, `make check-array-exactness` pass
- Leak-free under a differential `leaks` run: **0 bytes at both 200 and 20 000 iterations** across the success, gate-bail, mixed-type-tie and decline paths
- Every example in the docs verified against the built binary

## Docs

`docs/spec/builtins/lists-and-iteration.md` gains a `## Nearest` entry; `docs/spec/changelog/2026-08-03.md` records the rationale.

## Follow-up commit: exact mixed-exactness comparison

Code review found the distance comparator was **intransitive**, with plain
int64 values — no bigints or rationals needed:

```
a = 2^60, b = 2.0^60, c = 2^60 + 1
a - b -> 0.0   comparator said a == b
c - b -> 0.0   comparator said c == b
a - c -> -1    comparator said a <  c
```

Two distances of differing exactness were ordered by subtracting, and
`internal_subtract` widens the pair to a double, losing the exact operand. So
`Nearest[{2^60 + 1, 2.0^60}, 2^60]` reported a tie between an element at
distance 1 and one at distance 0. An intransitive comparator feeding a sort
gives order-dependent output.

A double is exactly a rational, so lifting both sides into `mpq` is exact and
total. `nearest_to_mpq` is shaped after `mod_quot_expr_to_mpq` (`core.c:2569`),
which is static there and has no `Real` case — that case is the point of it.
MPFR operands and non-finite reals fall through to the previous path.

**One deliberate user-visible change, and Mathematica agrees on both halves:**
`1` and `1.0` still tie (`1.0` lifts to exactly `1`), while `0.1` and `1/10` no
longer do — Mathematica's `Nearest[{0.9, 11/10}, 1]` is `{0.9}`, and now so is
ours. `Nearest[{0, 2.0}, 1]` and `Nearest[{1.5, 5/2}, 2]` still return both.

All 29 original rows passed throughout — none probed a mixed-exactness
comparison near double precision, which is why the table missed it. Four rows
added that do, for 33 total. `make check-c99` passes; leak-free at 20 000
iterations.
