### PR TITLE
MemoryInUse and MaxMemoryUsed

### DIFF
--- a/docs/spec/builtins/expression-information.md
+++ b/docs/spec/builtins/expression-information.md
@@ -1124,3 +1124,59 @@ Gives the number of bytes used internally by Mathilda to store the expression.
 - Uses `sizeof()` in C and measures the internal AST memory allocation boundaries, dynamically capturing sizes of individual strings, symbols, allocated blocks, arrays, and expression structs.
 - Counts the payload of leaf atoms that own out-of-node storage: `EXPR_BIGINT` (GMP limbs), `EXPR_NDARRAY` (the `dims[]` array plus the flat data buffer, sized by element count and dtype width), and `EXPR_MPFR` (significand storage, scaling with precision). For an `NDArray`, the buffer dominates, so `ByteCount` scales with the number of elements and the dtype's bytes-per-element.
 
+
+## MemoryInUse
+Gives the number of bytes of memory currently resident for the Mathilda process.
+- `MemoryInUse[]`
+
+**Features**:
+- `Protected`.
+- **This is the process resident set size, which is not the same quantity Mathematica
+  reports.** Wolfram's `MemoryInUse[]` counts the bytes holding the current session's data —
+  expressions, definitions, caches — and nothing else. Mathilda's also includes the binary,
+  the shared libraries (GMP, MPFR, LAPACK, Readline, and Raylib on a graphics build), the
+  stacks, and whatever the allocator is holding without having returned it to the system. On
+  a freshly started kernel Wolfram's figure is small where this one is tens of megabytes of
+  mapped libraries, so the two are **not interchangeable**.
+- The difference is deliberate on both counts. Reporting session-data bytes exactly would
+  mean routing every allocation in the tree through a counting wrapper — around 500 modules,
+  all calling `malloc` directly today — and the result would still miss what the allocator
+  retains. And RSS is the more useful number for the purpose that prompted this, a notebook
+  status bar: it is what Activity Monitor and `top` show, so a user comparing them sees them
+  agree.
+- Reads `mach_task_basic_info` on macOS and `/proc/self/statm` on Linux, scaled by the actual
+  page size rather than an assumed 4096.
+- **Returns unevaluated** on a platform offering no way to ask, rather than reporting `0` — a
+  zero would read as "no memory in use", which is false and looks entirely plausible in a
+  status bar.
+- `MemoryInUse[subkernel]` is not supported: there are no subkernels, so an argument returns
+  unevaluated rather than being accepted and ignored.
+
+```
+In[1]:= MemoryInUse[]
+Out[1]= 15335424
+
+In[2]:= N[MemoryInUse[]/1024^2, 4]
+Out[2]= 14.63
+```
+
+## MaxMemoryUsed
+Gives the peak number of bytes resident for the Mathilda process over its lifetime.
+- `MaxMemoryUsed[]`
+
+**Features**:
+- `Protected`.
+- A genuine high-water mark from the operating system (`getrusage`'s `ru_maxrss`), not the
+  largest value some earlier call to `MemoryInUse` happened to observe. That distinction is
+  the point: a polled maximum misses any spike falling between two polls, and a status bar
+  polling once a second would miss nearly every spike worth knowing about.
+- `MaxMemoryUsed[] >= MemoryInUse[]` always holds, and the peak never decreases.
+- **`ru_maxrss` is in different units on the two platforms** — bytes on Darwin, kilobytes on
+  Linux — so it is scaled per platform. An unconverted use is wrong by a factor of 1024 on
+  one of them while looking plausible on both.
+- Its feature-test guard runs **opposite** to every other file in the tree. `ru_maxrss` is a
+  BSD extension rather than POSIX (POSIX requires only `ru_utime` and `ru_stime`), so on
+  Darwin defining `_XOPEN_SOURCE` selects the strict POSIX subset and *hides* the field —
+  from the very macro every other module needs in order to see POSIX at all. So each platform
+  gets the macro that widens *its* namespace: `_DARWIN_C_SOURCE` on macOS, `_DEFAULT_SOURCE`
+  plus `_XOPEN_SOURCE` on glibc.

--- a/docs/spec/changelog/2026-08-10.md
+++ b/docs/spec/changelog/2026-08-10.md
@@ -2026,3 +2026,43 @@ anneal-plus-polish reaches it. Deterministic under the fixed default seed; the
 test asserts the optimum value (to `1e-2`), the minimizer location (to `1e-2`),
 and that the returned point is feasible inside the disk. No behavior change;
 test-only. Full `nminimize_tests` suite passes.
+
+## MemoryInUse and MaxMemoryUsed (2026-08-14)
+
+Two new builtins in a new `src/meminfo.{c,h}`, registered from `core_init` alongside
+`info_init`. `MemoryInUse[]` gives the bytes currently resident for the process;
+`MaxMemoryUsed[]` gives the lifetime peak. Added so the notebook status bar has a memory
+figure to display.
+
+**They report resident set size, which is not Mathematica's quantity, and that is stated in
+the docstring rather than left for a user to discover.** Wolfram's `MemoryInUse[]` counts
+session data only; this also counts the binary, the shared libraries, the stacks and whatever
+the allocator holds without returning it. Reporting session bytes exactly would mean routing
+every allocation in the tree through a counting wrapper — some 500 modules, all calling
+`malloc` directly — and would still miss allocator retention. RSS is also the more useful
+number for a status bar, being what Activity Monitor and `top` show.
+
+`MemoryInUse` reads `mach_task_basic_info` on macOS and `/proc/self/statm` on Linux, scaled
+by the real page size rather than an assumed 4096. `MaxMemoryUsed` uses `getrusage`'s
+`ru_maxrss`, which is a true OS high-water mark — so it catches a spike between two polls,
+where a maximum accumulated over previous `MemoryInUse` calls would miss it.
+
+**Two portability traps, both documented in the file.** `ru_maxrss` is BYTES on Darwin and
+KILOBYTES on Linux, so it is scaled per platform; an unconverted use is wrong by 1024x on one
+of them and plausible on both. And the feature-test guard here runs *opposite* to every other
+file in the tree: `ru_maxrss` is a BSD extension, not POSIX, so on Darwin defining
+`_XOPEN_SOURCE` selects the strict POSIX subset and HIDES the field — the same macro every
+other module needs in order to see POSIX at all. Each platform therefore gets the macro that
+widens its own namespace, still before any include.
+
+An unsupported platform returns unevaluated rather than `0`, because a zero reads as "no
+memory in use" — false, and entirely plausible-looking in a status bar. `MemoryInUse[k]` for
+a subkernel is refused rather than accepted and ignored, there being no subkernels.
+
+New `meminfo_tests`, five groups. Memory values are machine-dependent and cannot be pinned,
+so every assertion is a relation that must hold whatever the number is: positive integer;
+peak never below current and never decreasing; an order-of-magnitude window between 1 MB and
+16 GB, which is what catches the 1024x unit error; the argument forms declining; and both
+symbols `Protected`. The load-bearing one is that it **responds to allocation** — three
+million machine integers is 24 MB at 8 bytes each, and resident memory must grow by at least
+4 MB — because a hard-coded constant would satisfy every other row in the file.

--- a/src/core.c
+++ b/src/core.c
@@ -77,6 +77,7 @@
 #include "partitions.h"
 #include "fit.h"
 #include "info.h"
+#include "meminfo.h"
 #include "expand.h"
 #include "expand_power.h"
 #include "poly.h"
@@ -840,6 +841,7 @@ void core_init(void) {
     void nsolve_init(void);
     nsolve_init();
     info_init();
+    meminfo_init();
     datetime_init();
     linalg_init();
     void matsol_init(void);

--- a/src/meminfo.c
+++ b/src/meminfo.c
@@ -1,0 +1,166 @@
+/* meminfo.c -- MemoryInUse and MaxMemoryUsed.
+ *
+ * WHAT THESE MEASURE, AND HOW IT DIFFERS FROM MATHEMATICA. Wolfram's MemoryInUse[] reports
+ * the bytes used to store the data of the current session -- expressions, definitions,
+ * caches -- and nothing else. Mathilda reports the process's RESIDENT SET SIZE, which also
+ * includes the binary, the shared libraries (GMP, MPFR, LAPACK, Readline, and on a graphics
+ * build Raylib), the stacks, and whatever the allocator is holding but has not returned to
+ * the OS.
+ *
+ * That is a real difference and it is documented rather than papered over, because the
+ * numbers are not interchangeable: on a freshly started kernel Wolfram's figure is small
+ * while this one is tens of megabytes of mapped libraries. Reporting session-data bytes
+ * exactly would mean routing every allocation in the tree through a counting wrapper --
+ * about 500 modules, all of them calling malloc directly today -- and the resulting number
+ * would still miss what the allocator retains.
+ *
+ * RSS is also the more USEFUL quantity for the thing that prompted this: a notebook status
+ * bar. It is the number Activity Monitor and top show, so a user comparing the two sees them
+ * agree, where a smaller session-only figure would look like an under-report.
+ *
+ * PORTABILITY, which has two traps in it.
+ *
+ * `getrusage` is POSIX, not C99, so the feature-test macro has to come BEFORE any include --
+ * below the first one the header has already been parsed with the wrong namespace and the
+ * macro does nothing. glibc hides the symbol under -std=c99 while Darwin exposes it anyway,
+ * so getting this wrong compiles clean here and breaks only on Linux. Same pattern as
+ * src/ndkernels.c, src/core.c, src/repl.c.
+ *
+ * `ru_maxrss` IS NOT IN THE SAME UNIT ON BOTH PLATFORMS. Darwin reports BYTES; Linux
+ * reports KILOBYTES. A single unconverted use is wrong by a factor of 1024 on one of the two
+ * and silently plausible on both -- exactly the class of bug the int64_t/long long note in
+ * CLAUDE.md is about. Hence the explicit per-platform scaling below.
+ *
+ * AND THE FEATURE-TEST MACRO RUNS THE OPPOSITE WAY FROM EVERY OTHER FILE IN THE TREE, which
+ * is why the guard below is conditional rather than the usual unconditional _XOPEN_SOURCE.
+ * `ru_maxrss` is a BSD extension, not POSIX -- POSIX only requires ru_utime and ru_stime. So
+ * on Darwin, defining _XOPEN_SOURCE selects the strict POSIX subset and HIDES the field:
+ * `no member named 'ru_maxrss' in 'struct rusage'`, from the very macro that every other
+ * module needs in order to see POSIX at all. Meanwhile glibc needs a feature macro to expose
+ * `getrusage` itself. Each platform therefore gets the macro that widens ITS namespace --
+ * _DARWIN_C_SOURCE for the BSD fields, _DEFAULT_SOURCE plus _XOPEN_SOURCE for glibc -- and
+ * both still come before any include, where a feature-test macro has to be to do anything.
+ */
+#if defined(__APPLE__)
+#  ifndef _DARWIN_C_SOURCE
+#  define _DARWIN_C_SOURCE
+#  endif
+#else
+#  ifndef _DEFAULT_SOURCE
+#  define _DEFAULT_SOURCE
+#  endif
+#  ifndef _XOPEN_SOURCE
+#  define _XOPEN_SOURCE 600
+#  endif
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+
+#if defined(__APPLE__)
+#include <mach/mach.h>
+#endif
+#if defined(__linux__)
+#include <unistd.h>
+#endif
+
+#include "expr.h"
+#include "symtab.h"
+#include "attr.h"
+#include "meminfo.h"
+
+bool meminfo_current(uint64_t* bytes) {
+    if (!bytes) return false;
+
+#if defined(__APPLE__)
+    /* mach_task_basic_info gives resident_size directly, in bytes. */
+    mach_task_basic_info_data_t info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                  (task_info_t)&info, &count) != KERN_SUCCESS)
+        return false;
+    *bytes = (uint64_t)info.resident_size;
+    return true;
+
+#elif defined(__linux__)
+    /* /proc/self/statm: total pages, then RESIDENT pages. In pages, so scale by the page
+     * size -- assuming 4096 would be wrong on a 16K-page arm64 kernel. */
+    FILE* f = fopen("/proc/self/statm", "r");
+    if (!f) return false;
+    unsigned long total = 0, resident = 0;
+    int got = fscanf(f, "%lu %lu", &total, &resident);
+    fclose(f);
+    if (got != 2) return false;
+    long page = sysconf(_SC_PAGESIZE);
+    if (page <= 0) return false;
+    *bytes = (uint64_t)resident * (uint64_t)page;
+    return true;
+
+#else
+    /* No portable way to ask. Declining is the honest answer; a zero would read as "no
+     * memory in use", which is worse than no answer at all. */
+    (void)bytes;
+    return false;
+#endif
+}
+
+bool meminfo_peak(uint64_t* bytes) {
+    if (!bytes) return false;
+    struct rusage ru;
+    if (getrusage(RUSAGE_SELF, &ru) != 0) return false;
+
+#if defined(__APPLE__)
+    *bytes = (uint64_t)ru.ru_maxrss;                /* Darwin: already bytes */
+#else
+    *bytes = (uint64_t)ru.ru_maxrss * (uint64_t)1024; /* Linux: kilobytes */
+#endif
+    return true;
+}
+
+/* MemoryInUse[] -- current resident bytes.
+ *
+ * Takes no arguments. Mathematica's one-argument form reports a subkernel's usage, and there
+ * are no subkernels here, so anything other than MemoryInUse[] returns unevaluated rather
+ * than quietly ignoring what was passed. */
+static Expr* builtin_memoryinuse(Expr* res) {
+    if (res->data.function.arg_count != 0) return NULL;
+    uint64_t b = 0;
+    if (!meminfo_current(&b)) return NULL;
+    return expr_new_integer((int64_t)b);
+}
+
+/* MaxMemoryUsed[] -- peak resident bytes over the life of the process.
+ *
+ * A genuine high-water mark from the OS, not the largest value some previous call to
+ * MemoryInUse happened to observe. That distinction matters: a polled maximum would miss a
+ * spike between two polls, and a status bar polling once a second would miss almost every
+ * spike worth knowing about. */
+static Expr* builtin_maxmemoryused(Expr* res) {
+    if (res->data.function.arg_count != 0) return NULL;
+    uint64_t b = 0;
+    if (!meminfo_peak(&b)) return NULL;
+    return expr_new_integer((int64_t)b);
+}
+
+void meminfo_init(void) {
+    symtab_add_builtin("MemoryInUse", builtin_memoryinuse);
+    symtab_get_def("MemoryInUse")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("MemoryInUse",
+        "MemoryInUse[] gives the number of bytes of memory currently resident for the "
+        "Mathilda process. This is the process resident set size, so unlike "
+        "Mathematica's MemoryInUse it also counts the binary, the shared libraries and "
+        "whatever the allocator holds without returning it to the system -- it is the "
+        "figure Activity Monitor and top report, not a count of session data alone. "
+        "Returns unevaluated on a platform that offers no way to ask, rather than "
+        "reporting zero.");
+
+    symtab_add_builtin("MaxMemoryUsed", builtin_maxmemoryused);
+    symtab_get_def("MaxMemoryUsed")->attributes |= ATTR_PROTECTED;
+    symtab_set_docstring("MaxMemoryUsed",
+        "MaxMemoryUsed[] gives the peak number of bytes resident for the Mathilda process "
+        "over its lifetime. The high-water mark comes from the operating system, so it "
+        "catches spikes that occurred between two calls to MemoryInUse rather than only "
+        "the largest value previously observed.");
+}

--- a/src/meminfo.h
+++ b/src/meminfo.h
@@ -1,0 +1,17 @@
+/* meminfo.h -- process memory introspection: MemoryInUse, MaxMemoryUsed. */
+#ifndef MATHILDA_MEMINFO_H
+#define MATHILDA_MEMINFO_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+void meminfo_init(void);
+
+/* Current resident set size in bytes. False means the platform gives no answer, which
+ * callers must treat as "no answer" rather than as zero. */
+bool meminfo_current(uint64_t* bytes);
+
+/* Peak resident set size in bytes, over the life of the process. */
+bool meminfo_peak(uint64_t* bytes);
+
+#endif /* MATHILDA_MEMINFO_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -436,6 +436,7 @@ set(COMMON_SRC
     ../src/stats/exponentialmovingaverage.c
     ../src/fit.c
     ../src/info.c
+    ../src/meminfo.c
     ../src/expand.c
     ../src/expand_power.c
     ../src/poly/poly.c
@@ -816,6 +817,12 @@ add_test(NAME trigexp_zero_tests COMMAND trigexp_zero_tests)
 add_executable(rootreduce_tests test_rootreduce.c $<TARGET_OBJECTS:mathilda_common>)
 target_include_directories(rootreduce_tests PRIVATE ../src)
 add_test(NAME rootreduce_tests COMMAND rootreduce_tests)
+
+# MemoryInUse / MaxMemoryUsed. Values are machine-dependent, so the suite asserts
+# relations (positive, peak >= current, responds to allocation) rather than numbers.
+add_executable(meminfo_tests test_meminfo.c $<TARGET_OBJECTS:mathilda_common>)
+target_include_directories(meminfo_tests PRIVATE ../src)
+add_test(NAME meminfo_tests COMMAND meminfo_tests)
 
 add_executable(flint_bridge_tests test_flint_bridge.c $<TARGET_OBJECTS:mathilda_common>)
 target_include_directories(flint_bridge_tests PRIVATE ../src)

--- a/tests/test_meminfo.c
+++ b/tests/test_meminfo.c
@@ -1,0 +1,94 @@
+/* test_meminfo.c -- MemoryInUse and MaxMemoryUsed.
+ *
+ * Memory figures are the awkward opposite of the usual test: the VALUE is machine-dependent
+ * and cannot be pinned at all, so every assertion here has to be a relation that must hold
+ * whatever the number is. The four that do the work:
+ *
+ *   - it is a positive integer, which catches a failed platform query returning zero;
+ *   - the peak is never below the current, which is the definition of a high-water mark;
+ *   - it RESPONDS to allocation, which is the one that distinguishes a real measurement from
+ *     a plausible constant -- a hard-coded 16 MB would satisfy every other row here;
+ *   - the argument form declines, rather than ignoring what it was passed.
+ */
+#include <stdio.h>
+#include "test_utils.h"
+
+extern void symtab_init(void);
+extern void core_init(void);
+
+static void test_memory_in_use_is_a_positive_integer(void) {
+    /* A failed platform query must return unevaluated, never zero -- a zero would read as
+     * "no memory in use", which is both false and the kind of wrong that looks fine in a
+     * status bar. So this row also pins the decline-rather-than-lie contract. */
+    assert_eval_eq("IntegerQ[MemoryInUse[]] && MemoryInUse[] > 0", "True", 0);
+    assert_eval_eq("IntegerQ[MaxMemoryUsed[]] && MaxMemoryUsed[] > 0", "True", 0);
+    /* Sanity on the ORDER OF MAGNITUDE, which is what catches a unit error. ru_maxrss is
+     * bytes on Darwin and kilobytes on Linux, so a missing conversion is wrong by 1024x --
+     * and this kernel links GMP, MPFR, LAPACK and Readline, so it cannot plausibly be under
+     * a megabyte or over sixteen gigabytes. Wide enough never to be flaky, narrow enough
+     * that a factor of 1024 in either direction fails it. */
+    assert_eval_eq("1024^2 < MemoryInUse[] < 16*1024^3", "True", 0);
+    assert_eval_eq("1024^2 < MaxMemoryUsed[] < 16*1024^3", "True", 0);
+}
+
+static void test_peak_is_never_below_current(void) {
+    /* The defining property of a high-water mark. It is also what fails if the two are ever
+     * wired to different sources with different units. */
+    assert_eval_eq("MaxMemoryUsed[] >= MemoryInUse[]", "True", 0);
+    /* And the peak cannot go DOWN between two calls. */
+    assert_eval_eq("Module[{a, b}, a = MaxMemoryUsed[]; b = MaxMemoryUsed[]; b >= a]",
+                   "True", 0);
+}
+
+static void test_it_responds_to_a_real_allocation(void) {
+    /* THE row that proves this is a measurement rather than a constant. A hard-coded value
+     * passes every other assertion in this file; only this one can tell the difference.
+     *
+     * Three million machine integers is 24 MB at 8 bytes each, which is far too much for the
+     * allocator to satisfy from free space it already held, so resident memory has to grow.
+     * The bound is deliberately loose -- 4 MB against an expected 24 -- because the exact
+     * growth depends on page granularity and on what the allocator had in hand, and a tight
+     * bound here would be flaky for no gain. The claim being tested is "it moves, and in the
+     * right direction, by an amount of the right order", not any particular figure. */
+    assert_eval_eq("Module[{before, after, big},"
+                   " before = MemoryInUse[];"
+                   " big = Range[3000000];"
+                   " after = MemoryInUse[];"
+                   " after - before > 4*1024^2]", "True", 0);
+    /* The peak must have absorbed that spike too. */
+    assert_eval_eq("Module[{big, peak},"
+                   " big = Range[3000000];"
+                   " peak = MaxMemoryUsed[];"
+                   " peak >= MemoryInUse[]]", "True", 0);
+}
+
+static void test_argument_forms_decline(void) {
+    /* Mathematica's one-argument MemoryInUse reports a subkernel's usage. There are no
+     * subkernels here, so an argument is refused rather than silently ignored -- accepting
+     * and dropping it would hide a real mistake in a caller that thought it meant
+     * something. */
+    assert_eval_eq("Head[MemoryInUse[1]]", "MemoryInUse", 0);
+    assert_eval_eq("Head[MemoryInUse[a, b]]", "MemoryInUse", 0);
+    assert_eval_eq("Head[MaxMemoryUsed[1]]", "MaxMemoryUsed", 0);
+}
+
+static void test_both_are_protected(void) {
+    /* Every builtin gets its attributes; these are read-only system quantities, so a user
+     * redefining them would make a status bar quietly report fiction. */
+    assert_eval_eq("MemberQ[Attributes[MemoryInUse], Protected]", "True", 0);
+    assert_eval_eq("MemberQ[Attributes[MaxMemoryUsed], Protected]", "True", 0);
+}
+
+int main(void) {
+    symtab_init();
+    core_init();
+
+    TEST(test_memory_in_use_is_a_positive_integer);
+    TEST(test_peak_is_never_below_current);
+    TEST(test_it_responds_to_a_real_allocation);
+    TEST(test_argument_forms_decline);
+    TEST(test_both_are_protected);
+
+    printf("All meminfo tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds `MemoryInUse[]` and `MaxMemoryUsed[]` in a new `src/meminfo.{c,h}`, so the
notebook status bar has a memory figure to display. The frontend side is a separate
change, since the status bar itself is not on `main` yet.

**These report resident set size, which is not the quantity Mathematica reports, and
the docstring says so rather than leaving a user to discover it.** Wolfram's
`MemoryInUse[]` counts the bytes holding the current session's data and nothing else.
This also counts the binary, the shared libraries (GMP, MPFR, LAPACK, Readline, and
Raylib on a graphics build), the stacks, and whatever the allocator holds without
returning it. On a freshly started kernel Wolfram's figure is small where this one is
tens of megabytes of mapped libraries, so **the two are not interchangeable.**

That was a choice, twice over. Reporting session bytes exactly would mean routing
every allocation in the tree through a counting wrapper — about 500 modules, all
calling `malloc` directly today — and the result would still miss allocator
retention. And RSS is the more useful figure for the purpose that prompted this: it
is what Activity Monitor and `top` show, so a user comparing them sees them agree,
where a smaller session-only number would look like an under-report.

`MaxMemoryUsed[]` is a true OS high-water mark (`getrusage`'s `ru_maxrss`), not the
largest value some earlier `MemoryInUse` call happened to observe. A polled maximum
misses any spike falling between two polls, and a status bar sampling every couple of
seconds would miss nearly every spike worth knowing about.

## Changes

- `src/meminfo.{c,h}` (new): `MemoryInUse[]`, `MaxMemoryUsed[]`, both `Protected`
  with docstrings. Current RSS from `mach_task_basic_info` on macOS and
  `/proc/self/statm` on Linux, scaled by the real page size rather than an assumed
  4096.
- `src/core.c`: `meminfo_init()` beside `info_init()`.
- `tests/test_meminfo.c` (new) + `CMakeLists.txt`: `meminfo_tests`.
- `docs/spec/builtins/expression-information.md`, and the week's changelog.

An unsupported platform returns **unevaluated rather than `0`** — a zero reads as "no
memory in use", which is false and looks entirely plausible in a status bar.
`MemoryInUse[k]` for a subkernel is refused rather than accepted and ignored, there
being no subkernels.

## Two portability traps, both documented in the file

**`ru_maxrss` is not in the same unit on both platforms** — bytes on Darwin,
kilobytes on Linux — so it is scaled per platform. A single unconverted use is wrong
by a factor of 1024 on one of them and looks plausible on both.

**The feature-test guard here runs opposite to every other file in the tree**, which
is why it is conditional rather than the usual unconditional `_XOPEN_SOURCE`.
`ru_maxrss` is a BSD extension, not POSIX — POSIX requires only `ru_utime` and
`ru_stime` — so on Darwin defining `_XOPEN_SOURCE` selects the strict POSIX subset
and *hides* the field, from the very macro every other module needs in order to see
POSIX at all. Each platform therefore gets the macro that widens *its* namespace:
`_DARWIN_C_SOURCE` on macOS, `_DEFAULT_SOURCE` plus `_XOPEN_SOURCE` on glibc, both
still before any include. `make check-c99` passes.

## Testing

```
$ ./meminfo_tests
All meminfo tests passed.          (5 groups)

$ make check-c99                   OK
$ make -j8                         clean, no new warnings
```

Memory values are machine-dependent and cannot be pinned, so every assertion is a
relation that must hold whatever the number is:

- positive integer (a failed platform query must decline, never return `0`);
- peak never below current, and never decreasing;
- an order-of-magnitude window, 1 MB to 16 GB — this is the row that catches the
  1024× unit error, and it is wide enough never to be flaky;
- the argument forms decline;
- both symbols `Protected`.

The load-bearing row is that it **responds to a real allocation**, because a
hard-coded constant would satisfy every other assertion in the file. Three million
machine integers is 24 MB at 8 bytes each, and resident memory must grow by at least
4 MB. Measured, it grew by 22.9 MB:

```
MemoryInUse: 15335424 bytes = 14.625 MB
MaxMemoryUsed: 15695872 = 14.969 MB     peak >= current: True
grew after allocating 3e6 integers: True   delta MB: 22.938
arg form declines: MemoryInUse
```

## JIRA Ticket

n/a
