### PR TITLE
Fix list_tests on main: the Nearest bigint-rational pin flips, as it was written to

### DIFF
--- a/tests/test_list.c
+++ b/tests/test_list.c
@@ -1028,14 +1028,19 @@ void test_nearest() {
          * Numericalizing it (as RankedMin's ranked_numeric_key would) is a
          * deliberate follow-up, not current behaviour. */
         {"Nearest[{Pi, 4}, 3]", "Nearest[{Pi, 4}, 3]"},
-        /* A rational with a BIGINT component declines, for a reason that is
-         * not Nearest's: builtin_abs does not evaluate one, so the distance
-         * comes back as an unevaluated Abs[...] and the numeric gate rejects
-         * it. Abs[1/1000] is 1/1000 but Abs[1/10^25] is Abs[1/10^25], and
-         * Sign has the same gap. Pinned here so this row flips the day
-         * builtin_abs is fixed, rather than the limitation going unnoticed. */
-        {"Nearest[{1/10^25, 1}, 0]",
-         "Nearest[{1/10000000000000000000000000, 1}, 0]"},
+        /* A rational with a BIGINT component used to decline, for a reason
+         * that was not Nearest's: builtin_abs did not evaluate one, so the
+         * distance came back as an unevaluated Abs[...] and the numeric gate
+         * rejected it. This row was pinned in the declining state precisely so
+         * that it would flip the day builtin_abs was fixed rather than the
+         * limitation going unnoticed -- and it has: Abs[1/10^25] now evaluates
+         * to 1/10^25, so the distance is a real and the gate admits it.
+         *
+         * The row is kept, now pinning the answer instead of the refusal,
+         * because that is what it was always guarding: 1/10^25 is nearer to 0
+         * than 1 is, and it is returned EXACTLY, with no degradation to a
+         * double along the way. */
+        {"Nearest[{1/10^25, 1}, 0]", "{1/10000000000000000000000000}"},
 
         /* MIXED EXACT / INEXACT DISTANCES are compared as exact rationals,
          * not by subtracting. Subtraction widens the pair to a double and


### PR DESCRIPTION
## Summary

`list_tests` is currently red on `main`. One row in `tests/test_list.c` pinned
`Nearest[{1/10^25, 1}, 0]` as *unevaluated*, and it no longer is.

The refusal was never about `Nearest`. `builtin_abs` did not evaluate a rational
with a bigint component, so the distance came back as an unevaluated `Abs[...]`
and `Nearest`' numeric gate correctly rejected a non-real distance. The row's own
comment said it was pinned in that state so that it *would* flip the day
`builtin_abs` was fixed, rather than letting the limitation go unnoticed.

`builtin_abs` is fixed. `Abs[1/10^25]` is `1/10^25`, and `Sign` agrees on both
signs, so the distance is a real, the gate admits it, and `Nearest` answers.

The row is kept and now pins the answer instead of the refusal, because the
answer is what it was guarding all along: `1/10^25` is nearer to `0` than `1` is,
and it is returned exactly, with no degradation to a double along the way. The
comment records that the gap closed rather than predicting it.

## Changes

- `tests/test_list.c`: the `Nearest[{1/10^25, 1}, 0]` row now expects
  `{1/10000000000000000000000000}`; its comment rewritten to record the closure.

Test-only. No source, build or documentation changes.

## Testing

```
$ ./list_tests
All list tests passed!            (exit 0, 0 FAIL lines)
```

Before this change the same suite aborted:

```
FAIL: Nearest[{1/10^25, 1}, 0]
  Expected: Nearest[{1/10000000000000000000000000, 1}, 0]
  Actual:   {1/10000000000000000000000000}
Assertion failed: (strcmp(str, expected) == 0), test_utils.h line 27
```

Confirmed the new behaviour is right rather than merely different:

```
Abs[1/10^25]               1/10000000000000000000000000
Sign[1/10^25]              1
Sign[-1/10^25]             -1
Nearest[{1/10^25, 1}, 0]   {1/10000000000000000000000000}
```

Checked that nothing else is stale in the same class: this was the only row in
the suite pinning a refusal that came from the `Abs`/`Sign` bigint-rational gap.
The `FindClusters[{1/10^25, 2/10^25, 1}, 2]` row nearby already pinned a real
answer and is unaffected. The old comment's claim that "Sign has the same gap" is
no longer true, so that sentence is gone.

## JIRA Ticket

n/a
