### PR TITLE
Notebook: properties sidebar, Markdown/TeX prose, notebook search, Insert palette

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -133,6 +133,47 @@ prose reaches the DOM through `{@html}`: a notebook is an executable document
 whose code cells already evaluate arbitrary Mathilda, so HTML in its prose is not
 a new capability, and a regex pass would look like sanitisation without being it.
 
+### Notebook search
+
+`Cmd+F` in focused mode opens a find bar that searches **every cell** of the
+notebook in the active pane. It is deliberately not `@codemirror/search`: that
+package's `openSearchPanel` searches one editor — whichever cell holds focus — and
+a bar that silently ignores the other forty cells while calling itself notebook
+search is worse than no bar, because you would believe its "No matches". So
+`lib/search.ts` matches over the notebook's own model via `store.allCells()`, and
+navigation then drives whichever editor owns the match it landed on: a code cell
+gets a real CodeMirror selection and scroll, a prose cell is opened for editing
+(which un-renders it) and its range selected.
+
+`Cmd+F` is free because `@codemirror/search` is *not* installed, so no editor
+claims the binding. Enter and Shift+Enter walk the matches, wrapping both ways;
+typing only updates the count, since jumping per keystroke would scroll the
+notebook out from under someone still typing.
+
+What it does not do is highlight every match at once — that needs a CodeMirror
+decoration extension per cell, which is its own change. The count says how many
+there are and Enter walks them.
+
+`npm run check:search` compiles `lib/search.ts` with the project's own `tsc` and
+imports the result, so its 18 checks exercise the shipped functions rather than a
+paraphrase. Two properties carry it: matches are **non-overlapping** (`"aa"` in
+`"aaaa"` is two matches, not three, which is what separates the loop from the
+naive `from = at + 1`), and stepping wraps in **both** directions — in JavaScript
+`-1 % 3` is `-1`, so the naive form sends Shift+Enter at the first match to a
+negative index and the bar reads "0 of 3".
+
+### Interface scale
+
+The scale rows in the properties panel drive the same store the `Cmd+=` / `Cmd+-`
+/ `Cmd+0` bindings drive (root `font-size`, via `uiScale` in `lib/properties.ts`).
+It was a local in `App.svelte`; lifting it to a store is what lets the panel show
+the number the keyboard changes, rather than becoming a second scale that drifts
+from the first. The panel's steps are exactly representable in binary (0.75, 1,
+1.25, 1.5) so a button reads as selected on an exact equality, and only on one —
+the keyboard still moves in 0.1, and highlighting the nearest step while sitting
+between two would misreport the state. `Cmd+0` had been documented in that
+handler's own comment without being implemented; the store made it one line.
+
 `npm run check:prose` covers the pure half — the renderer and the marker
 constants, read out of `prose.ts` so the checks cannot drift from it. The DOM half
 needs a real pointer, since synthetic events do not reach the WKWebView.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -162,6 +162,31 @@ naive `from = at + 1`), and stepping wraps in **both** directions — in JavaScr
 `-1 % 3` is `-1`, so the naive form sends Shift+Enter at the first match to a
 negative index and the bar reads "0 of 3".
 
+### The Insert palette
+
+The **Insert** group offers CodeMirror snippet templates — Table, Matrix, Sum,
+Integrate, Solve, Plot, Module, a definition, and so on — inserted at the caret
+with `${field}` placeholders that Tab walks. Code cells only: every template is a
+Mathilda expression, and offering `Table[]` for a prose cell would insert text that
+never evaluates. The menu's hint is the *expansion*, so it shows what will land in
+the cell rather than only what it is called.
+
+`@codemirror/autocomplete` is now an explicit dependency. It was already in
+`node_modules` transitively through the `codemirror` meta-package and importing it
+on that basis works right up until the day the meta-package reorganises.
+
+The templates are the risk, not the machinery: one with an unbalanced bracket
+produces a broken cell every time the button is pressed, and reading
+`{{${a}, ${b}}, {${c}, ${d}}}` is a poor way to notice. So
+`npm run check:snippets` expands each template and feeds it to **the real Mathilda
+binary** inside `Hold[...]`, which parses without evaluating — `Plot[]` must not
+open a window and a definition must not define anything. A template whose expansion
+does not parse fails the check, which is a stronger guarantee than counting
+brackets: it is the language's own parser agreeing that what the button inserts is
+valid. Bracket counts are checked too, because they say *which* kind is unbalanced
+where the parser only says the line is wrong. If the C binary is not built the
+parser half reports SKIP rather than failing.
+
 ### Interface scale
 
 The scale rows in the properties panel drive the same store the `Cmd+=` / `Cmd+-`

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -174,9 +174,26 @@ the keyboard still moves in 0.1, and highlighting the nearest step while sitting
 between two would misreport the state. `Cmd+0` had been documented in that
 handler's own comment without being implemented; the store made it one line.
 
-`npm run check:prose` covers the pure half — the renderer and the marker
-constants, read out of `prose.ts` so the checks cannot drift from it. The DOM half
-needs a real pointer, since synthetic events do not reach the WKWebView.
+Inline TeX renders through KaTeX: `$…$` inline, `$$…$$` display. The math is
+pulled OUT before Markdown runs and put back after, and that order is the whole
+point — handed to Markdown first, `$a_1 * b_2$` loses `_1 * b_2` to emphasis and
+nothing downstream can recover it. Extraction is a hand-written scan rather than a
+regex because everything that must *not* be math is context: a `$` inside a code
+span or fence is a literal dollar, and `\$` is one anywhere. Two standard
+heuristics (pandoc and markdown-it use the same pair) keep prose about money from
+becoming equations — an opening `$` must be followed by a non-space and a closing
+`$` preceded by one, so "it cost $5 and $6" stays prose. Unclosed delimiters are
+left exactly as typed rather than swallowing the rest of the cell. The Text group's
+fifth button writes `$…$`, which is how the feature gets discovered at all; the
+alternative is knowing to type it.
+
+`npm run check:prose` compiles `lib/prose.ts` with the project's own `tsc` and
+imports the result, so its 39 checks exercise the shipped `renderProse`,
+`extractMath` and marker constants rather than a paraphrase — a paraphrase can
+agree with its test and disagree with the app. It keeps one direct `marked` import
+for a single negative control: that without `breaks: true` there is no `<br>` at
+all, so the option is load-bearing rather than decorative. The DOM half needs a
+real pointer, since synthetic events do not reach the WKWebView.
 
 Both panel stores are plain writables with no persistence, matching `darkMode` in
 `theme.ts`. Nothing in the app persists UI state yet, and making one preference

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -77,3 +77,32 @@ Mathilda C binary (../Mathilda)
 ```
 
 See docs/frontend-research.md for the full design rationale.
+
+### Focused-mode surfaces
+
+The window has two modes. On the canvas, the top strip is a 34px name-and-theme
+bar (`--appbar-h`). Focusing one or more notebooks swaps it for the 46px notebook
+toolbar (`--toolbar-h`), and three surfaces then belong to that mode only:
+
+| File | What it owns |
+|------|--------------|
+| `lib/Toolbar.svelte` | the labelled, ruled control groups; one `Menu.svelte` instance is shared and its `items` swapped |
+| `lib/StatusBar.svelte` | the optional 22px bottom strip: kernel state, last evaluation time, session totals |
+| `lib/PropertiesPanel.svelte` | the sidebar that slides in from the left: notebook name and size, cell counts, kernel status with Restart/Abort, display preferences, pane layout |
+
+The panel reports only what the model actually holds. A canvas notebook has a
+title and **no file** — `saveNotebook` takes a path from a dialog and nothing
+writes it back — so Location says the notebook is unsaved rather than inventing a
+path, and Size counts characters of source rather than quoting a file size for a
+file that does not exist.
+
+Two things follow from the toolbar being *verbs*: a preference that lasts the rest
+of the session belongs in the panel instead, which is where the `In[n]` label
+toggle lives (`lib/properties.ts`), and the Sidebar group is **one** button —
+Mathematica's equivalent group carries a chat panel as its second, and a button
+that opened nothing would be worse than the asymmetry.
+
+Both panel stores are plain writables with no persistence, matching `darkMode` in
+`theme.ts`. Nothing in the app persists UI state yet, and making one preference
+the only setting that survives a restart would be a surprise rather than a
+feature.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -102,6 +102,41 @@ toggle lives (`lib/properties.ts`), and the Sidebar group is **one** button —
 Mathematica's equivalent group carries a chat panel as its second, and a button
 that opened nothing would be worse than the asymmetry.
 
+### Markdown text cells
+
+A `text` cell shows **rendered Markdown** when it is not being edited and its raw
+source while it is — the two states Jupyter has, and what the cell-type picker has
+described as "Prose / markdown" since it was written, back when nothing rendered
+any. Rendering is `lib/prose.ts` over `marked`, with `breaks: true` so a single
+newline is a line break: a cell is typed like prose, and needing two trailing
+spaces to end a line would read as the cell ignoring Return.
+
+One element switches between the two states rather than two elements swapping, so
+the existing handlers, handle registration and arrow-key navigation are untouched
+— only what is painted into it and whether it is `contenteditable` change. An
+empty cell starts in edit mode, since a rendered empty cell is a zero-height
+click target.
+
+The toolbar's **Text** group wraps the selection in `**`, `*`, `` ` `` or a link,
+via `document.execCommand('insertText')` — deprecated, and still the only API that
+edits a contenteditable while keeping the browser's native undo stack, and it
+fires `input` so the cell's existing handler saves the new source with no extra
+plumbing. The group appears for `text` only: a section or subsection is an
+`<h1>`/`<h2>` that is not Markdown-rendered, so `**bold**` there would display its
+own asterisks.
+
+There is no bullet-list button and no caret-at-click-point, both for the same
+reason — each needs to map a position through a contenteditable whose line boxes
+may be text nodes, `<div>`s or `<br>`s, and a bullet landing mid-word or a caret
+landing at the wrong offset is worse than the button not being there. Rendered
+prose reaches the DOM through `{@html}`: a notebook is an executable document
+whose code cells already evaluate arbitrary Mathilda, so HTML in its prose is not
+a new capability, and a regex pass would look like sanitisation without being it.
+
+`npm run check:prose` covers the pure half — the renderer and the marker
+constants, read out of `prose.ts` so the checks cannot drift from it. The DOM half
+needs a real pointer, since synthetic events do not reach the WKWebView.
+
 Both panel stores are plain writables with no persistence, matching `darkMode` in
 `theme.ts`. Nothing in the app persists UI state yet, and making one preference
 the only setting that survives a restart would be a surprise rather than a

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "android:build": "tauri android build",
     "sync:refpages": "node scripts/sync-refpages.mjs",
     "check:prose": "node scripts/check-prose.mjs",
-    "check:search": "node scripts/check-search.mjs"
+    "check:search": "node scripts/check-search.mjs",
+    "check:snippets": "node scripts/check-snippets.mjs"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -33,6 +34,7 @@
     "vite": "^8.1.0"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/language": "^6.12.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "android:init": "tauri android init",
     "android:dev": "tauri android dev",
     "android:build": "tauri android build",
-    "sync:refpages": "node scripts/sync-refpages.mjs"
+    "sync:refpages": "node scripts/sync-refpages.mjs",
+    "check:prose": "node scripts/check-prose.mjs"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "android:dev": "tauri android dev",
     "android:build": "tauri android build",
     "sync:refpages": "node scripts/sync-refpages.mjs",
-    "check:prose": "node scripts/check-prose.mjs"
+    "check:prose": "node scripts/check-prose.mjs",
+    "check:search": "node scripts/check-search.mjs"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/frontend/scripts/check-prose.mjs
+++ b/frontend/scripts/check-prose.mjs
@@ -1,0 +1,77 @@
+// check-prose.mjs — the frontend's behavioural checks for Markdown text cells.
+//
+// Scope, stated plainly: this covers the PURE half of prose.ts -- what the
+// renderer does to a string, and what the four marker constants wrap a selection
+// with. It does not and cannot cover the DOM half (wrapSelection's execCommand,
+// the click-to-edit swap), because synthetic events do not reach the WKWebView
+// this app actually runs in; that last mile needs a real pointer.
+//
+// The marker constants are READ OUT OF prose.ts rather than duplicated here, so
+// this file cannot quietly drift from the thing it is checking.
+//
+//     npm run check:prose
+
+import { marked } from 'marked';
+import { readFileSync } from 'fs';
+
+const OPTS = { async: false, breaks: true, gfm: true };
+const render = (s) => (!s.trim() ? '' : marked.parse(s, OPTS));
+
+let fail = 0;
+const ok = (name, cond, got) => {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}${cond ? '' : `   got: ${JSON.stringify(got)}`}`);
+  if (!cond) fail++;
+};
+
+// The claim the docstring makes about `breaks: true`: a single newline is a line
+// break, because a prose cell is typed like prose, not like a Markdown file.
+const br = render('one\ntwo');
+ok('single newline becomes <br>', br.includes('<br>'), br);
+const noBreaks = marked.parse('one\ntwo', { async: false, gfm: true });
+ok('and would NOT without breaks:true', !noBreaks.includes('<br>'), noBreaks);
+
+ok('bold',        render('**a**').includes('<strong>a</strong>'), render('**a**'));
+ok('italic',      render('*a*').includes('<em>a</em>'), render('*a*'));
+ok('inline code', render('`a`').includes('<code>a</code>'), render('`a`'));
+ok('link',        render('[t](u)').includes('href="u"'), render('[t](u)'));
+ok('table (gfm)', render('|a|\n|-|\n|b|').includes('<table>'), 'no table');
+ok('empty is exactly the empty string', render('   \n  ') === '', render('   \n  '));
+
+// The marker constants, read out of the source so the test cannot drift from it:
+// applying each to a selection must produce the source text it claims, and the
+// caret offsets must land where the comments say.
+const src = readFileSync('src/lib/prose.ts', 'utf8');
+const spec = (name) => {
+  const m = src.match(new RegExp(`${name}\\s*=\\s*\\{[^}]*before:\\s*'([^']*)'\\s*,\\s*after:\\s*'([^']*)'\\s*,\\s*caret:\\s*\\{\\s*collapsed:\\s*(\\d+),\\s*selected:\\s*(\\d+)`));
+  if (!m) throw new Error(`could not read ${name} from prose.ts`);
+  return { before: m[1], after: m[2], collapsed: +m[3], selected: +m[4] };
+};
+for (const [name, sel, want] of [
+  ['PROSE_BOLD',   'word', '**word**'],
+  ['PROSE_ITALIC', 'word', '*word*'],
+  ['PROSE_CODE',   'word', '`word`'],
+  ['PROSE_LINK',   'word', '[word]()'],
+]) {
+  const s = spec(name);
+  const out = s.before + sel + s.after;
+  ok(`${name} wraps a selection as ${want}`, out === want, out);
+  // Collapsed: the caret must end up immediately after `before`, i.e. between the
+  // markers -- so collapsed must equal the length of everything after that point.
+  const inserted = s.before + s.after;
+  ok(`${name} collapsed caret sits after '${s.before}'`,
+     inserted.length - s.collapsed === s.before.length,
+     `${inserted.length} - ${s.collapsed}`);
+  // And that the rendered result of the wrap is the markup intended.
+  if (name !== 'PROSE_LINK') {
+    const tag = { PROSE_BOLD: '<strong>', PROSE_ITALIC: '<em>', PROSE_CODE: '<code>' }[name];
+    ok(`${name} round-trips through the renderer as ${tag}`, render(out).includes(tag), render(out));
+  }
+}
+// The link's caret goes between the parens either way: ']()' minus 1 lands before ')'.
+const link = spec('PROSE_LINK');
+ok('PROSE_LINK selected caret sits between the parens',
+   link.after.length - link.selected === link.after.indexOf('(') + 1,
+   `${link.after} back ${link.selected}`);
+
+console.log(fail === 0 ? '\nall prose checks passed' : `\n${fail} FAILED`);
+process.exit(fail === 0 ? 0 : 1);

--- a/frontend/scripts/check-prose.mjs
+++ b/frontend/scripts/check-prose.mjs
@@ -1,21 +1,40 @@
-// check-prose.mjs — the frontend's behavioural checks for Markdown text cells.
+// check-prose.mjs — behavioural checks for Markdown text cells.
 //
-// Scope, stated plainly: this covers the PURE half of prose.ts -- what the
-// renderer does to a string, and what the four marker constants wrap a selection
-// with. It does not and cannot cover the DOM half (wrapSelection's execCommand,
-// the click-to-edit swap), because synthetic events do not reach the WKWebView
-// this app actually runs in; that last mile needs a real pointer.
+// Compiles src/lib/prose.ts with the project's own tsc and imports the RESULT, so
+// these run the shipped renderProse, extractMath and marker constants rather than a
+// paraphrase of them. An earlier version re-implemented the marked options here and
+// read the constants out with a regex; importing the real thing is strictly better,
+// because a paraphrase can agree with the test and disagree with the app.
 //
-// The marker constants are READ OUT OF prose.ts rather than duplicated here, so
-// this file cannot quietly drift from the thing it is checking.
+// Covers the PURE half. The DOM half (wrapSelection's execCommand, the
+// click-to-edit swap) needs a real pointer in the WKWebView.
 //
 //     npm run check:prose
 
-import { marked } from 'marked';
-import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
 
-const OPTS = { async: false, breaks: true, gfm: true };
-const render = (s) => (!s.trim() ? '' : marked.parse(s, OPTS));
+/* Emitted INSIDE the project: prose.ts imports marked and katex, and node resolves
+   bare specifiers by walking up from the importing file. */
+const out = mkdtempSync(join('node_modules', '.mathilda-prose-'));
+try {
+  execFileSync('node_modules/.bin/tsc', [
+    'src/lib/prose.ts',
+    '--target', 'es2020', '--module', 'esnext', '--moduleResolution', 'bundler',
+    '--skipLibCheck', '--ignoreConfig', '--outDir', out,
+  ], { stdio: 'inherit' });
+} catch {
+  console.error('tsc failed to compile src/lib/prose.ts');
+  process.exit(1);
+}
+const P = await import(pathToFileURL(join(out, 'prose.js')).href);
+const { renderProse, extractMath, PROSE_BOLD, PROSE_ITALIC, PROSE_CODE, PROSE_LINK,
+        PROSE_MATH } = P;
+/* Imported directly for ONE check: that `breaks: true` is load-bearing. Proving the
+   option does something requires calling marked without it. */
+const { marked } = await import('marked');
 
 let fail = 0;
 const ok = (name, cond, got) => {
@@ -23,55 +42,101 @@ const ok = (name, cond, got) => {
   if (!cond) fail++;
 };
 
-// The claim the docstring makes about `breaks: true`: a single newline is a line
-// break, because a prose cell is typed like prose, not like a Markdown file.
-const br = render('one\ntwo');
-ok('single newline becomes <br>', br.includes('<br>'), br);
-const noBreaks = marked.parse('one\ntwo', { async: false, gfm: true });
-ok('and would NOT without breaks:true', !noBreaks.includes('<br>'), noBreaks);
+// ---- Markdown ----------------------------------------------------------------
+// The claim `breaks: true` makes: a single newline is a line break, because a cell
+// is typed like prose. The negative control is the point -- without the option
+// there is no <br> at all, so the option is load-bearing rather than decorative.
+ok('single newline becomes <br>', renderProse('one\ntwo').includes('<br>'),
+   renderProse('one\ntwo'));
+ok('and would NOT without breaks:true',
+   !marked.parse('one\ntwo', { async: false, gfm: true }).includes('<br>'),
+   marked.parse('one\ntwo', { async: false, gfm: true }));
+ok('bold',        renderProse('**a**').includes('<strong>a</strong>'), renderProse('**a**'));
+ok('italic',      renderProse('*a*').includes('<em>a</em>'), renderProse('*a*'));
+ok('inline code', renderProse('`a`').includes('<code>a</code>'), renderProse('`a`'));
+ok('link',        renderProse('[t](u)').includes('href="u"'), renderProse('[t](u)'));
+ok('table (gfm)', renderProse('|a|\n|-|\n|b|').includes('<table>'), 'no table');
+ok('empty is exactly the empty string', renderProse('   \n  ') === '', renderProse('   \n  '));
 
-ok('bold',        render('**a**').includes('<strong>a</strong>'), render('**a**'));
-ok('italic',      render('*a*').includes('<em>a</em>'), render('*a*'));
-ok('inline code', render('`a`').includes('<code>a</code>'), render('`a`'));
-ok('link',        render('[t](u)').includes('href="u"'), render('[t](u)'));
-ok('table (gfm)', render('|a|\n|-|\n|b|').includes('<table>'), 'no table');
-ok('empty is exactly the empty string', render('   \n  ') === '', render('   \n  '));
+// ---- Math extraction ---------------------------------------------------------
+const hasKatex   = (s) => s.includes('class="katex');
+const hasDisplay = (s) => s.includes('katex-display');
 
-// The marker constants, read out of the source so the test cannot drift from it:
-// applying each to a selection must produce the source text it claims, and the
-// caret offsets must land where the comments say.
-const src = readFileSync('src/lib/prose.ts', 'utf8');
-const spec = (name) => {
-  const m = src.match(new RegExp(`${name}\\s*=\\s*\\{[^}]*before:\\s*'([^']*)'\\s*,\\s*after:\\s*'([^']*)'\\s*,\\s*caret:\\s*\\{\\s*collapsed:\\s*(\\d+),\\s*selected:\\s*(\\d+)`));
-  if (!m) throw new Error(`could not read ${name} from prose.ts`);
-  return { before: m[1], after: m[2], collapsed: +m[3], selected: +m[4] };
-};
-for (const [name, sel, want] of [
-  ['PROSE_BOLD',   'word', '**word**'],
-  ['PROSE_ITALIC', 'word', '*word*'],
-  ['PROSE_CODE',   'word', '`word`'],
-  ['PROSE_LINK',   'word', '[word]()'],
+ok('$x$ renders as math',        hasKatex(renderProse('$x^2$')), renderProse('$x^2$').slice(0, 80));
+ok('$$x$$ renders as DISPLAY math', hasDisplay(renderProse('$$x^2$$')), 'not display');
+ok('$x$ is inline, not display', !hasDisplay(renderProse('$x^2$')), 'was display');
+
+// THE ordering property: Markdown must not see inside the math. Handed to marked
+// first, `$a_1 * b_2$` loses `_1 * b_2` to emphasis and nothing downstream can
+// recover it.
+const emph = renderProse('$a_1 * b_2$');
+ok('markdown does not eat _ and * inside math', hasKatex(emph) && !emph.includes('<em>'), emph.slice(0, 120));
+
+// Context: a dollar inside code is a dollar.
+ok('$ inside an inline code span is literal',
+   !hasKatex(renderProse('`$x$`')) && renderProse('`$x$`').includes('$x$'), renderProse('`$x$`'));
+ok('$ inside a fenced block is literal',
+   !hasKatex(renderProse('```\n$x$\n```')), renderProse('```\n$x$\n```'));
+ok('an escaped \\$ is literal', !hasKatex(renderProse('\\$5')), renderProse('\\$5'));
+
+// The money heuristic, which is why the delimiters are not a bare regex.
+ok('"it cost $5 and $6" stays prose',
+   !hasKatex(renderProse('it cost $5 and $6')), renderProse('it cost $5 and $6'));
+ok('an unclosed $ is left as typed',
+   !hasKatex(renderProse('a $ b')), renderProse('a $ b'));
+ok('an unclosed $$ is left as typed',
+   !hasKatex(renderProse('a $$ b')), renderProse('a $$ b'));
+ok('math does not cross a blank line',
+   !hasKatex(renderProse('$a\n\nb$')), renderProse('$a\n\nb$'));
+
+// Math nests inside Markdown structure rather than replacing it.
+const boldMath = renderProse('**$x$**');
+ok('math inside bold keeps both', boldMath.includes('<strong>') && hasKatex(boldMath), boldMath.slice(0, 100));
+
+// Bad TeX must not take the cell down.
+const bad = renderProse('$\\notacommand{x}$');
+ok('unparseable TeX still returns a string', typeof bad === 'string' && bad.length > 0, bad);
+
+// The sentinel cannot collide with prose that discusses the sentinel.
+const collide = extractMath('@@MATHILDA-MATH-0@@ and $x$');
+ok('the math token is chosen so the source cannot already contain it',
+   collide.spans.length === 1 && collide.text.includes('@@MATHILDA-MATH-0@@') &&
+   collide.text.includes(collide.token(0)) && collide.token(0) !== '@@MATHILDA-MATH-0@@',
+   collide.token(0));
+ok('and such a cell still renders its math',
+   hasKatex(renderProse('@@MATHILDA-MATH-0@@ and $x$')), 'no katex');
+
+// Offsets/counts of extraction itself.
+const two = extractMath('$a$ text $$b$$');
+ok('extracts both spans with the right display flags',
+   two.spans.length === 2 && two.spans[0].display === false && two.spans[0].tex === 'a' &&
+   two.spans[1].display === true && two.spans[1].tex === 'b',
+   two.spans);
+
+// ---- Marker constants --------------------------------------------------------
+for (const [name, spec, sel, want, tag] of [
+  ['PROSE_BOLD',   PROSE_BOLD,   'word', '**word**', '<strong>'],
+  ['PROSE_ITALIC', PROSE_ITALIC, 'word', '*word*',   '<em>'],
+  ['PROSE_CODE',   PROSE_CODE,   'word', '`word`',   '<code>'],
+  ['PROSE_LINK',   PROSE_LINK,   'word', '[word]()', null],
+  ['PROSE_MATH',   PROSE_MATH,   'x',    '$x$',      null],
 ]) {
-  const s = spec(name);
-  const out = s.before + sel + s.after;
-  ok(`${name} wraps a selection as ${want}`, out === want, out);
-  // Collapsed: the caret must end up immediately after `before`, i.e. between the
-  // markers -- so collapsed must equal the length of everything after that point.
-  const inserted = s.before + s.after;
-  ok(`${name} collapsed caret sits after '${s.before}'`,
-     inserted.length - s.collapsed === s.before.length,
-     `${inserted.length} - ${s.collapsed}`);
-  // And that the rendered result of the wrap is the markup intended.
-  if (name !== 'PROSE_LINK') {
-    const tag = { PROSE_BOLD: '<strong>', PROSE_ITALIC: '<em>', PROSE_CODE: '<code>' }[name];
-    ok(`${name} round-trips through the renderer as ${tag}`, render(out).includes(tag), render(out));
-  }
+  const wrapped = spec.before + sel + spec.after;
+  ok(`${name} wraps a selection as ${want}`, wrapped === want, wrapped);
+  const inserted = spec.before + spec.after;
+  ok(`${name} collapsed caret sits after '${spec.before}'`,
+     inserted.length - spec.caret.collapsed === spec.before.length,
+     `${inserted.length} - ${spec.caret.collapsed}`);
+  if (tag) ok(`${name} round-trips through the renderer as ${tag}`,
+              renderProse(wrapped).includes(tag), renderProse(wrapped));
 }
-// The link's caret goes between the parens either way: ']()' minus 1 lands before ')'.
-const link = spec('PROSE_LINK');
+ok('PROSE_MATH round-trips through the renderer as KaTeX',
+   renderProse(PROSE_MATH.before + 'x^2' + PROSE_MATH.after).includes('class="katex'),
+   renderProse(PROSE_MATH.before + 'x^2' + PROSE_MATH.after));
 ok('PROSE_LINK selected caret sits between the parens',
-   link.after.length - link.selected === link.after.indexOf('(') + 1,
-   `${link.after} back ${link.selected}`);
+   PROSE_LINK.after.length - PROSE_LINK.caret.selected === PROSE_LINK.after.indexOf('(') + 1,
+   `${PROSE_LINK.after} back ${PROSE_LINK.caret.selected}`);
 
+rmSync(out, { recursive: true, force: true });
 console.log(fail === 0 ? '\nall prose checks passed' : `\n${fail} FAILED`);
 process.exit(fail === 0 ? 0 : 1);

--- a/frontend/scripts/check-search.mjs
+++ b/frontend/scripts/check-search.mjs
@@ -1,0 +1,105 @@
+// check-search.mjs — behavioural checks for notebook search.
+//
+// Compiles src/lib/search.ts with the project's own tsc and imports the RESULT,
+// so these run the shipped functions rather than a paraphrase of them. Covers the
+// pure half only: matching and index stepping. The DOM half (revealing a match in
+// CodeMirror or in a prose cell) needs a real pointer in the WKWebView.
+//
+//     npm run check:search
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+/* Emitted INSIDE the project, not in the system temp dir: search.ts imports
+   svelte/store, and node resolves bare specifiers by walking up from the importing
+   file -- from /tmp there is no node_modules to find. */
+const out = mkdtempSync(join('node_modules', '.mathilda-search-'));
+try {
+  execFileSync('node_modules/.bin/tsc', [
+    'src/lib/search.ts',
+    '--target', 'es2020', '--module', 'esnext', '--moduleResolution', 'bundler',
+    '--skipLibCheck', '--ignoreConfig', '--outDir', out,
+  ], { stdio: 'inherit' });
+} catch {
+  console.error('tsc failed to compile src/lib/search.ts');
+  process.exit(1);
+}
+
+const { findMatches, stepIndex } = await import(pathToFileURL(join(out, 'search.js')).href);
+
+let fail = 0;
+const ok = (name, cond, got) => {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}${cond ? '' : `   got: ${JSON.stringify(got)}`}`);
+  if (!cond) fail++;
+};
+const eq = (name, got, want) =>
+  ok(`${name}`, JSON.stringify(got) === JSON.stringify(want), got);
+
+const cells = [
+  { id: 'c1', source: 'Sin[x] + sin[y]' },
+  { id: 'c2', source: 'Table[i, {i, 4}]' },
+  { id: 'c3', source: 'aaaa' },
+];
+
+eq('empty query finds nothing', findMatches(cells, '', false), []);
+
+// NON-OVERLAPPING is the property, and "aa" in "aaaa" is the case that separates
+// it from the naive from = at + 1 loop, which would give three matches.
+eq('"aa" in "aaaa" gives 2 non-overlapping matches',
+   findMatches([{ id: 'c3', source: 'aaaa' }], 'aa', false),
+   [{ cellId: 'c3', start: 0, end: 2 }, { cellId: 'c3', start: 2, end: 4 }]);
+
+// Case folding, both ways, on a source that contains both spellings.
+eq('case-insensitive finds both spellings',
+   findMatches([cells[0]], 'sin', false).map(m => m.start), [0, 9]);
+eq('case-sensitive finds only the exact one',
+   findMatches([cells[0]], 'sin', true).map(m => m.start), [9]);
+eq('case-sensitive finds only the other exact one',
+   findMatches([cells[0]], 'Sin', true).map(m => m.start), [0]);
+
+// Offsets must be usable directly as source offsets -- that is what the CodeMirror
+// dispatch relies on.
+const m0 = findMatches([cells[0]], 'sin', true)[0];
+ok('offsets slice out the match', cells[0].source.slice(m0.start, m0.end) === 'sin',
+   cells[0].source.slice(m0.start, m0.end));
+
+// Document order: cells in notebook order, offsets ascending within a cell.
+const multi = findMatches(cells, 'a', false);
+ok('matches come in document order',
+   multi.every((m, i) => i === 0 || cellRank(m) > cellRank(multi[i - 1]) ||
+                         (m.cellId === multi[i - 1].cellId && m.start > multi[i - 1].start)),
+   multi.map(m => `${m.cellId}:${m.start}`));
+function cellRank(m) { return cells.findIndex(c => c.id === m.cellId); }
+
+ok('every match carries the id of the cell it is in',
+   multi.every(m => cells.find(c => c.id === m.cellId)?.source
+                         .slice(m.start, m.end).toLowerCase() === 'a'),
+   multi);
+
+// A single space is a real search; only the empty string is rejected.
+ok('a space is a legitimate query',
+   findMatches([cells[1]], ' ', false).length === 2,
+   findMatches([cells[1]], ' ', false).length);
+
+ok('a query longer than the source finds nothing',
+   findMatches([{ id: 'x', source: 'ab' }], 'abc', false).length === 0, 'found some');
+
+// stepIndex: the negative-modulo trap. In JavaScript -1 % 3 is -1, so the naive
+// form sends Shift+Enter at the first match to a negative index.
+eq('stepping back from the first match wraps to the last', stepIndex(0, -1, 3), 2);
+eq('stepping forward from the last wraps to the first', stepIndex(2, 1, 3), 0);
+eq('stepping forward in the middle', stepIndex(0, 1, 3), 1);
+eq('no matches stays at 0', stepIndex(0, 1, 0), 0);
+eq('a single match stays put going forward', stepIndex(0, 1, 1), 0);
+eq('a single match stays put going back', stepIndex(0, -1, 1), 0);
+// Walking a full cycle in each direction must return to the start exactly.
+let i = 0; for (let k = 0; k < 7; k++) i = stepIndex(i, 1, 7);
+eq('a full forward cycle returns to the start', i, 0);
+let j = 0; for (let k = 0; k < 7; k++) j = stepIndex(j, -1, 7);
+eq('a full backward cycle returns to the start', j, 0);
+
+rmSync(out, { recursive: true, force: true });
+console.log(fail === 0 ? '\nall search checks passed' : `\n${fail} FAILED`);
+process.exit(fail === 0 ? 0 : 1);

--- a/frontend/scripts/check-snippets.mjs
+++ b/frontend/scripts/check-snippets.mjs
@@ -1,0 +1,88 @@
+// check-snippets.mjs — the Insert palette's templates, judged by Mathilda's parser.
+//
+// The machinery is CodeMirror's; the templates are ours, and they are the risk. A
+// template with an unbalanced bracket produces a broken cell every time the button
+// is pressed, and reading `{{${a}, ${b}}, {${c}, ${d}}}` is a poor way to notice.
+//
+// So each template is expanded (every ${field} left at its placeholder name) and fed
+// to the real Mathilda binary inside Hold[...], which parses without evaluating --
+// Plot[] must not open a window, and a definition must not define anything. A
+// template whose expansion does not parse fails here. That is stronger than counting
+// brackets: it is the language's own parser agreeing the insertion is valid.
+//
+//     npm run check:snippets
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+
+const out = mkdtempSync(join('node_modules', '.mathilda-snip-'));
+try {
+  execFileSync('node_modules/.bin/tsc', [
+    'src/lib/snippets.ts',
+    '--target', 'es2020', '--module', 'esnext', '--moduleResolution', 'bundler',
+    '--skipLibCheck', '--ignoreConfig', '--outDir', out,
+  ], { stdio: 'inherit' });
+} catch {
+  console.error('tsc failed to compile src/lib/snippets.ts');
+  process.exit(1);
+}
+const { SNIPPETS, expandedText } = await import(pathToFileURL(join(out, 'snippets.js')).href);
+
+let fail = 0;
+const ok = (name, cond, got) => {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}${cond ? '' : `   got: ${JSON.stringify(got)}`}`);
+  if (!cond) fail++;
+};
+
+ok('the palette is not empty', SNIPPETS.length > 0, SNIPPETS.length);
+ok('every entry has a label and a template',
+   SNIPPETS.every(s => s.label && s.template), SNIPPETS);
+ok('labels are unique', new Set(SNIPPETS.map(s => s.label)).size === SNIPPETS.length,
+   SNIPPETS.map(s => s.label));
+ok('every template has at least one field',
+   SNIPPETS.every(s => /\$\{[^}]*\}/.test(s.template)),
+   SNIPPETS.filter(s => !/\$\{[^}]*\}/.test(s.template)).map(s => s.label));
+
+for (const s of SNIPPETS) {
+  const e = expandedText(s.template);
+  ok(`${s.label}: expansion leaves no field syntax`, !e.includes('${'), e);
+  // Brackets, counted here as well as parsed below: the count says WHICH kind is
+  // unbalanced, where the parser only says the line is wrong.
+  for (const [o, c] of [['[', ']'], ['{', '}'], ['(', ')']]) {
+    const a = e.split(o).length - 1, b = e.split(c).length - 1;
+    ok(`${s.label}: ${o}${c} balance`, a === b, `${a} vs ${b} in ${e}`);
+  }
+}
+
+// ---- the parser -------------------------------------------------------------
+const bin = '../Mathilda';
+if (!existsSync(bin)) {
+  console.log('\nSKIP  Mathilda binary not built, so the parser half did not run (make -j)');
+} else {
+  /* One file, one Hold[...] per template. A syntax error stops the whole script
+     before anything evaluates and is reported as file:LINE: syntax error, so the
+     line number names the template -- which is why they go one per line in order. */
+  const lines = SNIPPETS.map(s => `Hold[${expandedText(s.template)}];`);
+  const file = join(out, 'snippets.m');
+  writeFileSync(file, lines.join('\n') + '\n');
+  let res = '', code = 0;
+  try {
+    res = execFileSync(bin, ['-file', file], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (err) {
+    code = err.status ?? 1;
+    res = String(err.stdout ?? '') + String(err.stderr ?? '');
+  }
+  const m = res.match(/:(\d+):\s*syntax error/);
+  if (m) {
+    const which = SNIPPETS[+m[1] - 1];
+    ok(`every expansion parses (failed on ${which ? which.label : 'line ' + m[1]})`, false, res.trim());
+  } else {
+    ok(`every expansion parses in Mathilda (${SNIPPETS.length} templates)`, code === 0, res.trim());
+  }
+}
+
+rmSync(out, { recursive: true, force: true });
+console.log(fail === 0 ? '\nall snippet checks passed' : `\n${fail} FAILED`);
+process.exit(fail === 0 ? 0 : 1);

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,6 +11,7 @@
   import { getCurrentWindow } from '@tauri-apps/api/window';
   import Canvas from './lib/Canvas.svelte';
   import Toolbar from './lib/Toolbar.svelte';
+  import PropertiesPanel from './lib/PropertiesPanel.svelte';
   import { kernelStatus } from './lib/notebook';
   import { darkMode } from './lib/theme';
   import { pingKernel, saveLibrary, loadLibrary, setWindowTitle as setTitleCmd } from './lib/ipc';
@@ -179,6 +180,12 @@
     </button>
   {/if}
 </div>
+
+<!-- Properties sidebar. Focused mode only: it reports on the notebook in the
+     active pane, and on the canvas there is no active pane to report on. -->
+{#if $canvasState.focusedIds.length}
+  <PropertiesPanel />
+{/if}
 
 <!-- Kernel dead banner -->
 {#if $kernelStatus === 'dead'}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,6 +12,9 @@
   import Canvas from './lib/Canvas.svelte';
   import Toolbar from './lib/Toolbar.svelte';
   import PropertiesPanel from './lib/PropertiesPanel.svelte';
+  import SearchBar from './lib/SearchBar.svelte';
+  import { searchOpen } from './lib/search';
+  import { uiScale } from './lib/properties';
   import { kernelStatus } from './lib/notebook';
   import { darkMode } from './lib/theme';
   import { pingKernel, saveLibrary, loadLibrary, setWindowTitle as setTitleCmd } from './lib/ipc';
@@ -133,20 +136,30 @@
      menu. Two implementations of "abort" is how one of them ends up wrong. */
 
   // ---------------------------------------------------------------------------
-  // Global UI scale (Cmd+= zoom in, Cmd+- zoom out, Cmd+0 reset)
-  let uiScale = 1.0;
-  $: document.documentElement.style.fontSize = `${uiScale * 16}px`;
+  /* Global UI scale (Cmd+= zoom in, Cmd+- zoom out, Cmd+0 reset).
+     A store rather than a local, so the properties panel can offer the SAME value
+     the keyboard drives. Two independent scales would drift apart. */
+  $: document.documentElement.style.fontSize = `${$uiScale * 16}px`;
 
   function onKeydown(e: KeyboardEvent) {
     const mod = e.metaKey || e.ctrlKey;
     if (!mod) return;
     if (e.key === 's' || e.key === 'S') { e.preventDefault(); saveFile(); return; }
     if (e.key === 'o' || e.key === 'O') { e.preventDefault(); openFile(); return; }
+    /* Cmd+F is free: @codemirror/search is not installed, so no editor claims it.
+       Focused mode only -- on the canvas there is no notebook to search. */
+    if (e.key === 'f' || e.key === 'F') {
+      if ($canvasState.focusedIds.length) { e.preventDefault(); searchOpen.set(true); }
+      return;
+    }
     // Cmd+= / Cmd++ → scale up; Cmd+- → scale down; Cmd+0 → reset
     if (e.key === '=' || e.key === '+') {
-      e.preventDefault(); uiScale = Math.min(2.0, +(uiScale + 0.1).toFixed(1));
+      e.preventDefault(); uiScale.update(v => Math.min(2.0, +(v + 0.1).toFixed(1)));
     } else if (e.key === '-' || e.key === '_') {
-      e.preventDefault(); uiScale = Math.max(0.5, +(uiScale - 0.1).toFixed(1));
+      e.preventDefault(); uiScale.update(v => Math.max(0.5, +(v - 0.1).toFixed(1)));
+    } else if (e.key === '0') {
+      /* The comment above has promised this since it was written. */
+      e.preventDefault(); uiScale.set(1.0);
     }
   }
 </script>
@@ -185,6 +198,7 @@
      active pane, and on the canvas there is no active pane to report on. -->
 {#if $canvasState.focusedIds.length}
   <PropertiesPanel />
+  <SearchBar />
 {/if}
 
 <!-- Kernel dead banner -->

--- a/frontend/src/lib/CellShell.svelte
+++ b/frontend/src/lib/CellShell.svelte
@@ -19,6 +19,7 @@
   import RefPage from './RefPage.svelte';
   import type { Cell, CellType, OutputItem } from './notebook';
   import { showExecLabels } from './properties';
+  import { renderProse } from './prose';
   import { selectedCells, selectOnly, toggleSelect, rangeSelect, clearSelection } from './notebook';
   import { registerHandle, unregisterHandle, setActiveCell, markBlurred } from './active';
 
@@ -263,6 +264,52 @@
     }
   }
 
+  /* A text cell shows RENDERED Markdown until you click into it, and its raw
+     source while you are editing -- the same two states Jupyter has, and what the
+     cell-type picker has promised ("Prose / markdown") since it was written.
+
+     One element rather than two, so every handler below, the handle registration
+     and the arrow-key navigation stay exactly as they were; only what is painted
+     into it and whether it is editable change.
+
+     A cell with no source starts in edit mode. Rendered-empty is a zero-height
+     box, and asking someone to click one is asking them to guess. */
+  let textEditing = cell.type === 'text' ? cell.source.trim() === '' : false;
+  $: renderedProse = cell.type === 'text' ? renderProse(cell.source) : '';
+
+  function paintProse() {
+    if (!proseEl) return;
+    if (cell.type !== 'text' || textEditing) proseEl.innerText = cell.source;
+    else proseEl.innerHTML = renderedProse;
+  }
+
+  /* Safe to repaint on every source change here, unlike the identity block below:
+     while NOT editing there is no caret in the element to clobber. */
+  $: if (proseEl && cell.type === 'text' && !textEditing) proseEl.innerHTML = renderedProse;
+
+  /* Entering edit mode has to wait a tick: `contenteditable` is still false in
+     the DOM until Svelte flushes, and focusing a non-editable div does nothing. */
+  async function enterProseEdit() {
+    if (cell.type !== 'text' || textEditing) return;
+    textEditing = true;
+    await tick();
+    if (!proseEl) return;
+    proseEl.innerText = cell.source;
+    /* The caret lands where focus() puts it, not at the click point. Mapping a
+       click to an offset in the SOURCE would mean mapping through the rendered
+       HTML, where `**bold**` is four visible characters and six source ones, so
+       caretRangeFromPoint would answer a different question than the one asked.
+       Jupyter has the same behaviour for the same reason. */
+    proseEl.focus();
+  }
+
+  /** Programmatic focus (arrow navigation, split, the toolbar) must open the
+   *  editor first, or it would focus a rendered, non-editable div. */
+  function focusProse() {
+    if (cell.type === 'text') { void enterProseEdit(); return; }
+    proseEl?.focus();
+  }
+
   // Focus ref + contenteditable state management
   let proseEl: HTMLElement;
   let _lastCellId = '';
@@ -272,21 +319,28 @@
   // If we update on every cell.source change, Svelte overwrites the user's
   // typed content, causing the duplication bug.
   $: if (proseEl && cell.id !== _lastCellId) {
-    proseEl.innerText = cell.source;
+    /* A different cell arrived in this component: it gets its own edit state, or
+       a rendered cell would inherit the previous one's open editor. */
+    textEditing = cell.type === 'text' ? cell.source.trim() === '' : false;
+    paintProse();
     _lastCellId = cell.id;
     // Register focus fn once the element exists
     dispatch('register', {
       id: cell.id,
-      fn: () => { proseEl?.focus(); },
+      fn: () => { focusProse(); },
     });
-    registerHandle(cell.id, { view: null, el: proseEl, focus: () => proseEl?.focus() });
+    registerHandle(cell.id, { view: null, el: proseEl, focus: () => focusProse() });
   }
 
   /* focus/blur do NOT bubble, so these have to sit on the contenteditable
      itself -- a focusin handler on .cell-shell could not tell which of a row's
      side-by-side cells the caret landed in. */
   function onProseFocus() { setActiveCell(notebookId, cell.id, cell.type); }
-  function onProseBlur()  { markBlurred(cell.id); }
+  function onProseBlur()  {
+    markBlurred(cell.id);
+    /* Leaving the cell renders it; the reactive repaint above does the painting. */
+    if (cell.type === 'text') textEditing = false;
+  }
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
@@ -372,13 +426,15 @@
       <!-- Content set via JS ($: proseEl update) to avoid contenteditable doubling -->
       <div
         class="prose-cell"
-        contenteditable="true"
+        class:prose-rendered={!textEditing}
+        class:prose-empty={!textEditing && !renderedProse}
+        contenteditable={textEditing}
         bind:this={proseEl}
         on:input={onTextInput}
         on:keydown={onProseKeydown}
         on:focus={onProseFocus}
         on:blur={onProseBlur}
-        on:click|stopPropagation
+        on:click|stopPropagation={() => enterProseEdit()}
       ></div>
 
     {:else if cell.type === 'section'}
@@ -585,6 +641,48 @@
   :global(.cm-editor .cm-cursor-primary) { border-left-color: #89b4fa !important; }
 
   /* prose / heading cells */
+  /* Rendered mode. Not editable, so it needs its own affordance: the cursor says
+     "click to edit" and an empty cell keeps a clickable line's worth of height,
+     since a rendered empty cell is otherwise a zero-height target. */
+  .prose-cell.prose-rendered { cursor: text; }
+  .prose-cell.prose-empty::before {
+    content: 'Text';
+    opacity: 0.35;
+  }
+  /* Markdown produces block elements the raw-text cell never contained. They are
+     given the cell's own rhythm rather than the browser's defaults, which would
+     open a paragraph gap at the top of every cell. */
+  .prose-cell.prose-rendered :global(p:first-child) { margin-top: 0; }
+  .prose-cell.prose-rendered :global(p:last-child)  { margin-bottom: 0; }
+  .prose-cell.prose-rendered :global(p) { margin: 0.5em 0; }
+  .prose-cell.prose-rendered :global(ul),
+  .prose-cell.prose-rendered :global(ol) { margin: 0.5em 0; padding-left: 1.4em; }
+  .prose-cell.prose-rendered :global(code) {
+    font-family: var(--mono, ui-monospace, monospace);
+    font-size: 0.92em;
+    background: var(--code-bg);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+  .prose-cell.prose-rendered :global(pre) {
+    background: var(--code-bg);
+    padding: 8px 10px;
+    border-radius: 4px;
+    overflow-x: auto;
+  }
+  .prose-cell.prose-rendered :global(pre code) { background: none; padding: 0; }
+  .prose-cell.prose-rendered :global(a) { color: var(--accent); }
+  .prose-cell.prose-rendered :global(blockquote) {
+    margin: 0.5em 0;
+    padding-left: 0.8em;
+    border-left: 2px solid var(--border);
+    color: var(--text-muted);
+  }
+  /* A table in prose scrolls inside its own box rather than widening the cell. */
+  .prose-cell.prose-rendered :global(table) { border-collapse: collapse; display: block; overflow-x: auto; }
+  .prose-cell.prose-rendered :global(th),
+  .prose-cell.prose-rendered :global(td) { border: 1px solid var(--border); padding: 3px 7px; }
+
   .prose-cell {
     padding: 6px 8px;
     font-size: 0.95rem;

--- a/frontend/src/lib/CellShell.svelte
+++ b/frontend/src/lib/CellShell.svelte
@@ -20,6 +20,11 @@
   import type { Cell, CellType, OutputItem } from './notebook';
   import { showExecLabels } from './properties';
   import { renderProse } from './prose';
+  /* Rendered prose can contain KaTeX, so this component owns the stylesheet.
+     Output.svelte imports it too and Vite dedupes; relying on ANOTHER component's
+     import would leave prose unstyled the day that one changed. It cannot live in
+     prose.ts, where a CSS import would break the node-run checks. */
+  import 'katex/dist/katex.min.css';
   import { selectedCells, selectOnly, toggleSelect, rangeSelect, clearSelection } from './notebook';
   import { registerHandle, unregisterHandle, setActiveCell, markBlurred } from './active';
 

--- a/frontend/src/lib/CellShell.svelte
+++ b/frontend/src/lib/CellShell.svelte
@@ -18,6 +18,7 @@
   import Output from './Output.svelte';
   import RefPage from './RefPage.svelte';
   import type { Cell, CellType, OutputItem } from './notebook';
+  import { showExecLabels } from './properties';
   import { selectedCells, selectOnly, toggleSelect, rangeSelect, clearSelection } from './notebook';
   import { registerHandle, unregisterHandle, setActiveCell, markBlurred } from './active';
 
@@ -309,7 +310,7 @@
         disabled={cell.status === 'running'}
         on:click|stopPropagation={() => dispatch('run', { id: cell.id })}
       >{#if cell.status === 'running'}<span class="spinner">●</span>{:else}▶{/if}</button>
-      {#if cell.execIdx != null}
+      {#if cell.execIdx != null && $showExecLabels}
         <span class="exec-label">In[{cell.execIdx}]</span>
       {/if}
     {:else if !headingReadonly}

--- a/frontend/src/lib/PropertiesPanel.svelte
+++ b/frontend/src/lib/PropertiesPanel.svelte
@@ -1,0 +1,308 @@
+<!--
+  PropertiesPanel.svelte — the sidebar that slides in from the left of the
+  focused view.
+
+  It answers questions about the notebook you are looking at that nothing else in
+  the window can: how big it actually is, whether the kernel is alive, and the two
+  display preferences that are settings rather than actions. The toolbar is for
+  verbs; a preference that persists for the rest of the session does not belong
+  in a strip of buttons, which is why the In[n] label toggle lives here.
+
+  WHAT IT DELIBERATELY DOES NOT CLAIM. A notebook on this canvas has a title and
+  no file: `saveNotebook` takes a path from a dialog at the moment of saving, and
+  nothing writes that path back into the model. So the Location row says the
+  notebook is unsaved rather than inventing a path, and Size is measured from the
+  content -- cells, and the characters of source they hold -- which is a real
+  number about a real object. A "42 KB" for a file that does not exist would be a
+  fabrication, and the panel's whole value is that its numbers can be trusted.
+-->
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import Icon from './Icon.svelte';
+  import { canvasState, activeActions, setFocusLayout } from './canvas';
+  import type { FocusLayout } from './canvas';
+  import { kernelStatus } from './notebook';
+  import type { Cell, NotebookRow } from './notebook';
+  import { restart, abortEvaluation } from './kernelActions';
+  import { darkMode } from './theme';
+  import { propertiesOpen, showExecLabels } from './properties';
+
+  const KERNEL_LABEL: Record<string, string> = {
+    starting:   'Starting…',
+    ready:      'Ready',
+    busy:       'Running',
+    restarting: 'Restarting…',
+    dead:       'Not running',
+  };
+
+  /* The active pane's rows, subscribed by hand: the store identity changes when
+     the active pane changes, and `$store` auto-subscription only works on a fixed
+     identifier. Same reason StatusBar does it this way. */
+  let rows: NotebookRow[] = [];
+  let unsub: (() => void) | null = null;
+  $: {
+    unsub?.();
+    unsub = null;
+    const store = $activeActions?.store;
+    if (store) unsub = store.subscribe((r: NotebookRow[]) => { rows = r; });
+    else rows = [];
+  }
+  onDestroy(() => unsub?.());
+
+  $: cells = rows.flatMap(r => r.cells) as Cell[];
+  $: codeCells  = cells.filter(c => c.type === 'code').length;
+  $: textCells  = cells.length - codeCells;
+  $: evaluated  = cells.filter(c => c.execIdx != null).length;
+  /* Characters of source, which is what the notebook actually weighs. Outputs are
+     excluded on purpose: they are recomputable and would make the number jump
+     around as cells run, which reads as a bug rather than a measurement. */
+  $: sourceChars = cells.reduce((n, c) => n + (c.source?.length ?? 0), 0);
+
+  $: title = $activeActions
+    ? ($canvasState.notebooks.find(nb => nb.id === $activeActions!.notebookId)?.title ?? '—')
+    : '—';
+  $: isRefpage = $activeActions
+    ? ($canvasState.notebooks.find(nb => nb.id === $activeActions!.notebookId)?.refpage ?? false)
+    : false;
+
+  $: paneCount = $canvasState.focusedIds.length;
+  $: layout = $canvasState.focusedLayout as FocusLayout;
+
+  function fmtChars(n: number): string {
+    if (n < 1000) return `${n} characters`;
+    return `${(n / 1000).toFixed(1)}k characters`;
+  }
+</script>
+
+<!-- aria-hidden while closed so the panel's controls leave the tab order with
+     it; the transform alone would keep them focusable off-screen. -->
+<aside
+  class="props"
+  class:open={$propertiesOpen}
+  aria-hidden={!$propertiesOpen}
+  aria-label="Notebook properties"
+>
+  <header class="props-head">
+    <span class="props-title">Properties</span>
+    <button
+      class="props-close"
+      title="Close properties"
+      tabindex={$propertiesOpen ? 0 : -1}
+      on:pointerdown|preventDefault
+      on:click={() => propertiesOpen.set(false)}
+    ><Icon name="close" /></button>
+  </header>
+
+  <section class="props-sec">
+    <h3>Notebook</h3>
+    <div class="row"><span class="k">Name</span><span class="v" title={title}>{title}</span></div>
+    <div class="row">
+      <span class="k">Location</span>
+      <!-- Honest: a canvas notebook has no file until a save dialog gives it one,
+           and that path is never written back into the model. -->
+      <span class="v muted">{isRefpage ? 'Generated reference page' : 'Not saved to a file'}</span>
+    </div>
+    <div class="row"><span class="k">Size</span><span class="v">{fmtChars(sourceChars)}</span></div>
+  </section>
+
+  <section class="props-sec">
+    <h3>Cells</h3>
+    <div class="row"><span class="k">Total</span><span class="v">{cells.length}</span></div>
+    <div class="row"><span class="k">Code</span><span class="v">{codeCells}</span></div>
+    <div class="row"><span class="k">Text</span><span class="v">{textCells}</span></div>
+    <div class="row">
+      <span class="k">Evaluated</span>
+      <span class="v">{evaluated} of {codeCells}</span>
+    </div>
+  </section>
+
+  <section class="props-sec">
+    <h3>Kernel</h3>
+    <div class="row">
+      <span class="k">Status</span>
+      <span class="v" class:bad={$kernelStatus === 'dead'}>
+        {KERNEL_LABEL[$kernelStatus] ?? $kernelStatus}
+      </span>
+    </div>
+    <div class="btn-row">
+      <button
+        class="props-btn"
+        tabindex={$propertiesOpen ? 0 : -1}
+        title="Restart the kernel, discarding every definition in the session"
+        on:pointerdown|preventDefault
+        on:click={() => restart()}
+      ><Icon name="restart" /> Restart</button>
+      <!-- Disabled unless there is something to abort: abortEvaluation restarts
+           the kernel, so offering it against an idle kernel invites throwing away
+           a session's definitions for no reason. -->
+      <button
+        class="props-btn"
+        tabindex={$propertiesOpen ? 0 : -1}
+        disabled={$kernelStatus !== 'busy' && $kernelStatus !== 'restarting'}
+        title="Abort the running evaluation"
+        on:pointerdown|preventDefault
+        on:click={() => abortEvaluation()}
+      ><Icon name="abort" /> Abort</button>
+    </div>
+  </section>
+
+  <section class="props-sec">
+    <h3>Display</h3>
+    <label class="check">
+      <input
+        type="checkbox"
+        tabindex={$propertiesOpen ? 0 : -1}
+        checked={$darkMode}
+        on:change={() => darkMode.update(v => !v)}
+      />
+      Dark theme
+    </label>
+    <label class="check">
+      <input
+        type="checkbox"
+        tabindex={$propertiesOpen ? 0 : -1}
+        checked={$showExecLabels}
+        on:change={() => showExecLabels.update(v => !v)}
+      />
+      Show In[n] labels
+    </label>
+  </section>
+
+  <!-- Layout is only a question when there is more than one pane; with one pane
+       the buttons would be inert controls, so the section is absent instead. -->
+  {#if paneCount > 1}
+    <section class="props-sec">
+      <h3>Layout</h3>
+      <div class="btn-row">
+        <button
+          class="props-btn"
+          class:on={layout === 'h'}
+          tabindex={$propertiesOpen ? 0 : -1}
+          title="Side by side"
+          on:pointerdown|preventDefault
+          on:click={() => setFocusLayout('h')}
+        ><Icon name="layoutH" /> Columns</button>
+        <button
+          class="props-btn"
+          class:on={layout === 'v'}
+          tabindex={$propertiesOpen ? 0 : -1}
+          title="Stacked"
+          on:pointerdown|preventDefault
+          on:click={() => setFocusLayout('v')}
+        ><Icon name="layoutV" /> Rows</button>
+      </div>
+      <div class="row"><span class="k">Panes</span><span class="v">{paneCount}</span></div>
+    </section>
+  {/if}
+</aside>
+
+<style>
+  /* Slides in from the LEFT, under the toolbar and above the panes. Transformed
+     rather than width-animated: animating width reflows the pane grid on every
+     frame, and the panes contain editors. */
+  .props {
+    position: absolute;
+    top: var(--toolbar-h, 46px);      /* the FOCUSED strip is 46px; --appbar-h is the canvas's 34 */
+    left: 0;
+    bottom: 0;
+    width: 232px;
+    z-index: 40;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow-y: auto;
+    padding: 10px 12px 16px;
+    box-sizing: border-box;
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    transform: translateX(-100%);
+    transition: transform 140ms ease;
+    font-size: 12px;
+  }
+  .props.open { transform: translateX(0); }
+  @media (prefers-reduced-motion: reduce) {
+    .props { transition: none; }
+  }
+
+  .props-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .props-title {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+  }
+  .props-close {
+    display: flex;
+    align-items: center;
+    background: none;
+    border: none;
+    padding: 2px;
+    cursor: pointer;
+    color: var(--text-dim);
+  }
+  .props-close:hover { color: var(--text); }
+
+  .props-sec { padding: 6px 0; border-top: 1px solid var(--border); }
+  .props-sec h3 {
+    margin: 0 0 5px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-dim);
+  }
+
+  .row {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 2px 0;
+    line-height: 1.5;
+  }
+  .k { color: var(--text-dim); flex: 0 0 auto; }
+  /* The value can be a long title; it truncates rather than widening the panel. */
+  .v {
+    color: var(--text);
+    text-align: right;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+  .v.muted { color: var(--text-muted); }
+  .v.bad { color: var(--err); }
+
+  .btn-row { display: flex; gap: 6px; margin: 4px 0; }
+  .props-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex: 1 1 0;
+    justify-content: center;
+    padding: 4px 6px;
+    font: inherit;
+    font-size: 11px;
+    color: var(--text);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    cursor: pointer;
+  }
+  .props-btn:hover:not(:disabled) { border-color: var(--accent); }
+  .props-btn:disabled { opacity: 0.45; cursor: default; }
+  .props-btn.on { border-color: var(--accent); color: var(--accent); }
+
+  .check {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 0;
+    cursor: pointer;
+    color: var(--text);
+  }
+  .check input { margin: 0; }
+</style>

--- a/frontend/src/lib/PropertiesPanel.svelte
+++ b/frontend/src/lib/PropertiesPanel.svelte
@@ -25,7 +25,7 @@
   import type { Cell, NotebookRow } from './notebook';
   import { restart, abortEvaluation } from './kernelActions';
   import { darkMode } from './theme';
-  import { propertiesOpen, showExecLabels } from './properties';
+  import { propertiesOpen, showExecLabels, uiScale, UI_SCALE_STEPS } from './properties';
 
   const KERNEL_LABEL: Record<string, string> = {
     starting:   'Starting…',
@@ -166,6 +166,26 @@
       />
       Show In[n] labels
     </label>
+
+    <!-- Scale drives the SAME store Cmd+= / Cmd+- / Cmd+0 have always driven; the
+         panel is a second way in, not a second setting. A step reads as selected
+         only on an exact match, because the keyboard moves in 0.1 and would
+         otherwise light up the nearest button while sitting between two. -->
+    <div class="row scale-row">
+      <span class="k">Scale</span>
+      <span class="scale-steps">
+        {#each UI_SCALE_STEPS as step}
+          <button
+            class="props-btn scale-btn"
+            class:on={$uiScale === step}
+            tabindex={$propertiesOpen ? 0 : -1}
+            title={`Set the interface scale to ${Math.round(step * 100)}%`}
+            on:pointerdown|preventDefault
+            on:click={() => uiScale.set(step)}
+          >{Math.round(step * 100)}%</button>
+        {/each}
+      </span>
+    </div>
   </section>
 
   <!-- Layout is only a question when there is more than one pane; with one pane
@@ -295,6 +315,10 @@
   .props-btn:hover:not(:disabled) { border-color: var(--accent); }
   .props-btn:disabled { opacity: 0.45; cursor: default; }
   .props-btn.on { border-color: var(--accent); color: var(--accent); }
+
+  .scale-row { align-items: center; }
+  .scale-steps { display: flex; gap: 4px; }
+  .scale-btn { flex: 0 0 auto; padding: 3px 5px; font-size: 10px; }
 
   .check {
     display: flex;

--- a/frontend/src/lib/SearchBar.svelte
+++ b/frontend/src/lib/SearchBar.svelte
@@ -1,0 +1,216 @@
+<!--
+  SearchBar.svelte — find across every cell of the focused notebook.
+
+  Sits under the toolbar, opens on Cmd+F, and reports "n of m" over the WHOLE
+  notebook rather than the focused cell. See search.ts for why this is not
+  @codemirror/search.
+
+  Navigation drives whichever editor owns the match: a code cell gets a real
+  CodeMirror selection and scroll, a prose cell is opened for editing and its
+  range selected. What it does NOT do is highlight every match at once -- that
+  needs a CodeMirror decoration extension per cell, which is its own change; the
+  count tells you how many there are and Enter walks them.
+-->
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { onDestroy } from 'svelte';
+  import Icon from './Icon.svelte';
+  import { activeActions } from './canvas';
+  import { getHandle } from './active';
+  import type { Cell, NotebookRow } from './notebook';
+  import { searchOpen, searchQuery, searchCaseSensitive, searchIndex,
+           findMatches, stepIndex } from './search';
+  import type { SearchMatch } from './search';
+
+  let inputEl: HTMLInputElement | undefined;
+
+  /* The active pane's rows, subscribed by hand: the store identity changes with
+     the pane, and `$store` only auto-subscribes a fixed identifier. */
+  let rows: NotebookRow[] = [];
+  let unsub: (() => void) | null = null;
+  $: {
+    unsub?.();
+    unsub = null;
+    const store = $activeActions?.store;
+    if (store) unsub = store.subscribe((r: NotebookRow[]) => { rows = r; });
+    else rows = [];
+  }
+  onDestroy(() => unsub?.());
+
+  $: cells = rows.flatMap(r => r.cells) as Cell[];
+  $: matches = findMatches(cells, $searchQuery, $searchCaseSensitive);
+  /* Clamped rather than reset: editing the query usually shortens the list, and
+     jumping back to the first match every keystroke would fight the typist. */
+  $: current = matches.length ? Math.min($searchIndex, matches.length - 1) : 0;
+
+  /* Focus the field when the bar opens. Not on every render -- that would steal
+     focus back from the notebook after every jump. */
+  let wasOpen = false;
+  $: if ($searchOpen !== wasOpen) {
+    wasOpen = $searchOpen;
+    if ($searchOpen) void openFocus();
+  }
+  async function openFocus() {
+    await tick();
+    inputEl?.focus();
+    inputEl?.select();
+  }
+
+  function close() {
+    searchOpen.set(false);
+  }
+
+  function go(delta: number) {
+    if (!matches.length) return;
+    const next = stepIndex(current, delta, matches.length);
+    searchIndex.set(next);
+    void reveal(matches[next]);
+  }
+
+  /** Put the match on screen and select it in whichever editor owns it. */
+  async function reveal(m: SearchMatch) {
+    const h = getHandle(m.cellId);
+    if (!h) return;
+    if (h.view) {
+      /* A code cell: CodeMirror does the selection and the scrolling, and the
+         offsets are already source offsets, which is what it wants. */
+      h.view.dispatch({
+        selection: { anchor: m.start, head: m.end },
+        scrollIntoView: true,
+      });
+      h.view.focus();
+      return;
+    }
+    /* A prose cell. focus() opens the editor if the cell was showing rendered
+       Markdown, and that is asynchronous, so the range is selected after the
+       flush. Selecting is only attempted when the element holds exactly one text
+       node, which is what the editor paints into it; anything else means the DOM
+       is not what this assumes and leaving the caret alone beats guessing. */
+    h.focus();
+    await tick();
+    const el = h.el;
+    if (!el) return;
+    el.scrollIntoView({ block: 'nearest' });
+    const node = el.firstChild;
+    if (!node || node.nodeType !== Node.TEXT_NODE || el.childNodes.length !== 1) return;
+    const len = node.textContent?.length ?? 0;
+    if (m.end > len) return;
+    const range = document.createRange();
+    range.setStart(node, m.start);
+    range.setEnd(node, m.end);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') { e.preventDefault(); close(); return; }
+    if (e.key === 'Enter')  { e.preventDefault(); go(e.shiftKey ? -1 : 1); return; }
+  }
+
+  /* Typing a new query re-runs the search but does not jump: the count updates as
+     you type, and Enter is what moves. Jumping per keystroke scrolls the notebook
+     out from under someone who is still typing. */
+</script>
+
+{#if $searchOpen}
+  <div class="search-bar" role="search">
+    <Icon name="search" />
+    <input
+      class="search-input"
+      type="text"
+      placeholder="Find in notebook"
+      bind:this={inputEl}
+      bind:value={$searchQuery}
+      on:keydown={onKeydown}
+    />
+
+    <span class="search-count" class:none={$searchQuery && !matches.length}>
+      {#if !$searchQuery}
+        &nbsp;
+      {:else if matches.length}
+        {current + 1} of {matches.length}
+      {:else}
+        No matches
+      {/if}
+    </span>
+
+    <button
+      class="search-btn"
+      class:on={$searchCaseSensitive}
+      title="Match case"
+      aria-pressed={$searchCaseSensitive}
+      on:pointerdown|preventDefault
+      on:click={() => searchCaseSensitive.update(v => !v)}
+    >Aa</button>
+
+    <button class="search-btn" title="Previous match (Shift+Enter)" disabled={!matches.length}
+            on:pointerdown|preventDefault on:click={() => go(-1)}
+    ><Icon name="caretUp" /></button>
+
+    <button class="search-btn" title="Next match (Enter)" disabled={!matches.length}
+            on:pointerdown|preventDefault on:click={() => go(1)}
+    ><Icon name="caret" /></button>
+
+    <button class="search-btn" title="Close (Escape)"
+            on:pointerdown|preventDefault on:click={close}
+    ><Icon name="close" /></button>
+  </div>
+{/if}
+
+<style>
+  /* Under the toolbar, spanning the focused view. Absolute rather than in the
+     flow: appearing must not resize the pane grid, which would relayout every
+     editor in it. */
+  .search-bar {
+    position: absolute;
+    top: var(--toolbar-h, 46px);
+    right: 12px;
+    z-index: 45;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px;
+    background: var(--menu-bg);
+    border: 1px solid var(--menu-border);
+    border-top: none;
+    border-radius: 0 0 6px 6px;
+    box-shadow: var(--menu-shadow);
+    font-size: 12px;
+  }
+
+  .search-input {
+    width: 200px;
+    padding: 3px 5px;
+    font: inherit;
+    color: var(--text);
+    background: var(--cell-bg);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+  }
+  .search-input:focus { outline: none; border-color: var(--accent); }
+
+  .search-count {
+    min-width: 74px;
+    text-align: right;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .search-count.none { color: var(--err); }
+
+  .search-btn {
+    display: flex;
+    align-items: center;
+    padding: 2px 4px;
+    font: inherit;
+    font-size: 11px;
+    color: var(--text-dim);
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+  .search-btn:hover:not(:disabled) { color: var(--text); border-color: var(--border); }
+  .search-btn:disabled { opacity: 0.4; cursor: default; }
+  .search-btn.on { color: var(--accent); border-color: var(--accent); }
+</style>

--- a/frontend/src/lib/Toolbar.svelte
+++ b/frontend/src/lib/Toolbar.svelte
@@ -37,6 +37,7 @@
   import { restart, abortEvaluation } from './kernelActions';
   import { showStatusBar, resetSessionStats } from './status';
   import { propertiesOpen } from './properties';
+  import { wrapSelection, PROSE_BOLD, PROSE_ITALIC, PROSE_CODE, PROSE_LINK } from './prose';
   import type { Cell, CellType, NotebookRow } from './notebook';
 
   type MenuId = 'eval' | 'kernel' | 'docs' | 'style' | 'addpane' | 'overflow' | null;
@@ -287,6 +288,21 @@
 
   $: codeView = activeCellObj?.type === 'code' ? (activeHandle()?.view ?? null) : null;
   $: showCodeGroup = activeCellObj?.type === 'code';
+  /* Only 'text'. A section or subsection is a single-line heading rendered as an
+     <h1>/<h2> and NOT through Markdown, so `**bold**` there would show its own
+     asterisks -- a button that inserts markup the cell will never interpret is
+     worse than no button. */
+  $: showTextGroup = activeCellObj?.type === 'text';
+
+  /* No disabled state, deliberately. Whether the caret is live in the cell is
+     exactly what ActiveCell.focused must not be used to gate (see active.ts), so
+     instead wrapSelection refuses when the selection is not inside the cell's
+     element: pressing one of these with the caret elsewhere does nothing rather
+     than editing whichever cell was last active. */
+  function applyProse(spec: { before: string; after: string;
+                              caret: { collapsed: number; selected: number } }) {
+    wrapSelection(activeHandle()?.el ?? null, spec.before, spec.after, spec.caret);
+  }
 
   function withView(fn: (v: import('@codemirror/view').EditorView) => void) {
     const v = activeHandle()?.view;
@@ -565,7 +581,25 @@
 </ToolbarGroup>
 
 <!-- Context-sensitive: only for code cells, and hidden rather than disabled
-     otherwise. The Text half arrives with Markdown text cells. -->
+     otherwise. The Text half above is the same idea for prose cells. -->
+<ToolbarGroup label="Text" visible={showTextGroup}>
+  <button class="tb-btn tb-bold" title="Bold (**)"
+          tabindex="-1" on:pointerdown|preventDefault on:click={() => applyProse(PROSE_BOLD)}
+  >B</button>
+
+  <button class="tb-btn tb-italic" title="Italic (*)"
+          tabindex="-1" on:pointerdown|preventDefault on:click={() => applyProse(PROSE_ITALIC)}
+  >I</button>
+
+  <button class="tb-btn tb-mono" title="Inline code (`)"
+          tabindex="-1" on:pointerdown|preventDefault on:click={() => applyProse(PROSE_CODE)}
+  >`</button>
+
+  <button class="tb-btn" title="Link ([text](url))"
+          tabindex="-1" on:pointerdown|preventDefault on:click={() => applyProse(PROSE_LINK)}
+  ><Icon name="link" /></button>
+</ToolbarGroup>
+
 <ToolbarGroup label="Code" visible={showCodeGroup}>
   <button class="tb-btn" title="Indent" disabled={!codeView}
           tabindex="-1" on:pointerdown|preventDefault on:click={() => withView(indentCode)}
@@ -801,4 +835,6 @@
     user-select: none;
     -webkit-user-select: none;
   }
+  .tb-bold   { font-weight: 700; }
+  .tb-italic { font-style: italic; font-family: Georgia, serif; }
 </style>

--- a/frontend/src/lib/Toolbar.svelte
+++ b/frontend/src/lib/Toolbar.svelte
@@ -36,6 +36,7 @@
   import { kernelStatus } from './notebook';
   import { restart, abortEvaluation } from './kernelActions';
   import { showStatusBar, resetSessionStats } from './status';
+  import { propertiesOpen } from './properties';
   import type { Cell, CellType, NotebookRow } from './notebook';
 
   type MenuId = 'eval' | 'kernel' | 'docs' | 'style' | 'addpane' | 'overflow' | null;
@@ -581,6 +582,21 @@
   <button class="tb-btn tb-mono" title="Comment or uncomment the selection" disabled={!codeView}
           tabindex="-1" on:pointerdown|preventDefault on:click={() => withView(commentCode)}
   >(*=*)</button>
+</ToolbarGroup>
+
+<!-- One button, not two: Mathematica's sidebar group also carries a chat panel,
+     and Mathilda has no chat. A second button that opened nothing would be worse
+     than the asymmetry. -->
+<ToolbarGroup label="Sidebar">
+  <button
+    class="tb-btn"
+    class:active={$propertiesOpen}
+    title={$propertiesOpen ? 'Hide properties' : 'Show properties'}
+    aria-pressed={$propertiesOpen}
+    tabindex="-1"
+    on:pointerdown|preventDefault
+    on:click={() => propertiesOpen.update(v => !v)}
+  ><Icon name="sidebar" /></button>
 </ToolbarGroup>
 
 <ToolbarGroup label="Notebook">

--- a/frontend/src/lib/Toolbar.svelte
+++ b/frontend/src/lib/Toolbar.svelte
@@ -38,6 +38,7 @@
   import { showStatusBar, resetSessionStats } from './status';
   import { propertiesOpen } from './properties';
   import { wrapSelection, PROSE_BOLD, PROSE_ITALIC, PROSE_CODE, PROSE_LINK } from './prose';
+  import { searchOpen } from './search';
   import type { Cell, CellType, NotebookRow } from './notebook';
 
   type MenuId = 'eval' | 'kernel' | 'docs' | 'style' | 'addpane' | 'overflow' | null;
@@ -641,6 +642,16 @@
     on:pointerdown|preventDefault
     on:click={() => darkMode.update(v => !v)}
   >{$darkMode ? '◑' : '☀'}</button>
+
+  <button
+    class="tb-btn"
+    class:active={$searchOpen}
+    title="Find in notebook (Cmd+F)"
+    aria-pressed={$searchOpen}
+    tabindex="-1"
+    on:pointerdown|preventDefault
+    on:click={() => searchOpen.update(v => !v)}
+  ><Icon name="search" /></button>
 
   <!-- A static title: what the caret is on is only resolved when the menu opens,
        and the menu's own first item names it. -->

--- a/frontend/src/lib/Toolbar.svelte
+++ b/frontend/src/lib/Toolbar.svelte
@@ -37,7 +37,8 @@
   import { restart, abortEvaluation } from './kernelActions';
   import { showStatusBar, resetSessionStats } from './status';
   import { propertiesOpen } from './properties';
-  import { wrapSelection, PROSE_BOLD, PROSE_ITALIC, PROSE_CODE, PROSE_LINK } from './prose';
+  import { wrapSelection, PROSE_BOLD, PROSE_ITALIC, PROSE_CODE, PROSE_LINK,
+           PROSE_MATH } from './prose';
   import { searchOpen } from './search';
   import type { Cell, CellType, NotebookRow } from './notebook';
 
@@ -599,6 +600,12 @@
   <button class="tb-btn" title="Link ([text](url))"
           tabindex="-1" on:pointerdown|preventDefault on:click={() => applyProse(PROSE_LINK)}
   ><Icon name="link" /></button>
+
+  <!-- Inline TeX. A text cell renders `$…$` through KaTeX, and this is how that
+       gets discovered: the alternative is knowing to type it. -->
+  <button class="tb-btn" title="Inline math ($…$, rendered with KaTeX)"
+          tabindex="-1" on:pointerdown|preventDefault on:click={() => applyProse(PROSE_MATH)}
+  ><Icon name="sigma" /></button>
 </ToolbarGroup>
 
 <ToolbarGroup label="Code" visible={showCodeGroup}>

--- a/frontend/src/lib/Toolbar.svelte
+++ b/frontend/src/lib/Toolbar.svelte
@@ -40,9 +40,10 @@
   import { wrapSelection, PROSE_BOLD, PROSE_ITALIC, PROSE_CODE, PROSE_LINK,
            PROSE_MATH } from './prose';
   import { searchOpen } from './search';
+  import { SNIPPETS, expandedText, insertSnippet } from './snippets';
   import type { Cell, CellType, NotebookRow } from './notebook';
 
-  type MenuId = 'eval' | 'kernel' | 'docs' | 'style' | 'addpane' | 'overflow' | null;
+  type MenuId = 'eval' | 'kernel' | 'docs' | 'style' | 'addpane' | 'insert' | 'overflow' | null;
   let openMenu: MenuId = null;
 
   /* One anchor per trigger, so the menu can measure against the button that
@@ -52,6 +53,7 @@
   let docsAnchor: HTMLElement;
   let styleAnchor: HTMLElement;
   let addPaneAnchor: HTMLElement;
+  let insertAnchor: HTMLElement;
   let overflowAnchor: HTMLElement;
 
   function toggleMenu(which: Exclude<MenuId, null>) {
@@ -405,6 +407,24 @@
     ? ($canvasState.notebooks.find(n => n.id === $canvasState.focusedActiveId)?.title ?? '')
     : '';
 
+  /* The Insert palette. The hint is the EXPANSION, so the menu shows what will
+     land in the cell rather than only what it is called -- and it is the same
+     string npm run check:snippets feeds to Mathilda's parser. */
+  $: insertItems = SNIPPETS.map(sn => ({
+    kind: 'item' as const,
+    id: sn.label,
+    label: sn.label,
+    hint: expandedText(sn.template),
+  })) as MenuItem[];
+
+  function onInsertSelect(id: string) {
+    const sn = SNIPPETS.find(x => x.label === id);
+    if (!sn) return;
+    /* codeView is re-read here rather than captured when the menu opened: the cell
+       can be deleted between the two, and insertSnippet declines on a null view. */
+    insertSnippet(activeHandle()?.view ?? null, sn.template);
+  }
+
   /* One <Menu> instance, driven by these three tables. Adding a dropdown means
      adding a row to each, not another component with its own backdrop and
      keyboard handling. */
@@ -414,6 +434,7 @@
     openMenu === 'docs'     ? docsItems :
     openMenu === 'style'    ? styleItems :
     openMenu === 'addpane'  ? addPaneItems :
+    openMenu === 'insert'   ? insertItems :
     openMenu === 'overflow' ? overflowItems : [];
 
   $: menuAnchor =
@@ -422,6 +443,7 @@
     openMenu === 'docs'     ? docsAnchor :
     openMenu === 'style'    ? styleAnchor :
     openMenu === 'addpane'  ? addPaneAnchor :
+    openMenu === 'insert'   ? insertAnchor :
     openMenu === 'overflow' ? overflowAnchor : null;
 
   function onMenuSelect(e: CustomEvent<{ id: string }>) {
@@ -431,6 +453,7 @@
       case 'docs':     onDocsSelect(e.detail.id); break;
       case 'style':    onStyleSelect(e.detail.id); break;
       case 'addpane':  if (e.detail.id) addPane(e.detail.id); break;
+      case 'insert':   onInsertSelect(e.detail.id); break;
       case 'overflow': onOverflowSelect(e.detail.id); break;
     }
   }
@@ -584,6 +607,21 @@
 
 <!-- Context-sensitive: only for code cells, and hidden rather than disabled
      otherwise. The Text half above is the same idea for prose cells. -->
+<!-- Insert. Code cells only, because every template is a Mathilda expression;
+     offering Table[] for a prose cell would insert text that never evaluates. -->
+<ToolbarGroup label="Insert" visible={showCodeGroup}>
+  <button
+    class="tb-btn"
+    title="Insert a template at the caret"
+    aria-haspopup="menu"
+    aria-expanded={openMenu === 'insert'}
+    tabindex="-1"
+    bind:this={insertAnchor}
+    on:pointerdown|preventDefault
+    on:click={() => toggleMenu('insert')}
+  ><Icon name="plus" /></button>
+</ToolbarGroup>
+
 <ToolbarGroup label="Text" visible={showTextGroup}>
   <button class="tb-btn tb-bold" title="Bold (**)"
           tabindex="-1" on:pointerdown|preventDefault on:click={() => applyProse(PROSE_BOLD)}

--- a/frontend/src/lib/properties.ts
+++ b/frontend/src/lib/properties.ts
@@ -1,0 +1,21 @@
+// properties.ts — state for the properties sidebar.
+//
+// Two stores, and they are here rather than in theme.ts or status.ts because
+// neither is about a theme or a measurement: one is whether the panel is open,
+// the other is a display preference the panel owns.
+//
+// Plain writables with no persistence, matching darkMode in theme.ts. Nothing in
+// this app persists UI state yet, and adding localStorage for one preference
+// would make this the only setting that survives a restart -- a surprise, not a
+// feature. When persistence arrives it should arrive for all of them at once.
+
+import { writable } from 'svelte/store';
+
+/** Whether the properties sidebar is showing. Toolbar's Sidebar group toggles it. */
+export const propertiesOpen = writable(false);
+
+/** Whether a code cell shows its `In[n]` label once it has been evaluated.
+ *
+ *  Lives here rather than in the toolbar because it is a persistent preference
+ *  about how the notebook reads, not an action -- the toolbar is for verbs. */
+export const showExecLabels = writable(true);

--- a/frontend/src/lib/properties.ts
+++ b/frontend/src/lib/properties.ts
@@ -19,3 +19,21 @@ export const propertiesOpen = writable(false);
  *  Lives here rather than in the toolbar because it is a persistent preference
  *  about how the notebook reads, not an action -- the toolbar is for verbs. */
 export const showExecLabels = writable(true);
+
+/** Global UI scale, applied by App.svelte as the root font size.
+ *
+ *  Lives here because the properties panel offers it, but it is NOT new: the
+ *  Cmd+= / Cmd+- / Cmd+0 bindings have driven this value since the toolbar
+ *  landed, as a local in App.svelte. Lifting it to a store is what lets the panel
+ *  show the same number the keyboard changes -- a second, independent scale would
+ *  drift from the first the moment either was used.
+ *
+ *  The steps the panel offers are exactly representable in binary (0.75, 1, 1.25,
+ *  1.5), so a comparison against one is an exact equality rather than an epsilon.
+ *  The keyboard still moves in 0.1 increments, which is why the panel highlights a
+ *  step only when the value is exactly on it. */
+export const uiScale = writable(1.0);
+
+/** The steps the panel offers. Not the keyboard's 0.1: a discrete set is what a
+ *  set of buttons can honestly represent. */
+export const UI_SCALE_STEPS = [0.75, 1, 1.25, 1.5];

--- a/frontend/src/lib/prose.ts
+++ b/frontend/src/lib/prose.ts
@@ -1,0 +1,106 @@
+// prose.ts — rendering and editing for Markdown text cells.
+//
+// The cell-type picker has described a text cell as "Prose / markdown" since it
+// was written, and nothing rendered any markdown: a text cell was a
+// contenteditable holding raw characters. This module is the half that makes the
+// label true, plus the selection edits the toolbar's Text group needs.
+//
+// Kept out of CellShell.svelte on purpose. The rendering is a pure function of a
+// string, and the selection edits are pure functions of (element, markers), so
+// both are readable and reviewable without mounting a component -- the same
+// reason cellCommands.ts exists next door.
+
+import { marked } from 'marked';
+
+/** Markdown to HTML for a text cell.
+ *
+ *  `breaks: true` because a text cell is typed like prose, not like a Markdown
+ *  file: a single newline is meant as a line break, and requiring two trailing
+ *  spaces to get one would read as the cell ignoring the Return key.
+ *
+ *  ON TRUST. The result is inserted with `{@html}`, so raw HTML in a cell's
+ *  source reaches the DOM. That is not a new capability being granted: a
+ *  notebook is an executable document whose code cells already evaluate
+ *  arbitrary Mathilda, so anyone in a position to put a `<script>` in the prose
+ *  of a notebook you open is already in a position to run code in it. What would
+ *  be wrong is claiming otherwise -- a regex pass over the output would look like
+ *  sanitisation while missing most of what it appears to cover, and `marked`
+ *  dropped its own `sanitize` option precisely because it could not do the job.
+ *  RefPage.svelte renders generated documentation through the same `{@html}`. */
+export function renderProse(src: string): string {
+  const text = src ?? '';
+  if (!text.trim()) return '';
+  return marked.parse(text, { async: false, breaks: true, gfm: true }) as string;
+}
+
+/** Where to leave the caret, counted back from the end of the inserted text. */
+export type CaretBack = {
+  /** Applied when the selection was empty. Usually `after.length`, so typing
+   *  continues INSIDE the markers just inserted. */
+  collapsed: number;
+  /** Applied when text was selected. Usually 0 -- the caret belongs after the
+   *  closing marker, since the wrapped words are finished. */
+  selected: number;
+};
+
+/** Wrap the current selection in `el` with Markdown markers.
+ *
+ *  Uses `document.execCommand('insertText')`, which is deprecated and is still
+ *  the right call here: it is the only API that edits a contenteditable while
+ *  keeping the browser's native undo stack intact, and it fires `input` so the
+ *  cell's existing handler writes the new source to the store with no extra
+ *  plumbing. Replacing a Range by hand gives an edit that Cmd-Z cannot undo,
+ *  which is a worse outcome than using a deprecated call in a WebView whose
+ *  engine is known.
+ *
+ *  Returns false and does nothing when there is no selection inside `el`, so a
+ *  toolbar button pressed with the caret elsewhere is inert rather than editing
+ *  whichever cell happens to be active. */
+export function wrapSelection(el: HTMLElement | null, before: string, after: string,
+                              caretBack: CaretBack): boolean {
+  if (!el) return false;
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return false;
+  if (!sel.anchorNode || !el.contains(sel.anchorNode)) return false;
+
+  const selected = sel.toString();
+  if (!document.execCommand('insertText', false, before + selected + after)) return false;
+
+  const back = selected.length === 0 ? caretBack.collapsed : caretBack.selected;
+  if (back > 0) moveCaretBack(back);
+  return true;
+}
+
+/** Step the caret back `n` characters within its own text node.
+ *
+ *  Deliberately does not walk into previous nodes: every caller moves back by at
+ *  most the few characters it just inserted, which are in the node the caret
+ *  landed in. A short node means the insert did something unexpected, and leaving
+ *  the caret where the browser put it is better than guessing across a boundary. */
+function moveCaretBack(n: number): void {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return;
+  const range = sel.getRangeAt(0);
+  const off = range.startOffset - n;
+  if (off < 0) return;
+  range.setStart(range.startContainer, off);
+  range.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+/* The four the Text group offers. Emphasis uses `**`/`*` rather than `__`/`_`,
+ * which read as literal underscores inside identifiers -- and identifiers are
+ * exactly what gets written about in a notebook's prose.
+ *
+ * There is no bullet-list button. Inserting "- " at the start of the current LINE
+ * means finding that line's start in a contenteditable whose line boxes may be
+ * text nodes, <div>s or <br>s depending on how the content was entered, and a
+ * bullet that lands mid-word is worse than a button that is not there. It wants a
+ * real caret to verify against, not a guess. */
+export const PROSE_BOLD   = { before: '**', after: '**', caret: { collapsed: 2, selected: 0 } };
+export const PROSE_ITALIC = { before: '*',  after: '*',  caret: { collapsed: 1, selected: 0 } };
+export const PROSE_CODE   = { before: '`',  after: '`',  caret: { collapsed: 1, selected: 0 } };
+/** Caret lands between the parentheses either way: with words selected the text
+ *  is done and the URL is what you still have to type. */
+export const PROSE_LINK   = { before: '[',  after: ']()', caret: { collapsed: 3, selected: 1 } };

--- a/frontend/src/lib/prose.ts
+++ b/frontend/src/lib/prose.ts
@@ -11,6 +11,7 @@
 // reason cellCommands.ts exists next door.
 
 import { marked } from 'marked';
+import katex from 'katex';
 
 /** Markdown to HTML for a text cell.
  *
@@ -30,7 +31,128 @@ import { marked } from 'marked';
 export function renderProse(src: string): string {
   const text = src ?? '';
   if (!text.trim()) return '';
-  return marked.parse(text, { async: false, breaks: true, gfm: true }) as string;
+  /* Math comes OUT before Markdown runs and goes back in after. The order is the
+     whole point: `$a_1 * b_2$` handed to Markdown first loses `_1 * b_2` to
+     emphasis, and no amount of care in the TeX pass afterwards can recover what
+     the emphasis rules already ate. */
+  const { text: masked, spans, token } = extractMath(text);
+  let html = marked.parse(masked, { async: false, breaks: true, gfm: true }) as string;
+  for (let i = 0; i < spans.length; i++) {
+    html = html.replace(token(i), renderTex(spans[i]));
+  }
+  return html;
+}
+
+/** One extracted math span. */
+export type MathSpan = { display: boolean; tex: string };
+
+function renderTex(span: MathSpan): string {
+  try {
+    /* throwOnError: false makes KaTeX render its own error marker in place rather
+       than take the whole cell down for one bad macro -- the same call
+       Output.svelte makes for kernel output. */
+    return katex.renderToString(span.tex, { throwOnError: false, displayMode: span.display });
+  } catch {
+    /* KaTeX can still throw on input it cannot even parse into an error. The raw
+       source is then the most useful thing to show: it is what was typed. */
+    const delim = span.display ? '$$' : '$';
+    return `<code>${delim}${escapeHtml(span.tex)}${delim}</code>`;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Pull `$…$` and `$$…$$` out of `src`, replacing each with an opaque token.
+ *
+ *  A hand-written scan rather than a regex, because the things that must NOT be
+ *  math are all context: a `$` inside a code span or fence is a literal dollar,
+ *  and `\$` is a literal dollar anywhere. A regex over the whole string cannot see
+ *  which of those it is inside.
+ *
+ *  TWO HEURISTICS, both standard (pandoc and markdown-it use the same pair), and
+ *  both there to keep prose about money from turning into equations: an opening
+ *  `$` must be followed by a non-space, and a closing `$` must be preceded by one.
+ *  So "it cost $5 and $6" stays prose, while `$x + 1$` is math. An unclosed `$`
+ *  is likewise left exactly as typed rather than swallowing the rest of the cell.
+ *
+ *  Exported for the checks in scripts/check-prose.mjs, which is the only reason it
+ *  is not private -- the tokenizer's edge cases are the part worth testing. */
+export function extractMath(src: string): {
+  text: string; spans: MathSpan[]; token: (i: number) => string;
+} {
+  /* A sentinel the source cannot already contain, so a cell that happens to
+     discuss this very placeholder still renders correctly. */
+  let stem = '@@MATHILDA-MATH-';
+  while (src.includes(stem)) stem += 'X';
+  const token = (i: number) => `${stem}${i}@@`;
+
+  const spans: MathSpan[] = [];
+  let out = '';
+  let i = 0;
+  const n = src.length;
+
+  while (i < n) {
+    const c = src[i];
+
+    /* An escaped dollar is a literal one. Copied through WITH its backslash, so
+       Markdown is the thing that unescapes it -- exactly as it would without any
+       math support. */
+    if (c === '\\' && i + 1 < n && src[i + 1] === '$') { out += src.slice(i, i + 2); i += 2; continue; }
+
+    /* A fenced code block: copy to the closing fence, or to the end if there is
+       none. Nothing inside is math. */
+    if (src.startsWith('```', i)) {
+      const close = src.indexOf('```', i + 3);
+      const end = close < 0 ? n : close + 3;
+      out += src.slice(i, end); i = end; continue;
+    }
+
+    /* An inline code span, closed by a run of backticks of the SAME length --
+       which is how ``a ` b`` holds a literal backtick. */
+    if (c === '`') {
+      let run = 0;
+      while (i + run < n && src[i + run] === '`') run++;
+      const fence = '`'.repeat(run);
+      const close = src.indexOf(fence, i + run);
+      const end = close < 0 ? n : close + run;
+      out += src.slice(i, end); i = end; continue;
+    }
+
+    if (src.startsWith('$$', i)) {
+      const close = src.indexOf('$$', i + 2);
+      if (close > i + 2) {
+        spans.push({ display: true, tex: src.slice(i + 2, close) });
+        out += token(spans.length - 1); i = close + 2; continue;
+      }
+      out += '$$'; i += 2; continue;          /* unclosed: literal */
+    }
+
+    if (c === '$') {
+      const next = src[i + 1];
+      if (next !== undefined && !/\s/.test(next)) {
+        /* Scan for a closing `$` preceded by a non-space, skipping escaped ones. */
+        let j = i + 1;
+        let found = -1;
+        while (j < n) {
+          if (src[j] === '\\') { j += 2; continue; }
+          if (src[j] === '$' && !/\s/.test(src[j - 1])) { found = j; break; }
+          if (src[j] === '\n' && src[j + 1] === '\n') break;   /* math does not cross a blank line */
+          j++;
+        }
+        if (found > i + 1) {
+          spans.push({ display: false, tex: src.slice(i + 1, found) });
+          out += token(spans.length - 1); i = found + 1; continue;
+        }
+      }
+      out += '$'; i += 1; continue;           /* not math: literal */
+    }
+
+    out += c; i += 1;
+  }
+
+  return { text: out, spans, token };
 }
 
 /** Where to leave the caret, counted back from the end of the inserted text. */
@@ -104,3 +226,6 @@ export const PROSE_CODE   = { before: '`',  after: '`',  caret: { collapsed: 1, 
 /** Caret lands between the parentheses either way: with words selected the text
  *  is done and the URL is what you still have to type. */
 export const PROSE_LINK   = { before: '[',  after: ']()', caret: { collapsed: 3, selected: 1 } };
+/** Inline math. The fifth marker, and the one the rendering pass above exists for:
+ *  a button that writes `$…$` is how you find out the cell renders it. */
+export const PROSE_MATH   = { before: '$',  after: '$',  caret: { collapsed: 1, selected: 0 } };

--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -1,0 +1,76 @@
+// search.ts — find across every cell of the focused notebook.
+//
+// NOT @codemirror/search. That package's openSearchPanel searches ONE editor --
+// the cell that happens to hold focus -- and a find bar that silently ignores the
+// other forty cells while calling itself notebook search is worse than no find
+// bar, because you would trust its "no matches". So the matching runs over the
+// notebook's own model, `store.allCells()`, and navigation then drives whichever
+// editor owns the match it landed on.
+//
+// The matcher is a pure function of (cells, query, caseSensitive) with no store
+// and no DOM, which is what lets `npm run check:search` run the real thing rather
+// than a paraphrase of it.
+
+import { writable } from 'svelte/store';
+
+/** One occurrence, as offsets into that cell's own source. */
+export type SearchMatch = {
+  cellId: string;
+  /** Offset of the first character of the match within the cell's source. */
+  start: number;
+  /** Offset one past the last character. */
+  end: number;
+};
+
+/** The subset of a cell this module needs, so the matcher is testable without
+ *  building a whole Cell. */
+export type SearchableCell = { id: string; source: string };
+
+export const searchOpen = writable(false);
+export const searchQuery = writable('');
+export const searchCaseSensitive = writable(false);
+/** Index into the current match list. Clamped by the bar, not here. */
+export const searchIndex = writable(0);
+
+/** Every occurrence of `query`, in document order: cells in notebook order, and
+ *  within a cell by increasing offset.
+ *
+ *  Matches do NOT overlap. Searching "aa" in "aaaa" gives two matches at 0 and 2,
+ *  not three at 0, 1 and 2 -- overlapping hits would make "next match" step
+ *  through positions that look identical to the reader, and every editor's find
+ *  behaves this way.
+ *
+ *  An empty or whitespace-only query finds nothing rather than matching at every
+ *  offset. A query of a single space is a legitimate search, so only the empty
+ *  string is rejected; "  " finds real double spaces.
+ */
+export function findMatches(cells: SearchableCell[], query: string,
+                            caseSensitive: boolean): SearchMatch[] {
+  const out: SearchMatch[] = [];
+  if (!query) return out;
+
+  const needle = caseSensitive ? query : query.toLowerCase();
+  for (const cell of cells) {
+    const src = cell.source ?? '';
+    const hay = caseSensitive ? src : src.toLowerCase();
+    let from = 0;
+    for (;;) {
+      const at = hay.indexOf(needle, from);
+      if (at < 0) break;
+      out.push({ cellId: cell.id, start: at, end: at + query.length });
+      from = at + query.length;   /* non-overlapping */
+    }
+  }
+  return out;
+}
+
+/** Step `index` by `delta` within `count` matches, wrapping in both directions.
+ *
+ *  Separate from the component because off-by-one and negative-modulo are exactly
+ *  the two things worth checking: in JavaScript `-1 % 3` is `-1`, not `2`, so the
+ *  naive form sends Shift+Enter at the first match to a negative index and the
+ *  bar shows "0 of 3". */
+export function stepIndex(index: number, delta: number, count: number): number {
+  if (count <= 0) return 0;
+  return ((index + delta) % count + count) % count;
+}

--- a/frontend/src/lib/snippets.ts
+++ b/frontend/src/lib/snippets.ts
@@ -1,0 +1,67 @@
+// snippets.ts — the Insert group's template palette.
+//
+// Each entry is a CodeMirror snippet template: `${name}` marks a field, and Tab
+// walks them after insertion. `snippet()` from @codemirror/autocomplete does the
+// work; this module is the templates plus the two functions the toolbar needs.
+//
+// The templates are the risk, not the machinery. A template that inserts an
+// unbalanced bracket is a broken cell every time it is used, and reading one is a
+// poor way to notice -- `{{${a}, ${b}}, {${c}, ${d}}}` has to be counted. So
+// `expandedText` exists, `npm run check:snippets` feeds each expansion through the
+// real Mathilda binary, and a template whose expansion does not PARSE fails the
+// check. That is a stronger guarantee than balanced brackets: it is the language's
+// own parser agreeing that what the button inserts is a valid expression.
+
+import { snippet } from '@codemirror/autocomplete';
+import type { EditorView } from '@codemirror/view';
+
+export type SnippetDef = {
+  /** Menu label. */
+  label: string;
+  /** CodeMirror snippet template; `${name}` is a tab field. */
+  template: string;
+};
+
+/* Ordered by how often the thing is reached for, not alphabetically: a palette is
+ * read top-down and the first two entries should be the ones that save the most
+ * typing. Every expansion is checked against Mathilda's parser. */
+export const SNIPPETS: SnippetDef[] = [
+  { label: 'Table',       template: 'Table[${expr}, {${i}, 1, ${n}}]' },
+  { label: 'Matrix 2×2',  template: '{{${a}, ${b}}, {${c}, ${d}}}' },
+  { label: 'Sum',         template: 'Sum[${expr}, {${i}, 1, ${n}}]' },
+  { label: 'Product',     template: 'Product[${expr}, {${i}, 1, ${n}}]' },
+  { label: 'Integrate',   template: 'Integrate[${expr}, ${x}]' },
+  { label: 'NIntegrate',  template: 'NIntegrate[${expr}, {${x}, 0, 1}]' },
+  { label: 'Derivative',  template: 'D[${expr}, ${x}]' },
+  { label: 'Limit',       template: 'Limit[${expr}, ${x} -> 0]' },
+  { label: 'Solve',       template: 'Solve[${lhs} == ${rhs}, ${x}]' },
+  { label: 'Plot',        template: 'Plot[${expr}, {${x}, -5, 5}]' },
+  { label: 'Module',      template: 'Module[{${vars}}, ${body}]' },
+  { label: 'Definition',  template: '${f}[${x}_] := ${body}' },
+  { label: 'Replace all', template: '${expr} /. ${lhs} -> ${rhs}' },
+  { label: 'Map',         template: 'Map[${f}, ${list}]' },
+];
+
+/** The text a template becomes once every field is left at its placeholder name.
+ *
+ *  What the user sees the instant the snippet lands, so it doubles as the menu's
+ *  hint and as what the parser check parses. `${expr}` becomes `expr`. */
+export function expandedText(template: string): string {
+  return template.replace(/\$\{([^}]*)\}/g, '$1');
+}
+
+/** Insert `template` at the caret, replacing any selection.
+ *
+ *  Declines when there is no editor rather than guessing a target: the Insert
+ *  group is only shown for a code cell, but the active cell can be deleted between
+ *  the menu opening and an item being chosen. */
+export function insertSnippet(view: EditorView | null, template: string): boolean {
+  if (!view) return false;
+  const { from, to } = view.state.selection.main;
+  /* snippet() returns an apply function shaped for the completion system, which
+     passes the completion it came from; there is no completion here, and it is
+     unused for a plain insertion. */
+  snippet(template)(view, null as never, from, to);
+  view.focus();
+  return true;
+}


### PR DESCRIPTION
## Summary

Closes the notebook toolbar plan — P7, P9 and P10 — in five commits. Stacked on one branch because they all touch `Toolbar.svelte` and `CellShell.svelte`; separate branches off `main` would have collided. Based on `main`, which carries the toolbar since #57 merged.

## Changes

**P7 — properties sidebar** (`lib/PropertiesPanel.svelte`, `lib/properties.ts`)

Slides in from the left: notebook name and size, cell counts, kernel status with Restart/Abort, display preferences, interface scale, and pane layout (present only when more than one pane is open, so the buttons are never inert). The Sidebar group is **one** button — Mathematica's equivalent carries a chat panel as its second, and Mathilda has no chat.

It reports only what the model holds. A canvas notebook has a title and **no file** (`saveNotebook` takes a path from a dialog and nothing writes it back), so Location says the notebook is unsaved rather than inventing a path, and Size counts characters of source. Outputs are excluded — they are recomputable, and including them would make the number jump as cells run.

The `In[n]` label was unconditional in `CellShell` and is now a preference: the toolbar is for verbs, and a session-long setting is not one.

**Interface scale** drives the same store `Cmd+=` / `Cmd+-` / `Cmd+0` have driven since #57 — it was a local in `App.svelte`, so the panel could not have reached it without becoming a second scale that drifts. Steps are 0.75/1/1.25/1.5, exactly representable, so a button highlights on an exact equality and only on one. `Cmd+0` turned out to be documented in that handler's own comment and never implemented; the store made it one line.

**P9 — Markdown and TeX prose** (`lib/prose.ts`)

A text cell renders Markdown when not being edited and raw source while it is — what the cell-type picker has promised since it was written, back when nothing rendered any. **One** element switches between the states rather than two swapping, so every handler, the handle registration and arrow-key navigation are untouched.

Inline TeX renders through KaTeX (`$…$`, `$$…$$`). Math is pulled **out before** Markdown runs and put back after, and that order is the point: handed to Markdown first, `$a_1 * b_2$` loses `_1 * b_2` to emphasis and nothing downstream recovers it. Extraction is a hand-written scan, not a regex, because everything that must *not* be math is context — a `$` in a code span or fence is a literal dollar, `\$` is one anywhere. Two standard heuristics keep prose about money from becoming equations, so **"it cost $5 and $6" stays prose**.

The **Text** group is the half whose Code counterpart already existed: bold, italic, inline code, link, inline math. `text` cells only — a section is an `<h1>` that is not Markdown-rendered, so `**bold**` there would show its own asterisks.

**P10 — notebook search** (`lib/search.ts`, `lib/SearchBar.svelte`)

`Cmd+F` searches **every cell** of the notebook in the active pane. Deliberately not `@codemirror/search`: its `openSearchPanel` searches one editor, and a bar that ignores the other forty cells while calling itself notebook search is worse than none, because its "No matches" would be believed. Matching runs over `store.allCells()`; navigation then drives whichever editor owns the match. `Cmd+F` is free precisely because that package is not installed.

**P10 — Insert palette** (`lib/snippets.ts`)

CodeMirror snippet templates with `${field}` placeholders Tab walks. `@codemirror/autocomplete` becomes an explicit dependency — it was already present transitively via the `codemirror` meta-package, and importing it on that basis works until the day that package reorganises.

## Testing

Three new check scripts, all compiling the real modules with the project's own `tsc` and importing the result — a paraphrase can agree with its test and disagree with the app:

- `npm run check:prose` — 39 checks. Load-bearing ones: Markdown does not eat `_`/`*` inside math (the ordering property), a `$` inside code is literal, unclosed delimiters stay as typed, the substitution token cannot collide with prose discussing it, and one direct `marked` import proves `breaks: true` does something.
- `npm run check:search` — 18 checks. Matches are **non-overlapping** (`"aa"` in `"aaaa"` is two, not three) and stepping wraps **both** ways (in JS `-1 % 3` is `-1`, so the naive form reads "0 of 3").
- `npm run check:snippets` — expands each template and feeds it to **the real Mathilda binary** inside `Hold[...]`, which parses without evaluating. All 14 parse. Stronger than counting brackets: the language's own parser agrees the insertion is valid. SKIPs cleanly if the C binary is not built.

Plus: `npm run check` adds no new errors or warnings over baseline (the two errors are pre-existing, in `Output.svelte` and `NotebookCard.svelte:733`); `npm run build` succeeds; and every new surface was confirmed present in the bundle rather than dead-code-eliminated. Every CSS variable resolves against the real palette — a first draft used `--panel`, `--error`, `--btn-bg` and `--appbar-h`, none correct here, and a bad `var()` falls back silently with no error anywhere.

**Wants a click-through before merge.** Synthetic events do not reach the WKWebView, so the DOM half of each feature — the click-to-edit swap, `execCommand` wrapping, revealing a search match — is unverified by me.

## JIRA Ticket

n/a