### PR TITLE
Notebook: kernel memory in the status bar, behind a menu toggle

### DIFF
--- a/frontend/src/lib/StatusBar.svelte
+++ b/frontend/src/lib/StatusBar.svelte
@@ -13,7 +13,10 @@
 -->
 <script lang="ts">
   import { kernelStatus } from './notebook';
-  import { lastOp, evalCount, evalTotalMs, formatMs } from './status';
+  import { lastOp, evalCount, evalTotalMs, formatMs,
+           memoryBytes, memoryStale, showMemory, formatBytes } from './status';
+  import { evaluateCell } from './ipc';
+  import { onMount } from 'svelte';
   import { activeCell } from './active';
   import { activeActions } from './canvas';
   import { restart } from './kernelActions';
@@ -50,6 +53,73 @@
   $: activeInfo = ($activeCell && $activeActions && $activeCell.notebookId === $activeActions.notebookId)
     ? cells.find(c => c.id === $activeCell!.cellId) ?? null
     : null;
+
+  /* ---- Memory sampling ----------------------------------------------------
+   *
+   * Lives here rather than in a store so it only runs while the bar is on
+   * screen: a hidden status bar should cost nothing at all.
+   *
+   * Deliberately NOT routed through recordOp(). A poll is not the user's work,
+   * so counting it would inflate the very session totals displayed two segments
+   * to the left -- a bar that changed its own numbers by being visible.
+   *
+   * The kernel does not record In[]/Out[] in pipe mode and exec indices are
+   * assigned by the frontend per cell, so these samples cannot disturb cell
+   * numbering either. That was checked rather than assumed; it is the reason a
+   * timed poll is acceptable at all.
+   *
+   * SEQUENCED, NEVER OVERLAPPED. A single in-flight flag means a slow sample
+   * cannot stack up behind itself -- without it, a kernel that went busy
+   * mid-poll would accumulate one queued evaluation per tick and hand the user
+   * a backlog to wait through.
+   */
+  const MEMORY_POLL_MS = 2000;
+  let sampling = false;
+
+  async function sampleMemory() {
+    /* Not ready means busy, starting, restarting or dead. In every one of those
+       the right move is to leave the last figure up and flag it, not to queue
+       an evaluation the user will end up waiting behind. */
+    if ($kernelStatus !== 'ready') { memoryStale.set(true); return; }
+    if (sampling) return;
+    sampling = true;
+    try {
+      let raw = '';
+      await evaluateCell('MemoryInUse[]', (msg) => {
+        if (msg.type === 'expr') raw += msg.payload;
+      });
+      /* MemoryInUse returns unevaluated on a platform that cannot answer, so a
+         non-numeric reply is a real possibility and means "no figure", not
+         zero. Blank the value rather than showing a fabricated 0 B. */
+      const n = Number(raw.trim());
+      if (Number.isFinite(n) && n > 0) {
+        memoryBytes.set(n);
+        memoryStale.set(false);
+      } else {
+        memoryBytes.set(null);
+        memoryStale.set(false);
+      }
+    } catch {
+      /* A failed sample keeps the previous figure and marks it stale. */
+      memoryStale.set(true);
+    } finally {
+      sampling = false;
+    }
+  }
+
+  onMount(() => {
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const unsubMem = showMemory.subscribe(on => {
+      if (on && timer === null) {
+        void sampleMemory();                  /* something to show immediately */
+        timer = setInterval(() => void sampleMemory(), MEMORY_POLL_MS);
+      } else if (!on && timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    });
+    return () => { if (timer !== null) clearInterval(timer); unsubMem(); };
+  });
 
   /* One line, and short: this sits in a 22px strip. */
   $: opSource = $lastOp
@@ -91,6 +161,21 @@
   {/if}
 
   <span class="spacer"></span>
+
+  <!-- Kernel memory. Opt-in, so absent unless asked for. -->
+  {#if $showMemory}
+    <span
+      class="seg"
+      class:stale={$memoryStale}
+      title={$memoryBytes == null
+        ? 'Kernel memory — no figure yet'
+        : `Kernel resident memory${$memoryStale ? ' (last known — the kernel is busy, so it cannot be sampled right now)' : ''}. This is the process resident set size, the same figure Activity Monitor shows, so it includes the binary and shared libraries as well as session data.`}
+    >
+      <span class="seg-label">Mem</span>
+      <span class="seg-value">{$memoryBytes == null ? '—' : formatBytes($memoryBytes)}</span>
+    </span>
+    <span class="rule"></span>
+  {/if}
 
   <!-- Session totals -->
   {#if $evalCount > 0}
@@ -151,6 +236,10 @@
     color: inherit;
   }
   .seg.muted { opacity: 0.5; }
+  /* A stale figure is dimmed rather than hidden: the number is still the best
+     information available, and hiding it would read as "memory went to zero"
+     at exactly the moment it most likely spiked. */
+  .seg.stale .seg-value { opacity: 0.45; font-style: italic; }
   .seg.err .seg-value.strong { color: var(--err); }
 
   .seg-label {

--- a/frontend/src/lib/Toolbar.svelte
+++ b/frontend/src/lib/Toolbar.svelte
@@ -35,7 +35,7 @@
   import { symbolAtSelection } from './refpages';
   import { kernelStatus } from './notebook';
   import { restart, abortEvaluation } from './kernelActions';
-  import { showStatusBar, resetSessionStats } from './status';
+  import { showStatusBar, showMemory, resetSessionStats } from './status';
   import type { Cell, CellType, NotebookRow } from './notebook';
 
   type MenuId = 'eval' | 'kernel' | 'docs' | 'style' | 'addpane' | 'overflow' | null;
@@ -358,6 +358,7 @@
       : []),
     { kind: 'sep' },
     { kind: 'item', id: 'statusbar', label: 'Status bar', checked: $showStatusBar },
+    { kind: 'item', id: 'memory', label: 'Kernel memory', checked: $showMemory },
     { kind: 'sep' },
     { kind: 'item', id: 'rename', label: 'Rename notebook…', icon: 'rename' },
     { kind: 'item', id: 'collapse', label: $activeFlags?.collapsed ? 'Expand notebook' : 'Collapse notebook', icon: 'collapse' },
@@ -369,6 +370,17 @@
     /* The status bar is a view preference, not a notebook command, so it does
        not need a pane and must be handled before the guard below. */
     if (id === 'statusbar') { showStatusBar.update(v => !v); return; }
+    /* Memory is the same kind of thing -- a view preference, no pane needed.
+       Turning it on also turns the bar on, since a segment of a hidden bar is
+       a setting with no visible effect, which reads as a broken menu item. */
+    if (id === 'memory') {
+      showMemory.update(v => {
+        const next = !v;
+        if (next) showStatusBar.set(true);
+        return next;
+      });
+      return;
+    }
     const pane = $activeActions;
     if (!pane) return;
     switch (id) {

--- a/frontend/src/lib/status.ts
+++ b/frontend/src/lib/status.ts
@@ -30,6 +30,65 @@ export const evalTotalMs = writable(0);
  *  to be nothing but notebook. */
 export const showStatusBar = writable(true);
 
+/* ---- Kernel memory -------------------------------------------------------
+ *
+ * The kernel's resident bytes, from MemoryInUse[]. Off by default: it costs a
+ * kernel round-trip every few seconds, which nobody should pay for without
+ * asking, and most sessions never care.
+ *
+ * WHY THIS POLLS ONLY WHEN THE KERNEL IS IDLE, which is the whole design.
+ * The C kernel is single-threaded and serializes every evaluation behind one
+ * mutex. A poll issued while a long computation is running would sit in that
+ * queue, and then the user's NEXT cell would sit behind the poll — so a status
+ * bar, a decoration, would be adding latency to real work. That trade is never
+ * worth it, so the poll is skipped whenever the kernel is not `ready`.
+ *
+ * The cost of that choice is real and worth naming: a big computation is
+ * exactly when memory is most interesting, and it is exactly when this cannot
+ * look. So the last known figure stays on screen and is marked STALE rather
+ * than being blanked — a number with a caveat beats no number, and blanking it
+ * would read as "memory dropped to nothing" at the very moment it spiked.
+ *
+ * Reading it without the kernel's help would need the sidecar's RSS read from
+ * Rust, which works while busy but takes a different implementation per
+ * platform and per target (a child PID on desktop, self on the in-process
+ * mobile build). That is the better answer if the staleness ever becomes
+ * annoying; it is not worth it for a first cut.
+ */
+
+/** Kernel resident bytes, or null before the first successful sample. */
+export const memoryBytes = writable<number | null>(null);
+
+/** True when the displayed figure predates the current kernel activity — set
+ *  when a sample is skipped because the kernel is busy, or when one fails. */
+export const memoryStale = writable(false);
+
+/** Is the memory segment shown? Off by default; polling is not free. */
+export const showMemory = writable(false);
+
+/** Bytes as something that fits a 22px strip.
+ *
+ * Binary units, because that is what MemoryInUse counts and what Activity
+ * Monitor and top show, so the three agree. One decimal below 100 and none
+ * above keeps the width steady as the value moves, which matters in a strip
+ * where a jittering number is more distracting than an imprecise one. */
+export function formatBytes(b: number): string {
+  if (!isFinite(b) || b < 0) return '—';
+  if (b < 1024) return `${Math.round(b)} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let v = b / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v >= 100 ? Math.round(v) : v.toFixed(1)} ${units[i]}`;
+}
+
+/** A kernel restart invalidates the figure along with the session totals: the
+ *  process that used those bytes is gone. */
+export function resetMemory() {
+  memoryBytes.set(null);
+  memoryStale.set(false);
+}
+
 export function recordOp(op: LastOp) {
   lastOp.set(op);
   if (op.ok) {
@@ -44,6 +103,7 @@ export function resetSessionStats() {
   evalCount.set(0);
   evalTotalMs.set(0);
   lastOp.set(null);
+  resetMemory();
 }
 
 /** Milliseconds as something short enough for a status bar. */


### PR DESCRIPTION
## Summary

Adds a **Mem** segment to the notebook status bar, fed by `MemoryInUse[]` (merged in #61), with a
"Kernel memory" item in the overflow menu beside "Status bar".

Off by default: it costs a kernel round-trip every two seconds and most sessions never care. Turning it
on also turns the status bar on, since a segment of a hidden bar is a setting with no visible effect and
reads as a broken menu item.

## It polls only while the kernel is idle, and that is the design

The C kernel is single-threaded and serialises every evaluation behind one mutex. A poll issued during a
long computation would sit in that queue — and then the user's *next cell* would sit behind the poll. A
status bar is a decoration; it must never add latency to real work.

The cost of that choice is named rather than hidden: **a big computation is exactly when memory is most
interesting, and exactly when this cannot look.** So the last figure stays on screen, dimmed and marked
stale, rather than being blanked — blanking would read as "memory dropped to nothing" at the moment it
most likely spiked.

Reading it without the kernel's help would mean the sidecar's RSS from Rust, which works while busy but
takes a different implementation per platform and per target (a child PID on desktop, self on the
in-process mobile build). That is the better answer if the staleness becomes annoying; it is not worth it
for a first cut.

## Two things it deliberately does not do

**It does not go through `recordOp()`.** A poll is not the user's work, and counting it would inflate the
session totals displayed two segments to its left — a bar that changed its own numbers by being visible.

**It cannot disturb cell numbering**, and that was checked rather than assumed: pipe mode records no
`In[]`/`Out[]`, and exec indices are assigned per cell by the frontend. That is the reason a timed poll is
acceptable at all.

A single in-flight flag keeps samples sequenced — without it, a kernel that went busy mid-poll would queue
one evaluation per tick and hand the user a backlog to wait through.

Sampling lives in the component rather than a store, so a hidden bar costs nothing. A non-numeric reply
blanks the figure instead of showing `0 B`: `MemoryInUse` returns unevaluated where the platform cannot
answer, and a fabricated zero in a status bar is worse than a dash.

## Changes

- `frontend/src/lib/status.ts` — `memoryBytes`, `memoryStale`, `showMemory` stores, `formatBytes`,
  and `resetMemory` wired into `resetSessionStats` (a restart invalidates the figure along with the
  totals: the process that used those bytes is gone).
- `frontend/src/lib/StatusBar.svelte` — the segment and the sampler.
- `frontend/src/lib/Toolbar.svelte` — the menu item and handler.

## Testing

`svelte-check` reports **0 errors**; the 5 warnings are pre-existing `tsconfig` complaints in no file this
touches. Clean `vite build`.

The last mile needs a real mouse: synthetic input does not reach the WKWebView, so the menu toggle and the
segment's stale styling want a human click-through.

## JIRA Ticket

n/a
