### PR TITLE
RandomGraph[{n, m}, k]: trailing-count form (RG-1)

### DIFF
--- a/docs/spec/builtins/graphs.md
+++ b/docs/spec/builtins/graphs.md
@@ -114,12 +114,22 @@ constructor path:
   vertices.
 - `RandomGraph[{n, m}]` — a random undirected graph with `n` vertices and `m`
   distinct edges (uses the seeded system RNG, so `SeedRandom` makes it
-  reproducible). Returns unevaluated if `m` exceeds `n(n-1)/2`.
+  reproducible). Returns unevaluated if `m` exceeds `n(n-1)/2`. For `n <= 1`
+  the only possible graph is the edgeless one, which is what is returned.
+- `RandomGraph[{n, m}, k]` — a list of `k` independently sampled such graphs.
+  `k = 0` gives `{}`; `k = 1` gives a one-element list, **not** a bare `Graph`.
+  A negative, non-integer, or symbolic `k` leaves the expression unevaluated,
+  silently — the convention the count-taking `Random*` heads share. Each
+  element costs a full `O(n^2)` candidate materialisation and its own
+  `RandomSample`, so both time and memory scale as `O(k n^2)`; at `n = 50` a
+  call retains roughly 364 KB per element (a known limitation of the shared
+  single-graph path, not specific to the `k` form).
 
 ```
 EdgeCount[CompleteGraph[5]]      (* 10                        *)
 EdgeList[CycleGraph[4]]          (* {1<->2, 2<->3, 3<->4, 4<->1} *)
 VertexDegree[PathGraph[5]]       (* {1, 2, 2, 2, 1}           *)
+Length[RandomGraph[{6, 5}, 3]]   (* 3                         *)
 ```
 
 ## Search & computation

--- a/docs/spec/changelog/2026-08-24.md
+++ b/docs/spec/changelog/2026-08-24.md
@@ -2495,3 +2495,58 @@ and exact/machine agreement -- so a stale or aliased temporary fails in the suit
 `tests/scripts/geometry_leakcheck.sh` was confirmed sensitive by injection: removing
 one `geom_cross_tmp_clear` makes it report 4800 leaks / 153600 bytes and fail, while
 the whole C suite still passes.
+
+## `RandomGraph[{n, m}, k]` — the trailing-count form (RG-1)
+
+`RandomGraph` accepted exactly one argument, so `RandomGraph[{5, 4}, 3]` was
+unevaluated. It now takes an optional trailing count and returns a `List` of `k`
+independently sampled graphs, following the conventions the five count-taking
+heads in `src/random.c` already agree on: `k = 0` gives `{}`, `k = 1` gives a
+one-element list rather than a bare `Graph`, and a negative, non-integer, or
+symbolic `k` is silently unevaluated (SPEC §4 — `NULL`, no `Message`). A failure
+mid-loop frees what it accumulated and returns `NULL`, so a partial list is never
+returned.
+
+The single-graph body was lifted into `one_random_graph`, which both arities
+share, plus a `vertex_list` helper. The `evaluate(RandomSample[...])` round-trip
+is preserved deliberately — it is what makes `SeedRandom` reproducibility fall
+out for free — and the refactor is RNG-transparent: a seeded 1-arg call produces
+a byte-identical edge list. The stream *position* after `RandomGraph[{5, 0}]` is
+established by inspection only — the `n >= 2` path adds and removes no RNG
+consumption, and the new early return is keyed on `maxe`, not `m`, so it cannot
+be reached when `n >= 2`. It has **not** been compared against a pre-change
+binary; that check (AC-17) was not run.
+
+Incidental fix: `n <= 1` leaves no candidate edges, and `RandomSample[{}, m]` is
+itself unevaluated, so `RandomGraph[{0, 0}]` and `RandomGraph[{1, 0}]` returned
+unevaluated. The helper now answers the edgeless graph directly. This early
+return is keyed on `n(n-1)/2 == 0` only, deliberately *not* on `m == 0` — the
+`m = 0, n >= 2` case works today via `RandomSample[cand, 0]`, and skipping that
+call would shift the RNG stream for every later draw.
+
+Hardening: the overflow guard is a bound on `n` *before* the multiply —
+`n > 2147483647L` is unevaluated — and that is the load-bearing half. Checking
+the product afterwards cannot catch a wrap: `n = 2^32 + 1` wraps `n(n-1)` to
+`2^32` in 64 bits and yields a small, plausible-looking `maxe` while the
+candidate loop still runs to the true `n(n-1)/2` and writes past the buffer.
+With `n < 2^31` the product cannot exceed `2^62`, which is what makes the
+secondary bound — `n(n-1)/2` computed in `unsigned long long` and compared
+against `SIZE_MAX / sizeof(Expr*)` — exact and meaningful. Previously the
+product was computed in signed `long`, where a wrap to a negative value also
+let the `m > maxe` gate pass.
+
+Two of the three `calloc` sites on this path are `NULL`-checked (the candidate
+array in `one_random_graph` and the result array in the `k` loop).
+`int_vertices` (`src/graph/generators.c:45-49`) still allocates and immediately
+dereferences without a check — pre-existing, and knowingly left open here even
+though this change adds a caller in `vertex_list`. An absurd `n` or `k` is now
+unevaluated rather than a crash; a genuine allocation failure inside
+`int_vertices` remains a `NULL` dereference.
+
+Memory: the helper frees the `int_vertices` C array, which `expr_new_function`
+memcpys rather than adopts — `Do[RandomGraph[{1, 0}], {50}]` is now completely
+leak-free. The pre-existing candidate-tree retention (~364 KB, ~6,100 `Expr`
+nodes per call at `n = 50`) is **not** fixed here and multiplies by `k`; it is
+documented in the docstring and the spec entry instead. The same one-line array
+leak in `CompleteGraph`, `CycleGraph`, and both `PathGraph` branches is
+out of scope for this change.

--- a/docs/spec/changelog/2026-08-24.md
+++ b/docs/spec/changelog/2026-08-24.md
@@ -2511,11 +2511,12 @@ The single-graph body was lifted into `one_random_graph`, which both arities
 share, plus a `vertex_list` helper. The `evaluate(RandomSample[...])` round-trip
 is preserved deliberately — it is what makes `SeedRandom` reproducibility fall
 out for free — and the refactor is RNG-transparent: a seeded 1-arg call produces
-a byte-identical edge list. The stream *position* after `RandomGraph[{5, 0}]` is
-established by inspection only — the `n >= 2` path adds and removes no RNG
-consumption, and the new early return is keyed on `maxe`, not `m`, so it cannot
-be reached when `n >= 2`. It has **not** been compared against a pre-change
-binary; that check (AC-17) was not run.
+a byte-identical edge list. The stream *position* after `RandomGraph[{5, 0}]` has
+now been measured against a binary built at the pre-change SHA `7701df5b`:
+`(SeedRandom[7]; RandomGraph[{5, 0}]; RandomInteger[{1, 10^6}])` gives `55361` on
+both, as does the `n >= 2` variant and a seeded `EdgeList[RandomGraph[{6, 5}]]`.
+This is what confirms the `maxe`-keyed early return did not silently extend to
+`m == 0` and consume one draw fewer (AC-17, previously argued by inspection).
 
 Incidental fix: `n <= 1` leaves no candidate edges, and `RandomSample[{}, m]` is
 itself unevaluated, so `RandomGraph[{0, 0}]` and `RandomGraph[{1, 0}]` returned

--- a/src/graph/generators.c
+++ b/src/graph/generators.c
@@ -5,6 +5,7 @@
  *   PathGraph[n]              - undirected path 1-2-...-n
  *   PathGraph[{v1,...,vk}]    - undirected path over the given vertices
  *   RandomGraph[{n, m}]       - undirected graph with n vertices, m random edges
+ *   RandomGraph[{n, m}, k]    - a list of k such graphs
  *
  * Each assembles a Graph[List verts, List edges] expression and returns it; the
  * evaluator canonicalizes and validates it via builtin_graph. Vertices are the
@@ -20,6 +21,7 @@
 #include "eval.h"
 #include "sym_names.h"
 #include <stdlib.h>
+#include <stdint.h>   /* SIZE_MAX */
 
 /* Small integer argument as a nonnegative long, or -1 if not a suitable int. */
 static long as_count(const Expr* e) {
@@ -100,19 +102,40 @@ Expr* builtin_path_graph(Expr* res) {
     return make_graph(int_vertices(n), (size_t)n, edges, ne);
 }
 
-Expr* builtin_random_graph(Expr* res) {
-    if (res->data.function.arg_count != 1) return NULL;
-    const Expr* spec = res->data.function.args[0];
-    if (!graph_is_list(spec) || spec->data.function.arg_count != 2) return NULL;
-    long n = as_count(spec->data.function.args[0]);
-    long m = as_count(spec->data.function.args[1]);
-    if (n < 0 || m < 0) return NULL;
-    long maxe = n * (n - 1) / 2;
-    if (m > maxe) return NULL;   /* more edges than a simple graph allows */
+/* Vertices 1..n wrapped as a List; frees the intermediate C array, which
+ * expr_new_function memcpys rather than adopting (src/expr.c:257). */
+static Expr* vertex_list(long n) {
+    Expr** verts = int_vertices(n);
+    Expr* vlist = expr_new_function(expr_new_symbol(SYM_List), verts, (size_t)n);
+    free(verts);
+    return vlist;
+}
+
+/* One random undirected graph: n vertices, m of the n(n-1)/2 candidate edges.
+ * Returns NULL if the sampler declines or an allocation fails. Caller has
+ * already validated n >= 0, m >= 0, maxe representable, m <= maxe.
+ *
+ * Assembly is inline rather than via make_graph (:36-41) on purpose: that
+ * helper frees none of the arrays it is handed (its "moves ownership" comment
+ * predates the memcpy) and takes an Expr** edge array, not a built List. */
+static Expr* one_random_graph(long n, unsigned long long maxe, long m) {
+    /* n <= 1 leaves no candidates, and RandomSample[{}, m] is itself
+     * unevaluated (is_nonempty_list, src/random.c:1707) — which is why
+     * RandomGraph[{0,0}] failed before RG-1. Answer directly instead.
+     *
+     * Deliberately NOT extended to m == 0 with n >= 2: that case works via
+     * RandomSample[cand, 0], and skipping the call would shift the RNG stream
+     * for every later draw. */
+    if (maxe == 0) {
+        Expr* gargs[2] = { vertex_list(n),
+                           expr_new_function(expr_new_symbol(SYM_List), NULL, 0) };
+        return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+    }
 
     /* All candidate undirected edges. */
     size_t ncand = (size_t)maxe;
-    Expr** cand = (ncand > 0) ? calloc(ncand, sizeof(Expr*)) : NULL;
+    Expr** cand = calloc(ncand, sizeof(Expr*));
+    if (!cand) return NULL;                  /* absurd n: unevaluated, not a crash */
     size_t k = 0;
     for (long i = 1; i <= n; i++)
         for (long j = i + 1; j <= n; j++)
@@ -127,8 +150,53 @@ Expr* builtin_random_graph(Expr* res) {
     Expr* sampled = evaluate(sample_call);   /* consumes sample_call */
     if (!graph_is_list(sampled)) { expr_free(sampled); return NULL; }
 
-    Expr* gargs[2] = { expr_new_function(expr_new_symbol(SYM_List),
-                                         int_vertices(n), (size_t)n),
-                       sampled };
+    Expr* gargs[2] = { vertex_list(n), sampled };
     return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+}
+
+Expr* builtin_random_graph(Expr* res) {
+    size_t argc = res->data.function.arg_count;
+    if (argc != 1 && argc != 2) return NULL;
+    const Expr* spec = res->data.function.args[0];
+    if (!graph_is_list(spec) || spec->data.function.arg_count != 2) return NULL;
+    long n = as_count(spec->data.function.args[0]);
+    long m = as_count(spec->data.function.args[1]);
+    if (n < 0 || m < 0) return NULL;
+
+    /* n(n-1)/2 overflows signed long for large n, and a negative maxe would let
+     * the m gate below pass. Bound n BEFORE multiplying: checking the product
+     * afterwards cannot catch a wrap, since n = 2^32 + 1 wraps n(n-1) to 2^32
+     * and yields a small, plausible-looking maxe while the candidate loop still
+     * runs to the true n(n-1)/2 and writes past the buffer. With n < 2^31 the
+     * product cannot exceed 2^62, so the unsigned arithmetic below is exact and
+     * the SIZE_MAX bound is meaningful. An n past that is unevaluated, per the
+     * head's error channel. */
+    if (n > 2147483647L) return NULL;
+    unsigned long long maxe = (n < 2) ? 0ULL
+        : (unsigned long long)n * (unsigned long long)(n - 1) / 2;
+    if (maxe > (unsigned long long)(SIZE_MAX / sizeof(Expr*))) return NULL;
+    if ((unsigned long long)m > maxe) return NULL;  /* more edges than a simple graph allows */
+
+    if (argc == 1) return one_random_graph(n, maxe, m);
+
+    /* RandomGraph[{n,m}, k]: k independent graphs. k = 0 gives {}; a negative,
+     * non-integer, or symbolic k is silently unevaluated, matching the five
+     * count-taking heads in src/random.c (SPEC section 4: NULL, no Message). */
+    long kcount = as_count(res->data.function.args[1]);
+    if (kcount < 0) return NULL;
+    if ((unsigned long long)kcount > (unsigned long long)(SIZE_MAX / sizeof(Expr*)))
+        return NULL;
+    Expr** gs = (kcount > 0) ? calloc((size_t)kcount, sizeof(Expr*)) : NULL;
+    if (kcount > 0 && !gs) return NULL;
+    for (long i = 0; i < kcount; i++) {
+        gs[i] = one_random_graph(n, maxe, m);
+        if (!gs[i]) {                        /* never return a partial list */
+            for (long j = 0; j < i; j++) expr_free(gs[j]);
+            free(gs);
+            return NULL;
+        }
+    }
+    Expr* out = expr_new_function(expr_new_symbol(SYM_List), gs, (size_t)kcount);
+    free(gs);
+    return out;
 }

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -121,7 +121,8 @@ void graph_init(void) {
     symtab_get_def("RandomGraph")->attributes |= ATTR_PROTECTED;
     symtab_set_docstring("RandomGraph",
         "RandomGraph[{n, m}] gives a random undirected graph with n vertices "
-        "and m edges.");
+        "and m edges. RandomGraph[{n, m}, k] gives a list of k such graphs; "
+        "memory use grows with k.");
 
     /* ---- Phase 5: search & computation algorithms ------------------------ */
     symtab_add_builtin("FindShortestPath", builtin_find_shortest_path);

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -100,7 +100,7 @@ Expr* builtin_adjacency_graph(Expr* res);  /* AdjacencyGraph[m]                *
 Expr* builtin_complete_graph(Expr* res);   /* CompleteGraph[n]                 */
 Expr* builtin_cycle_graph(Expr* res);      /* CycleGraph[n]                    */
 Expr* builtin_path_graph(Expr* res);       /* PathGraph[n] / PathGraph[{...}]  */
-Expr* builtin_random_graph(Expr* res);     /* RandomGraph[{n, m}]              */
+Expr* builtin_random_graph(Expr* res);     /* RandomGraph[{n,m}] / [{n,m},k]   */
 
 /* ---- Phase 5: shared adjacency scaffolding (graph_util.c) ------------------
  * Integer-indexed adjacency derived from a validated graph. Vertex i is

--- a/tests/test_graph.c
+++ b/tests/test_graph.c
@@ -225,6 +225,44 @@ static void test_random_graph(void) {
     ASSERT(strcmp(s, "True") == 0);
     free(s);
     expr_free(e1);
+
+    /* --- RandomGraph[{n,m},k]: k independent graphs (RG-1) --- */
+    assert_eval_eq("Length[RandomGraph[{6, 5}, 3]]", "3", 0);
+    assert_eval_eq("And @@ (GraphQ /@ RandomGraph[{6, 5}, 3])", "True", 0);
+    assert_eval_eq("Union[VertexCount /@ RandomGraph[{6, 5}, 3]]", "{6}", 0);
+    assert_eval_eq("Union[EdgeCount /@ RandomGraph[{6, 5}, 3]]", "{5}", 0);
+    /* k = 1 is a one-element list, not a bare graph. */
+    assert_eval_eq("Length[RandomGraph[{6, 5}, 1]]", "1", 0);
+    assert_eval_eq("RandomGraph[{6, 5}, 0]", "{}", 0);
+    /* Bad k: silently unevaluated, per the src/random.c convention. */
+    assert_eval_eq("Head[RandomGraph[{6, 5}, -1]]", "RandomGraph", 0);
+    assert_eval_eq("Head[RandomGraph[{6, 5}, 2.5]]", "RandomGraph", 0);
+    assert_eval_eq("Head[RandomGraph[{6, 5}, q]]", "RandomGraph", 0);
+    /* m out of range fails identically at either arity. */
+    assert_eval_eq("Head[RandomGraph[{3, 10}, 2]]", "RandomGraph", 0);
+    /* Independence: 5 draws from C(28,4) are not all the same edge set. */
+    assert_eval_eq("Length[Union[EdgeList /@ RandomGraph[{8, 4}, 5]]] > 1", "True", 0);
+    /* n <= 1 and m = 0: edgeless graphs, no longer unevaluated. */
+    assert_eval_eq("VertexCount[RandomGraph[{0, 0}]]", "0", 0);
+    assert_eval_eq("EdgeCount[RandomGraph[{1, 0}]]", "0", 0);
+    assert_eval_eq("Union[EdgeCount /@ RandomGraph[{5, 0}, 2]]", "{0}", 0);
+    /* An absurd n or k is unevaluated, not a crash. n = 2^32 + 1 is the witness
+     * that matters: n(n-1) wraps to 2^32 in 64 bits, so a guard applied to the
+     * product instead of to n admits a small maxe and then overruns the
+     * candidate buffer. n = 2^62 happens to wrap above the bound and so passes
+     * either way. */
+    assert_eval_eq("Head[RandomGraph[{4294967297, 1}, 1]]", "RandomGraph", 0);
+    assert_eval_eq("Head[RandomGraph[{4294967297, 1}]]", "RandomGraph", 0);
+    assert_eval_eq("Head[RandomGraph[{5, 2}, 4611686018427387904]]", "RandomGraph", 0);
+
+    /* Determinism under a fixed seed, k form. */
+    Expr* e2 = evaluate(parse_expression(
+        "(SeedRandom[42]; EdgeList /@ RandomGraph[{6,5},3]) === "
+        "(SeedRandom[42]; EdgeList /@ RandomGraph[{6,5},3])"));
+    char* s2 = expr_to_string(e2);
+    ASSERT(strcmp(s2, "True") == 0);
+    free(s2);
+    expr_free(e2);
 }
 
 /* ---- Phase 5: algorithms -------------------------------------------------- */

--- a/thoughts/shared/receipts/ladder-7701df5b36ca+dirty.md
+++ b/thoughts/shared/receipts/ladder-7701df5b36ca+dirty.md
@@ -1,0 +1,15 @@
+# Verification receipt
+
+- commit: `7701df5b36cab11000efad1f3b2dff094ff2316f` **plus uncommitted changes** — this run verified the WORKING TREE, which that commit does not fully contain. Commit and re-run for a receipt that vouches for a SHA.
+- runner: `skills/verification-ladder/scripts/ladder.py` (rungs are subprocesses; no model ran below the judge rung)
+
+| rung | outcome | command |
+|---|---|---|
+| static | failed | `ruff check .` |
+
+**RECOMMENDATION:** BLOCKED — static failed; no verification claim can be made until it is green
+"Review-ready" is never emitted by this tool — that verdict requires the judge rung, which is a human or an LLM, not a subprocess this receipt can vouch for.
+
+**Judge rung:** an adversarial review ran and left `thoughts/shared/tickets/RG-1/adversarial.md`. Cited, not adjudicated — this tool records that the review exists and where to read it. It does not parse the review's verdicts, so a citation here never means the findings were resolved.
+
+A receipt is what makes one run servable to every reviewer: the next reader re-runs the diff since this SHA, not the whole review again.

--- a/thoughts/shared/tickets/RG-1/adversarial.md
+++ b/thoughts/shared/tickets/RG-1/adversarial.md
@@ -1,0 +1,88 @@
+# Adversarial review — RG-1 (`RandomGraph[{n,m},k]`)
+
+**Date:** 2026-08-30 22:54:35 (written); HIGH re-verified and resolved 2026-08-30 23:03:49
+**Scope:** uncommitted working-tree diff vs `7701df5b` — `src/graph/generators.c`,
+`src/graph/graph.c`, `src/graph/graph.h`, `tests/test_graph.c`,
+`docs/spec/builtins/graphs.md`, `docs/spec/changelog/2026-08-24.md`
+**Plan:** `thoughts/shared/tickets/RG-1/plan.md`
+
+Ticket scope (AC-1 … AC-17, AC-19) is implemented and matches the docs, docstring, and
+changelog. Ownership on the new paths is correct: `vertex_list` frees the memcpy'd array,
+`cand` is freed after `expr_new_function`, `sampled` is freed on the reject path, the
+`k`-loop frees accumulated graphs and `gs` on partial failure, `res` is never freed, and
+`NULL` is returned for every decline.
+
+## ~~HIGH~~ → RESOLVED — the `maxe` overflow guard still wraps; out-of-bounds heap write
+
+> **RESOLVED 2026-08-30 23:03:49** (`src/graph/generators.c` mtime; working tree on top of
+> HEAD `7701df5b` — the fix is uncommitted, so it has no SHA of its own yet).
+> Re-verified by reading the current file: `src/graph/generators.c:174` now reads
+> `if (n > 2147483647L) return NULL;` and sits **before** the multiply at `:175-176`, with
+> the comment block at `:166-173` naming this exact `n = 2^32 + 1` witness as its reason.
+> With `n < 2^31` the product `n(n-1)` cannot exceed `2^62`, so the `unsigned long long`
+> arithmetic is exact and the downstream `SIZE_MAX` bound is meaningful. The wrap described
+> below is unreachable, and the 17 GB `calloc` is never attempted.
+> Live check (now safe, since both witnesses decline before allocating):
+> `RandomGraph[{4294967297, 1}]` and `RandomGraph[{2147483648, 1}]` both return
+> unevaluated; `RandomGraph[{5,4}]` still returns `Graph[<5 vertices, 4 edges>]`.
+> The finding below is retained as written for the record — it describes the pre-fix file.
+
+`src/graph/generators.c:169-171`, exploited at `:136-142`.
+
+`maxe = (unsigned long long)n * (n-1) / 2` is computed in the same 64-bit width it is
+meant to protect, so it wraps silently. Witness `n = 2^32 + 1 = 4294967297`, `m = 1`:
+
+- `n*(n-1) = 2^64 + 2^32` → wraps to `2^32`, so `maxe = 2^31`.
+- `2^31 < SIZE_MAX / sizeof(Expr*)` (≈2^61), so the bound at `:171` passes.
+- `m = 1 <= maxe`, so `:172` passes.
+- `:137` allocates `calloc(2^31, 8)` = 17.2 GB — under Linux overcommit this routinely
+  succeeds.
+- `:140-142` then iterates over the **true** `n(n-1)/2 ≈ 9.2e18` candidate pairs, writing
+  `cand[k++]` past the `2^31`-th slot. Heap corruption, not a `NULL`-checkable failure.
+
+The loop bound is `n`, not `ncand`; nothing reconciles the two. Where the `calloc` happens
+to fail the result is a benign `NULL`, so the outcome is allocator- and platform-dependent,
+which is worse than a deterministic decline.
+
+AC-18's chosen witness (`n = 2^62`) wraps to a value *above* the `SIZE_MAX` bound and so
+is rejected by coincidence — the test passes while the bug class is untouched.
+
+Fix: bound `n` itself before multiplying (e.g. reject `n` above ~`2^31`, well past any
+allocatable candidate set), or detect the wrap in the product, rather than checking the
+product after the fact.
+
+**Verification status:** CONFIRMED by code reading (arithmetic and the loop bound both
+checked in the file). Deliberately **not** exercised on the live binary — running the
+witness risks a 17 GB allocation followed by an out-of-bounds write.
+
+## MEDIUM — `int_vertices` returns `NULL` on allocation failure and is dereferenced
+
+`src/graph/generators.c:46-47`, newly reached via `vertex_list` at `:108`.
+
+The `calloc` result is unchecked and `v[i] = ...` dereferences it. Pre-existing code, but
+the diff adds a caller and the changelog advertises that "both `calloc`s are
+`NULL`-checked" — there are three allocation sites on this path and this is the unchecked
+one.
+
+Still present as of 23:03:49 (`:45-49` in the current file — `Expr** v = (n > 0) ? calloc(...)`
+followed by an unguarded `v[i] = ...`). The reachability argument has changed with the HIGH's
+fix: the multi-billion-vertex route via a wrapped `maxe` is now closed, so this is reachable
+only through a genuine allocation failure at a large-but-legal `n` (up to `2^31 - 1`
+vertices), not through the overflow. Severity stays MEDIUM.
+
+## LOW — the changelog's leak claim has no artifact behind it
+
+`docs/spec/changelog/2026-08-24.md`: "`Do[RandomGraph[{1, 0}], {50}]` is now completely
+leak-free". No valgrind output or scripted leak check is in the diff, so if the claim
+regresses nothing in the tree notices. `tests/scripts/geometry_leakcheck.sh` — cited in the
+same changelog file — is the existing pattern for exactly this.
+
+## Could not assess
+
+- Whether the C suite passes, and whether AC-18's witness returns unevaluated on this
+  build — the 466-binary suite was explicitly out of scope for this run.
+- AC-17 (RNG stream position unchanged) — needs both binaries built and a seeded draw
+  diffed. Inspection shows no RNG consumption added or removed on the `n >= 2` path, which
+  is consistent with the claim but is not the measurement AC-17 asks for.
+- No domain checklist configured (`.claude/GUIDANCE_ROLES.md` absent), so this ran on the
+  generic list alone.

--- a/thoughts/shared/tickets/RG-1/plan-summary.html
+++ b/thoughts/shared/tickets/RG-1/plan-summary.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>RG-1</title>
+<link rel="stylesheet" href="../../../../../kit-delivered/skills/render-artifact/assets/style.css">
+</head>
+<body>
+
+
+
+<div class="page">
+  <div class="layout">
+    <nav class="sidebar"><details class="outline-group page-toc" open><summary>On this page</summary><ul><li style="padding-left:0px"><a href="#rg-1-randomgraph-n-m-k-one-page-view">RG-1 — RandomGraph[{n, m}, k]: one-page view</a></li>
+<li style="padding-left:0px"><a href="#recommendation">Recommendation</a></li>
+<li style="padding-left:0px"><a href="#options-considered">Options considered</a></li>
+<li style="padding-left:0px"><a href="#decision-criteria">Decision criteria</a></li>
+<li style="padding-left:0px"><a href="#decisions">Decisions</a></li>
+<li style="padding-left:0px"><a href="#non-goals">Non-goals</a></li>
+<li style="padding-left:0px"><a href="#open-questions">Open Questions</a></li>
+<li style="padding-left:12px"><a href="#unresolved">Unresolved</a></li>
+<li style="padding-left:12px"><a href="#resolved">Resolved</a></li>
+<li style="padding-left:0px"><a href="#requires-approval">Requires Approval</a></li>
+<li style="padding-left:0px"><a href="#architecture-impact">Architecture Impact</a></li>
+<li style="padding-left:0px"><a href="#subsystems-dependencies">Subsystems &amp; Dependencies</a></li>
+<li style="padding-left:0px"><a href="#how-we-ll-know-it-worked">How we&#x27;ll know it worked</a></li>
+<li style="padding-left:0px"><a href="#review-status">Review status</a></li>
+<li style="padding-left:0px"><a href="#appendix">Appendix</a></li></ul></details></nav>
+    <main class="content">
+      <header class="page-header">
+        <h1 id="rg-1">RG-1</h1>
+        <div class="meta"><span class="meta-item"><b>ticket:</b> RG-1</span> <span class="meta-item"><b>type:</b> plan</span> <span class="meta-item"><b>lifecycle:</b> active</span> <span class="meta-item"><b>status:</b> draft</span> <span class="meta-item"><b>created:</b> 2026-08-30</span></div>
+      </header>
+      
+      
+      <section class="open-questions" id="oq-section"><h2 id="open-questions">Open Questions</h2>
+<h3 id="unresolved">Unresolved</h3>
+<p><em>None.</em></p>
+<h3 id="resolved">Resolved</h3>
+<ul>
+<li class="checkbox-item checked"><span class="checkbox">&#9745;</span> Should the <code>n &lt;= 1</code> / <code>maxe == 0</code> case be fixed incidentally? — Yes. Confirmed with the human, 2026-08-30: the helper early-returns an edgeless graph, which the <code>k</code> form needs anyway and which removes a wrong answer rather than replicating it <code>k</code> times.</li>
+<li class="checkbox-item checked"><span class="checkbox">&#9745;</span> Cap <code>k</code> to bound the per-call leak, fix the leak, or document it? — Document only. Confirmed with the human, 2026-08-30. No sibling <code>Random*</code> head caps its count, and fixing the candidate-tree leak was already scoped out by the research.</li>
+</ul></section>
+      
+      <h2 id="recommendation">Recommendation</h2>
+<p>Extract the single-graph body of <code>builtin_random_graph</code> (<code>src/graph/generators.c:103-134</code>) into a static helper, make the builtin a thin dispatcher on <code>arg_count</code>, and loop the helper <code>k</code> times into a <code>List</code>. <code>k</code> is validated with the file's existing <code>as_count</code> (<code>:25-28</code>), which already gives the exact count semantics the five sibling heads in <code>src/random.c</code> agree on: <code>k = 0</code> → <code>{}</code>, and negative, non-integer, or symbolic <code>k</code> → unevaluated, silently.</p>
+<p>Two phases: <strong>(1)</strong> the generator change, <strong>(2)</strong> tests, docstring, spec, changelog. One source file of real change; the rest is docs and tests.</p>
+<h2 id="options-considered">Options considered</h2>
+<table>
+<thead><tr>
+<th>Option</th>
+<th>Verdict</th>
+</tr></thead><tbody>
+<tr>
+<td>Extract a helper, loop it <code>k</code> times (chosen)</td>
+<td>Smallest diff that shares one code path between both arities. Keeps the current inline assembly — <code>make_graph</code> frees none of the arrays it is handed and takes an edge array, not a built <code>List</code>.</td>
+</tr>
+<tr>
+<td>Generalize count-spec parsing into a shared helper</td>
+<td>Rejected — no such helper exists; seven heads across three subsystems hand-roll their own. Would touch <code>src/random.c</code>, <code>src/ml/dist.c</code>, <code>src/list/constant_array.c</code>.</td>
+</tr>
+<tr>
+<td>Replace the <code>evaluate(RandomSample[...])</code> round-trip with a C-level RNG call</td>
+<td>Rejected — the round-trip is what makes <code>SeedRandom</code> work for free. Research resolved the O(n²) rework as out of scope.</td>
+</tr>
+<tr>
+<td>Also fix the measured candidate-tree leak (Finding 4B)</td>
+<td>Rejected — nearest call of the three. Research scoped it out; the human confirmed documenting over fixing.</td>
+</tr>
+</tbody></table>
+<h2 id="decision-criteria">Decision criteria</h2>
+<ul>
+<li>Match the established convention rather than invent one: silent <code>NULL</code> for a bad count (zero <code>Message(</code> calls in <code>src/random.c</code>), <code>{Graph[...]}</code> for <code>k = 1</code>.</li>
+<li>Preserve <code>SeedRandom</code> reproducibility — non-negotiable, and free if the sampler call stays as-is.</li>
+<li>Do not let the refactor change the existing 1-arg form.</li>
+</ul>
+<h2 id="decisions">Decisions</h2>
+<ul>
+<li><strong>Flat <code>k</code> only.</strong> The nested <code>RandomGraph[{n, m}, {k1, k2}]</code> form is out of scope, per the research's resolved question.</li>
+<li><strong>Extract a static helper, don't generalize.</strong> There is no shared count-spec parser anywhere in the tree — <code>src/random.c</code> holds five hand-written copies. A sixth local check is the idiomatic choice here; a generalizing refactor would be scope creep.</li>
+<li><strong>Keep the <code>evaluate(RandomSample[...])</code> round-trip.</strong> It is why <code>SeedRandom</code> works.</li>
+<li><strong>Fix the <code>n &lt;= 1</code> case incidentally</strong> (chosen by the human, 2026-08-30). The helper early-returns an edgeless graph when <code>maxe == 0</code> — and <strong>only</strong> then, not when <code>m == 0</code>, which works today and must keep consuming the RNG stream identically.</li>
+<li><strong>Document the leak, don't cap <code>k</code></strong> (chosen by the human, 2026-08-30). No sibling <code>Random*</code> head restricts its count, and a cap would be a non-Mathematica restriction.</li>
+<li><strong>Free the C arrays this diff allocates</strong>, keeping the assembly inline rather than calling <code>make_graph</code>, which frees nothing. <code>expr_new_function</code> memcpys (<code>src/expr.c:257</code>), so the caller owns the array. Leak (A), fixed only where the diff lands.</li>
+<li><strong>Fail unevaluated instead of crashing on an absurd <code>n</code> or <code>k</code>.</strong> Compute <code>maxe</code> in <code>unsigned long long</code>, bound it against <code>SIZE_MAX</code>, and check both <code>calloc</code>s — no arbitrary cap, just the head's existing <code>NULL</code> error channel.</li>
+</ul>
+<h2 id="non-goals">Non-goals</h2>
+<ul>
+<li><strong>The candidate-tree leak, Finding 4B</strong> (~364 KB/call at n=50). Scoped out by research; documented rather than fixed. It multiplies by <code>k</code>.</li>
+<li><strong>Leak (A) in the other four generators</strong> (<code>CompleteGraph</code>, <code>CycleGraph</code>, both <code>PathGraph</code> branches). Same one-line shape, but out of this diff.</li>
+<li><strong>The nested <code>{k1, k2}</code> dimension form.</strong></li>
+<li><strong>Reworking the O(n²) candidate materialization.</strong> Explicitly resolved as out of scope.</li>
+<li><strong>Any packed/NDArray/<code>Compile[]</code> surface.</strong> <code>RandomGraph</code> returns a <code>Graph</code> object, not a machine array — the "non-machine object" exemption CLAUDE.md names. Verified absent from <code>src/pack.c</code>'s <code>AWARE</code> list, <code>src/ndkernels.c</code>, <code>src/ndinteger.c</code>, and <code>src/compile/</code>.</li>
+</ul>
+<h2 id="requires-approval">Requires Approval</h2>
+<p>The <code>n &lt;= 1</code> fix (AC-14, AC-15) changes the observable behavior of the <strong>existing</strong> 1-arg form: <code>RandomGraph[{0, 0}]</code> and <code>RandomGraph[{1, 0}]</code> go from unevaluated to returning an edgeless graph. That is a bug fix, not a regression, but it is a behavior change outside the ticket's literal scope and was approved in conversation on 2026-08-30.</p>
+<h2 id="architecture-impact">Architecture Impact</h2>
+<ul>
+<li>New services introduced: none</li>
+<li>APIs changed: <code>RandomGraph</code> gains a second, optional argument — backward compatible yes (the 1-arg form is unchanged; the previously-unevaluated 2-arg form now evaluates)</li>
+<li>Data crossing a service boundary: none</li>
+<li>New external dependency: none</li>
+<li>Deployment topology change: none</li>
+</ul>
+<h2 id="subsystems-dependencies">Subsystems &amp; Dependencies</h2>
+<ul>
+<li>Subsystems touched: graph (invocation: inline — no doc exists; <code>thoughts/shared/subsystems/</code> is absent from the tree)</li>
+<li>Interdependencies surfaced: graph ↔ random — <code>builtin_random_graph</code> reaches <code>RandomSample</code> through <code>evaluate()</code> rather than a C-level RNG call. This is load-bearing for <code>SeedRandom</code> and is also the cause of the <code>n &lt;= 1</code> bug being fixed here.</li>
+</ul>
+<h2 id="how-we-ll-know-it-worked">How we'll know it worked</h2>
+<p>19 acceptance criteria in the full plan, all REPL-observable, covering the <code>k</code> form, the <code>k = 0</code> / <code>k = 1</code> boundary, invalid <code>k</code>, out-of-range <code>m</code> at both arities, seeded determinism, draw independence, the unchanged 1-arg form, and the <code>n &lt;= 1</code> fix. Plus a build under <code>SDKROOT=$(xcrun --show-sdk-path) make -j8</code>, <code>make check-c99</code>, the graph unit suite, and a <code>leaks --atExit</code> run.</p>
+<h2 id="review-status">Review status</h2>
+<p><code>plan-reviewer</code> ran on 2026-08-30 (scope-boundary + testability lenses): 2 BLOCKING, 2 WORTH FLAGGING, all four addressed in the full plan. The blocking pair were a <code>make_graph</code>-vs-inline contradiction that would have reintroduced the leak the plan commits to fixing, and an unapproved RNG-stream change to the existing 1-arg form at <code>m == 0</code> — that early return is now <code>maxe == 0</code> only. Findings are transcribed verbatim in the full plan's <code>## Plan Review</code>; <code>### Blocking</code> is clear.</p>
+<h2 id="appendix">Appendix</h2>
+<p>Full detail, phase breakdown, code sketches, and the reviewer findings: <a href="plan.md"><code>thoughts/shared/tickets/RG-1/plan.md</code></a>. Source research: <a href="research.md"><code>thoughts/shared/tickets/RG-1/research.md</code></a>.</p>
+    </main>
+  </div>
+</div>
+<script src="../../../../../kit-delivered/skills/render-artifact/assets/mermaid.min.js"></script>
+<script src="../../../../../kit-delivered/skills/render-artifact/assets/site-nav.js" defer></script>
+<script>
+  mermaid.initialize({ startOnLoad: true, securityLevel: "strict" });
+</script>
+</body>
+</html>

--- a/thoughts/shared/tickets/RG-1/plan-summary.md
+++ b/thoughts/shared/tickets/RG-1/plan-summary.md
@@ -1,0 +1,134 @@
+---
+ticket: RG-1
+created: 2026-08-30
+type: plan
+lifecycle: active
+status: draft
+full_plan: thoughts/shared/tickets/RG-1/plan.md
+---
+
+# RG-1 — `RandomGraph[{n, m}, k]`: one-page view
+
+## Recommendation
+
+Extract the single-graph body of `builtin_random_graph`
+(`src/graph/generators.c:103-134`) into a static helper, make the builtin a thin dispatcher
+on `arg_count`, and loop the helper `k` times into a `List`. `k` is validated with the
+file's existing `as_count` (`:25-28`), which already gives the exact count semantics the
+five sibling heads in `src/random.c` agree on: `k = 0` → `{}`, and negative, non-integer,
+or symbolic `k` → unevaluated, silently.
+
+Two phases: **(1)** the generator change, **(2)** tests, docstring, spec, changelog.
+One source file of real change; the rest is docs and tests.
+
+## Options considered
+
+| Option | Verdict |
+|---|---|
+| Extract a helper, loop it `k` times (chosen) | Smallest diff that shares one code path between both arities. Keeps the current inline assembly — `make_graph` frees none of the arrays it is handed and takes an edge array, not a built `List`. |
+| Generalize count-spec parsing into a shared helper | Rejected — no such helper exists; seven heads across three subsystems hand-roll their own. Would touch `src/random.c`, `src/ml/dist.c`, `src/list/constant_array.c`. |
+| Replace the `evaluate(RandomSample[...])` round-trip with a C-level RNG call | Rejected — the round-trip is what makes `SeedRandom` work for free. Research resolved the O(n²) rework as out of scope. |
+| Also fix the measured candidate-tree leak (Finding 4B) | Rejected — nearest call of the three. Research scoped it out; the human confirmed documenting over fixing. |
+
+## Decision criteria
+
+- Match the established convention rather than invent one: silent `NULL` for a bad count
+  (zero `Message(` calls in `src/random.c`), `{Graph[...]}` for `k = 1`.
+- Preserve `SeedRandom` reproducibility — non-negotiable, and free if the sampler call
+  stays as-is.
+- Do not let the refactor change the existing 1-arg form.
+
+## Decisions
+
+- **Flat `k` only.** The nested `RandomGraph[{n, m}, {k1, k2}]` form is out of scope, per
+  the research's resolved question.
+- **Extract a static helper, don't generalize.** There is no shared count-spec parser
+  anywhere in the tree — `src/random.c` holds five hand-written copies. A sixth local check
+  is the idiomatic choice here; a generalizing refactor would be scope creep.
+- **Keep the `evaluate(RandomSample[...])` round-trip.** It is why `SeedRandom` works.
+- **Fix the `n <= 1` case incidentally** (chosen by the human, 2026-08-30). The helper
+  early-returns an edgeless graph when `maxe == 0` — and **only** then, not when `m == 0`,
+  which works today and must keep consuming the RNG stream identically.
+- **Document the leak, don't cap `k`** (chosen by the human, 2026-08-30). No sibling
+  `Random*` head restricts its count, and a cap would be a non-Mathematica restriction.
+- **Free the C arrays this diff allocates**, keeping the assembly inline rather than
+  calling `make_graph`, which frees nothing. `expr_new_function` memcpys
+  (`src/expr.c:257`), so the caller owns the array. Leak (A), fixed only where the diff
+  lands.
+- **Fail unevaluated instead of crashing on an absurd `n` or `k`.** Compute `maxe` in
+  `unsigned long long`, bound it against `SIZE_MAX`, and check both `calloc`s — no
+  arbitrary cap, just the head's existing `NULL` error channel.
+
+## Non-goals
+
+- **The candidate-tree leak, Finding 4B** (~364 KB/call at n=50). Scoped out by research;
+  documented rather than fixed. It multiplies by `k`.
+- **Leak (A) in the other four generators** (`CompleteGraph`, `CycleGraph`, both
+  `PathGraph` branches). Same one-line shape, but out of this diff.
+- **The nested `{k1, k2}` dimension form.**
+- **Reworking the O(n²) candidate materialization.** Explicitly resolved as out of scope.
+- **Any packed/NDArray/`Compile[]` surface.** `RandomGraph` returns a `Graph` object, not a
+  machine array — the "non-machine object" exemption CLAUDE.md names. Verified absent from
+  `src/pack.c`'s `AWARE` list, `src/ndkernels.c`, `src/ndinteger.c`, and `src/compile/`.
+
+## Open Questions
+
+### Unresolved
+
+_None._
+
+### Resolved
+
+- [x] Should the `n <= 1` / `maxe == 0` case be fixed incidentally? — Yes. Confirmed with
+  the human, 2026-08-30: the helper early-returns an edgeless graph, which the `k` form
+  needs anyway and which removes a wrong answer rather than replicating it `k` times.
+- [x] Cap `k` to bound the per-call leak, fix the leak, or document it? — Document only.
+  Confirmed with the human, 2026-08-30. No sibling `Random*` head caps its count, and
+  fixing the candidate-tree leak was already scoped out by the research.
+
+## Requires Approval
+
+The `n <= 1` fix (AC-14, AC-15) changes the observable behavior of the **existing** 1-arg
+form: `RandomGraph[{0, 0}]` and `RandomGraph[{1, 0}]` go from unevaluated to returning an
+edgeless graph. That is a bug fix, not a regression, but it is a behavior change outside
+the ticket's literal scope and was approved in conversation on 2026-08-30.
+
+## Architecture Impact
+
+- New services introduced: none
+- APIs changed: `RandomGraph` gains a second, optional argument — backward compatible yes
+  (the 1-arg form is unchanged; the previously-unevaluated 2-arg form now evaluates)
+- Data crossing a service boundary: none
+- New external dependency: none
+- Deployment topology change: none
+
+## Subsystems & Dependencies
+
+- Subsystems touched: graph (invocation: inline — no doc exists;
+  `thoughts/shared/subsystems/` is absent from the tree)
+- Interdependencies surfaced: graph ↔ random — `builtin_random_graph` reaches
+  `RandomSample` through `evaluate()` rather than a C-level RNG call. This is load-bearing
+  for `SeedRandom` and is also the cause of the `n <= 1` bug being fixed here.
+
+## How we'll know it worked
+
+19 acceptance criteria in the full plan, all REPL-observable, covering the `k` form, the
+`k = 0` / `k = 1` boundary, invalid `k`, out-of-range `m` at both arities, seeded
+determinism, draw independence, the unchanged 1-arg form, and the `n <= 1` fix. Plus a
+build under `SDKROOT=$(xcrun --show-sdk-path) make -j8`, `make check-c99`, the graph unit
+suite, and a `leaks --atExit` run.
+
+## Review status
+
+`plan-reviewer` ran on 2026-08-30 (scope-boundary + testability lenses): 2 BLOCKING,
+2 WORTH FLAGGING, all four addressed in the full plan. The blocking pair were a
+`make_graph`-vs-inline contradiction that would have reintroduced the leak the plan
+commits to fixing, and an unapproved RNG-stream change to the existing 1-arg form at
+`m == 0` — that early return is now `maxe == 0` only. Findings are transcribed verbatim
+in the full plan's `## Plan Review`; `### Blocking` is clear.
+
+## Appendix
+
+Full detail, phase breakdown, code sketches, and the reviewer findings:
+[`thoughts/shared/tickets/RG-1/plan.md`](plan.md).
+Source research: [`thoughts/shared/tickets/RG-1/research.md`](research.md).

--- a/thoughts/shared/tickets/RG-1/plan.md
+++ b/thoughts/shared/tickets/RG-1/plan.md
@@ -1,0 +1,675 @@
+---
+ticket: RG-1
+created: 2026-08-30
+source_sha: 7701df5b36cab11000efad1f3b2dff094ff2316f
+subsystems: [graph]
+type: plan
+lifecycle: active
+status: draft
+---
+
+# `RandomGraph[{n, m}, k]` Implementation Plan
+
+## TL;DR
+
+Add the trailing-count form `RandomGraph[{n, m}, k]`, returning a `List` of `k`
+independent random graphs. The single-graph body in `src/graph/generators.c:103-134` is
+extracted into a static helper that both arities call; `k` is validated with the file's
+existing `as_count`. Risk is contained to one function and one head. Verified by extending
+`test_random_graph` plus a REPL check of the `k = 0`, `k = 1`, and invalid-`k` cases.
+
+## Overview
+
+`RandomGraph` today accepts exactly one argument — the gate is a literal
+`arg_count != 1` at `src/graph/generators.c:104` — so `RandomGraph[{5, 4}, 3]` returns
+unevaluated. Five sibling heads in `src/random.c` already implement the trailing-count
+argument and agree unanimously on its conventions, so this change adds a sixth local copy
+of that shape rather than inventing one.
+
+The single-graph path stays exactly as it is: it samples by constructing and
+`evaluate()`-ing a real `RandomSample[...]` call, which is what makes `SeedRandom`
+reproducibility fall out for free. That coupling is load-bearing and is preserved, not
+optimized away. The `k` form simply calls that path `k` times and collects the results.
+
+Two things surface from the refactor. The helper keeps the current body's **inline**
+assembly rather than adopting the file's `make_graph` helper, because `make_graph` neither
+frees the C arrays it is handed nor accepts an already-built edge `List` — see Alternatives
+Considered. And for `n <= 1` the candidate list is empty, which trips a guard inside
+`RandomSample` and makes `RandomGraph[{0, 0}]` unevaluated today; an early return for that
+one case fixes it as a side effect.
+
+## Decisions
+
+- **Flat `k` only.** The nested `RandomGraph[{n, m}, {k1, k2}]` form is out of scope, per
+  the research's resolved question.
+- **Extract a static helper, don't generalize.** No shared count-spec parser exists;
+  `src/random.c` holds five hand-written copies, so a sixth local check is idiomatic here.
+- **Keep the `evaluate(RandomSample[...])` round-trip.** It is why `SeedRandom` works.
+- **Fix the `n <= 1` case incidentally** (chosen by the human, 2026-08-30). The helper
+  early-returns an edgeless graph when `maxe == 0` — and **only** then, not when `m == 0`,
+  which works today and must keep consuming the RNG stream identically.
+- **Document the leak, don't cap `k`** (chosen by the human, 2026-08-30). No sibling
+  `Random*` head restricts its count, and a cap would be a non-Mathematica restriction.
+- **Free the C arrays this diff allocates**, keeping the assembly inline rather than
+  calling `make_graph`, which frees nothing. `expr_new_function` memcpys
+  (`src/expr.c:257`), so the caller owns the array. Leak (A), fixed only where the diff
+  lands.
+- **Fail unevaluated instead of crashing on an absurd `n` or `k`.** Compute `maxe` in
+  `unsigned long long`, bound it against `SIZE_MAX`, and check both `calloc`s — no
+  arbitrary cap, just the head's existing `NULL` error channel.
+
+## Non-goals
+
+- **The candidate-tree leak, Finding 4B** (~364 KB/call at n=50). Scoped out by research;
+  documented rather than fixed. It multiplies by `k`.
+- **Leak (A) in the other four generators** (`CompleteGraph`, `CycleGraph`, both
+  `PathGraph` branches). Same one-line shape, but out of this diff.
+- **The nested `{k1, k2}` dimension form.**
+- **Reworking the O(n²) candidate materialization.** Explicitly resolved as out of scope.
+- **Any packed/NDArray/`Compile[]` surface.** `RandomGraph` returns a `Graph` object, not a
+  machine array — the "non-machine object" exemption CLAUDE.md names. Verified absent from
+  `src/pack.c`'s `AWARE` list, `src/ndkernels.c`, `src/ndinteger.c`, and `src/compile/`.
+
+## Acceptance Criteria
+
+| ID | Given | When | Then | Input | Expected |
+|---|---|---|---|---|---|
+| AC-1 | the k form with k > 1 | called with n=6, m=5, k=3 | a List of k graphs is returned | `Length[RandomGraph[{6, 5}, 3]]` | `3` |
+| AC-2 | the k form | each element is a valid simple graph on n vertices with m edges | every element satisfies GraphQ | `And @@ (GraphQ /@ RandomGraph[{6, 5}, 3])` | `True` |
+| AC-3 | the k form | edge and vertex counts checked per element | each has n vertices and m edges | `Union[VertexCount /@ RandomGraph[{6, 5}, 3]]` | `{6}` |
+| AC-4 | the k form | edge counts checked per element | each has exactly m edges | `Union[EdgeCount /@ RandomGraph[{6, 5}, 3]]` | `{5}` |
+| AC-5 | k = 1 | called with n=6, m=5, k=1 | a one-element List, not a bare Graph | `Length[RandomGraph[{6, 5}, 1]]` | `1` |
+| AC-6 | k = 0 | called with n=6, m=5, k=0 | the empty List | `RandomGraph[{6, 5}, 0]` | `{}` |
+| AC-7 | negative k | called with k = -1 | unevaluated, no Message | `Head[RandomGraph[{6, 5}, -1]]` | `RandomGraph` |
+| AC-8 | non-integer k | called with k = 2.5 | unevaluated | `Head[RandomGraph[{6, 5}, 2.5]]` | `RandomGraph` |
+| AC-9 | symbolic k | called with k = q | unevaluated | `Head[RandomGraph[{6, 5}, q]]` | `RandomGraph` |
+| AC-10 | m exceeds n(n-1)/2 | called with n=3, m=10, k=2 | unevaluated, same as the 1-arg form | `Head[RandomGraph[{3, 10}, 2]]` | `RandomGraph` |
+| AC-11 | a fixed seed | the k form evaluated twice under SeedRandom[42] | identical results | `(SeedRandom[42]; EdgeList /@ RandomGraph[{6,5},3]) === (SeedRandom[42]; EdgeList /@ RandomGraph[{6,5},3])` | `True` |
+| AC-12 | the k form draws independently | k graphs under one seed | the k elements are not all the identical edge set | `Length[Union[EdgeList /@ RandomGraph[{8, 4}, 5]]] > 1` | `True` |
+| AC-13 | the 1-arg form | unchanged after the refactor | still a bare Graph, n vertices, m edges | `{Head[RandomGraph[{6,5}]], EdgeCount[RandomGraph[{6,5}]]}` | `{Graph, 5}` |
+| AC-14 | n <= 1 (§7 incidental fix) | called with n=0, m=0 | an edgeless graph, no longer unevaluated | `VertexCount[RandomGraph[{0, 0}]]` | `0` |
+| AC-15 | n = 1 (§7 incidental fix) | called with n=1, m=0 | an edgeless one-vertex graph | `EdgeCount[RandomGraph[{1, 0}]]` | `0` |
+| AC-16 | m = 0 with the k form, n >= 2 | called with n=5, m=0, k=2 | two edgeless graphs on n vertices, still via the sampler | `Union[EdgeCount /@ RandomGraph[{5, 0}, 2]]` | `{0}` |
+| AC-17 | m = 0, n >= 2, 1-arg form | the RNG stream position after the call is unchanged from today | the next draw matches the pre-change binary | `(SeedRandom[7]; RandomGraph[{5, 0}]; RandomInteger[{1, 10^6}])` | identical value before and after this change |
+| AC-18 | an absurd n that overflows n(n-1)/2 | called with n = 2^62, m = 1, k = 1 | unevaluated, no crash | `Head[RandomGraph[{4611686018427387904, 1}, 1]]` | `RandomGraph` |
+| AC-19 | an absurd k | called with n=5, m=2, k = 2^62 | unevaluated, no crash | `Head[RandomGraph[{5, 2}, 4611686018427387904]]` | `RandomGraph` |
+
+## Entry Points
+
+- `RandomGraph[{n, m}, k]`
+
+## Open Questions
+
+### Unresolved
+
+_None._
+
+### Resolved
+
+- [x] Should the `n <= 1` / `maxe == 0` case be fixed incidentally? — Yes. Confirmed with
+  the human, 2026-08-30: the helper early-returns an edgeless graph, which the `k` form
+  needs anyway and which removes a wrong answer rather than replicating it `k` times.
+- [x] Cap `k` to bound the per-call leak, fix the leak, or document it? — Document only.
+  Confirmed with the human, 2026-08-30. No sibling `Random*` head caps its count, and
+  fixing the candidate-tree leak was already scoped out by the research.
+
+## Plan Review
+
+Reviewed 2026-08-30 by `plan-reviewer`, scope-boundary + testability lenses. Two BLOCKING
+and two WORTH FLAGGING findings; all four addressed in the plan above.
+
+### Blocking
+
+_None._
+
+### Worth Flagging
+
+**[WORTH FLAGGING] No allocation-failure or integer-overflow path anywhere in the new code, in a change whose whole risk story is memory**
+- Where: Phase 1 code block, `one_random_graph` (`calloc(ncand, ...)`) and
+  `builtin_random_graph` (`calloc(kcount, ...)`); `if (m > n * (n - 1) / 2)`
+- Why: `as_count` accepts any non-negative machine `EXPR_INTEGER`, so `n` can be ~2^62.
+  `n * (n - 1) / 2` then overflows signed `long` (UB, possibly negative, which lets the
+  `m > maxe` gate pass), `ncand` becomes an astronomical `calloc` returning `NULL`, and
+  `cand[k++]` dereferences it. Same for `calloc((size_t)kcount, ...)` with a large `k`,
+  which the plan deliberately declines to cap.
+- Addressed: `maxe` is now computed in `unsigned long long` and bounded against
+  `SIZE_MAX / sizeof(Expr*)`, both `calloc`s are `NULL`-checked, and AC-18/AC-19 pin the
+  absurd-`n` and absurd-`k` cases. Recorded as a Decision.
+
+**[WORTH FLAGGING] The leak-(A)-is-gone criterion has no stated way to observe it**
+- Where: Phase 1 → Manual Verification, third bullet; Testing Strategy step 5
+- Why: `RandomGraph[{50,20}]` leaks ~6,066 `Expr` nodes per call from Finding 4B,
+  deliberately unfixed. Over 50 calls that is ~300k leak records, in which the absence of
+  50 single `calloc` root-leak records is not something "shows the leak scaling with `k`"
+  tells you. No command, filter, or expected count distinguished the two classes.
+- Addressed: the criterion now names `Do[RandomGraph[{1, 0}], {50}]` — the `maxe == 0`
+  path, which builds no candidate tree — and requires **zero** `ROOT LEAK` records naming
+  `builtin_random_graph` or `int_vertices`, with the same grep applied to the n=50 shape.
+
+### Resolved
+
+**[BLOCKING] The plan gives two incompatible shapes for the non-degenerate assembly path — `make_graph` vs. inline — and one of them reintroduces the leak the plan claims to fix**
+- Where: `## Overview`, `### Key Discoveries`, `## Core Flow Diagram`
+  (`V["make_graph(int_vertices(n), n, sampled edges)"]`) vs. the Phase 1 code block, which
+  used `make_graph` only in the degenerate branch and hand-inlined the sampled branch.
+- Why: `make_graph`'s `/* (moves ownership) */` comment is false — `expr_new_function`
+  memcpys (`src/expr.c:257`) — and it frees nothing, so an implementer following the
+  diagram reintroduces leak (A), which Decisions commits to fixing. It also takes
+  `(Expr** edges, size_t ne)`, not a sampled `List`, so the diagram's call is not even
+  type-compatible.
+- Resolved 2026-08-30: took the reviewer's option (a). Dropped the "route through
+  `make_graph`" language from Overview and Key Discoveries, redrew the diagram as inline
+  assembly, and factored the shared part into a `vertex_list(n)` helper that frees the C
+  array. The Non-goals entry for leak (A) in the other four generators stands unchanged.
+
+**[BLOCKING] The `m == 0` half of the early return silently changes the existing 1-arg form beyond what Requires Approval covers**
+- Where: `## Decisions` (`maxe == 0` **or** `m == 0`), `## Requires Approval`,
+  `## Migration Notes`
+- Why: `RandomGraph[{5, 0}]` works today — it builds a non-empty candidate list and calls
+  `RandomSample[cand, 0]`, which returns `{}`. Skipping that call leaves the returned graph
+  identical but the RNG stream position different, observable under `SeedRandom` in any
+  script mixing `RandomGraph[{n,0}]` with later random draws. Migration Notes claimed "the
+  1-arg form is unchanged for `n >= 2`," which this contradicted.
+- Resolved 2026-08-30: took the reviewer's first option. The early return is now
+  `maxe == 0` only — the case that is actually broken and actually approved. `m == 0` with
+  `n >= 2` keeps its sampler call. AC-17 pins the RNG-stream position against the
+  pre-change binary, and Migration Notes says so explicitly.
+
+## Requires Approval
+
+The `n <= 1` fix (AC-14, AC-15) changes the observable behavior of the **existing** 1-arg
+form: `RandomGraph[{0, 0}]` and `RandomGraph[{1, 0}]` go from unevaluated to returning an
+edgeless graph. That is a bug fix, not a regression, but it is a behavior change outside
+the ticket's literal scope and was approved in conversation on 2026-08-30.
+
+## Architecture Impact
+
+- New services introduced: none
+- APIs changed: `RandomGraph` gains a second, optional argument — backward compatible yes
+  (the 1-arg form is unchanged; the previously-unevaluated 2-arg form now evaluates)
+- Data crossing a service boundary: none
+- New external dependency: none
+- Deployment topology change: none
+
+**GUIDANCE ROLE: architecture-guidance.** `.claude/GUIDANCE_ROLES.md` is not present in
+this repo, so the role is not-configured. Nothing cited here.
+
+## Subsystems & Dependencies
+
+- Subsystems touched: graph (invocation: inline — no doc exists;
+  `thoughts/shared/subsystems/` is absent from the tree)
+- Interdependencies surfaced: graph ↔ random — `builtin_random_graph` reaches
+  `RandomSample` through `evaluate()` rather than a C-level RNG call. This is load-bearing
+  for `SeedRandom` and is also the cause of the `n <= 1` bug being fixed here.
+
+## Risks and Rollback
+
+The change is one head's arity plus a refactor of its body, so the risks are local and
+three:
+
+1. **The refactor silently breaks the 1-arg form.** Both arities now share
+   `one_random_graph`, so a mistake there hits existing callers. Noticed by AC-13 and the
+   untouched pre-existing assertions at `tests/test_graph.c:214-220`.
+2. **A memory error in the new failure path.** The `k` loop frees accumulated graphs on a
+   `NULL` element, and `one_random_graph` now frees the `int_vertices` C array — a
+   double-free or use-after-free here would be a crash, not a wrong answer. Noticed by the
+   `leaks --atExit` step in Phase 1 and by the unit suite running under the normal
+   allocator; run `valgrind --leak-check=full` if anything looks off.
+3. **`RandomGraph[{0,0}]` / `[{1,0}]` changing from unevaluated to a graph.** Intended
+   (AC-14/15) and approved, but it is a behavior change to shipped behavior. Noticed only
+   by someone depending on the old unevaluated result — nothing in the tree does
+   (`grep`ped: no `RandomGraph` call sites outside tests and docs).
+
+Rollback is `git revert` of a single commit: one source file, one header comment, one
+docstring, one test function, two docs files. No data, schema, or dependency state to
+unwind, and no consumer to coordinate with.
+
+---
+
+## Current State Analysis
+
+- `src/graph/generators.c:104` — `if (res->data.function.arg_count != 1) return NULL;` is
+  the entire reason the `k` form is absent. Measured: `RandomGraph[{5,4}, 3]` returns
+  unevaluated, and `RandomGraph[{5,4}, 1]` likewise. The head is otherwise sound.
+- `src/graph/generators.c:113-133` — builds all `n(n-1)/2` candidate `UndirectedEdge`
+  expressions, samples via a constructed and `evaluate()`d `RandomSample[cand, m]`, then
+  assembles `Graph[List[1..n], sampled]` **inline** rather than through the file's own
+  `make_graph` helper at `:36-41`. Every other generator in the file uses `make_graph`.
+- `src/graph/generators.c:25-28` — `as_count` already implements exactly the count
+  predicate the sibling heads agree on (non-negative machine `EXPR_INTEGER`, else `-1`).
+  Nothing new needs writing to validate `k`.
+- `src/random.c` — five copies of the trailing-count shape
+  (`builtin_randominteger:418-553`, `randomreal_machine:941-1024`,
+  `randomcomplex_machine:1394-1449`, `builtin_randomchoice:1730-1868`,
+  `builtin_randomsample:1967-2033`), plus `builtin_randomvariate` in `src/ml/dist.c:465-485`.
+  No shared helper exists. Zero `Message(` calls in the file — silent `NULL` is the
+  convention, per SPEC §4.
+- Count conventions, measured across all five heads: `0` → `{}`; negative, non-integer, and
+  symbolic → unevaluated, silently. Unanimous.
+- `src/expr.c:257` — `expr_new_function` **memcpys** the argument array, so the caller owns
+  the C array. `int_vertices` (`:43-47`) `calloc`s a fresh one per call and no generator
+  frees it; that is leak (A).
+- `src/random.c:1707` — `is_nonempty_list`, used at `:1751-1753`, makes
+  `RandomSample[{}, 0]` itself unevaluated. That is why `RandomGraph[{0,0}]` and
+  `RandomGraph[{1,0}]` are unevaluated today: `maxe == 0` → empty `cand_list` → unevaluated
+  sample → `graph_is_list(sampled)` fails at `:128`.
+
+## Desired End State
+
+`RandomGraph[{n, m}]` behaves exactly as it does today for `n >= 2`, and additionally
+returns an edgeless graph for `n <= 1`. `RandomGraph[{n, m}, k]` returns a `List` of `k`
+independently sampled graphs, `{}` for `k = 0`, a one-element list for `k = 1`, and
+unevaluated for a negative, non-integer, or symbolic `k` — silently, with no `Message[]`.
+Both arities share one code path. `SeedRandom` reproducibility holds for both. Verified by
+the 16 Acceptance Criteria rows above, the extended `test_random_graph`, and a clean build.
+
+### Key Discoveries:
+
+- The arity gate is one line (`src/graph/generators.c:104`); the feature is entirely absent
+  rather than partially wrong.
+- `as_count` (`src/graph/generators.c:25-28`) gives the sibling-head count semantics for
+  free — no new validation logic.
+- `builtin_random_graph` bypasses `make_graph` (`:36-41`), and rightly so: `make_graph`'s
+  `/* (moves ownership) */` comment is false given the memcpy at `src/expr.c:257`, it frees
+  nothing, and it takes `(Expr** edges, size_t ne)` rather than a built edge `List`. The
+  helper keeps the inline assembly and frees its own arrays.
+- `k = 1` must return `{Graph[...]}`, not a bare graph — Mathematica semantics, matching
+  `RandomInteger[{1,10}, 1]` → `{7}`.
+- The `evaluate(RandomSample[...])` round-trip is load-bearing for `SeedRandom`.
+
+## Components & Files Affected
+
+| File | Change |
+|---|---|
+| `src/graph/generators.c:103-134` | Extract the single-graph body into `static Expr* one_random_graph(long n, unsigned long long maxe, long m)` plus a `vertex_list` helper; add the `maxe == 0` early return and the overflow/`calloc` guards; relax the gate to accept 1 or 2 args; loop the helper `k` times into a `List` |
+| `src/graph/generators.c:5` | Header comment: add the `RandomGraph[{n, m}, k]` line |
+| `src/graph/graph.h:103` | Trailing signature comment → `/* RandomGraph[{n,m}] / [{n,m},k] */` |
+| `src/graph/graph.c:122-124` | Extend the docstring to name the `k` form. Attributes unchanged (`ATTR_PROTECTED` only, set via the module's `symtab_get_def(name)->attributes \|= ...` idiom) |
+| `tests/test_graph.c:213-228` | Extend `test_random_graph` with the `k`-form, invalid-`k`, and `n <= 1` cases. No new registration needed (`:310-311` already registers it) |
+| `docs/spec/builtins/graphs.md:115-117` | Document the `k` form, the `k` conventions, and the per-`k` memory cost |
+| `docs/spec/changelog/2026-08-24.md` | Change summary (Monday of the current ISO week; file exists) |
+
+## Core Flow Diagram
+
+```mermaid
+flowchart TD
+    A["RandomGraph[...]"] --> B{arg_count}
+    B -->|"not 1 or 2"| N["return NULL"]
+    B -->|1| C["parse {n, m}"]
+    B -->|2| K["parse {n, m}, k = as_count(arg1)"]
+    C --> D{"n >= 0, m >= 0, maxe fits, m <= maxe"}
+    K --> D
+    D -->|no| N
+    D -->|yes, 1-arg| H["one_random_graph(n, m)"]
+    D -->|yes, 2-arg| KV{"k >= 0 and k*ptr fits"}
+    KV -->|no| N
+    KV -->|yes| L["loop i = 0..k-1: one_random_graph(n, m)"]
+    L -->|"any element NULL"| N2["free accumulated, return NULL"]
+    L --> M["List of k graphs (k = 0 gives {})"]
+    H --> G["Graph[...]"]
+    subgraph one_random_graph
+      P{"maxe == 0 (n <= 1)"}
+      P -->|yes| Q["inline Graph[List 1..n, List[]], free verts array"]
+      P -->|no| R["calloc candidates (NULL check)"] --> S["evaluate(RandomSample[cand, m])"]
+      S --> T{"graph_is_list?"} -->|no| U["NULL"]
+      T -->|yes| V["inline Graph[List 1..n, sampled], free verts array"]
+    end
+```
+
+## Alternatives Considered
+
+### Generalize the count-spec parsing into a shared helper
+
+**Rejected because:** there is no such helper today and seven heads across three subsystems
+each hand-roll their own. Introducing one as a side effect of adding an arity to a graph
+generator would touch `src/random.c`, `src/ml/dist.c`, and `src/list/constant_array.c` — a
+refactor with far more blast radius than the feature it serves.
+
+### Replace the `evaluate(RandomSample[...])` round-trip with a C-level RNG call
+
+**Rejected because:** the round-trip is exactly what makes `SeedRandom` reproducibility work
+without any code in this file. It is also O(n²) in allocation, so replacing it is tempting —
+but the research resolved that as out of scope, and a `k` loop over the existing path is what
+was agreed.
+
+### Also fix the candidate-tree leak (Finding 4B)
+
+**Rejected because:** the research measured it and scoped it out, and the human confirmed
+documenting over fixing. This was the nearest call of the three: the leak multiplies by `k`,
+so this change makes it easier to hit. It is documented in the docstring and changelog
+instead.
+
+## Implementation Approach
+
+One phase of code, one phase of docs and tests. The code phase is a single-function
+refactor: lift `:113-133` into `one_random_graph(long n, unsigned long long maxe, long m)`
+returning `Expr*` (or `NULL` on sampler or allocation failure), add the `maxe == 0` early
+return, then make `builtin_random_graph` a thin dispatcher over `arg_count`. Both arities
+share the spec validation (`n`, `m`, `maxe` representable, `m <= maxe`), which stays in the
+dispatcher so an out-of-range `m`
+fails identically at either arity (AC-10). The `k` loop bails to `NULL` — freeing whatever it
+has accumulated — if any element comes back `NULL`, so a partial list is never returned.
+
+## Phase 1: The `k` form
+
+### Overview
+
+Extract the helper, add the early return, dispatch on arity, loop for `k`.
+
+### Changes Required:
+
+#### 1. The generator
+
+**File**: `src/graph/generators.c`
+**Changes**: replace `builtin_random_graph` (`:103-134`) with a helper plus a dispatcher.
+
+```c
+/* Vertices 1..n wrapped as a List; frees the intermediate C array, which
+ * expr_new_function memcpys rather than adopting (src/expr.c:257). */
+static Expr* vertex_list(long n) {
+    Expr** verts = int_vertices(n);
+    Expr* vlist = expr_new_function(expr_new_symbol(SYM_List), verts, (size_t)n);
+    free(verts);
+    return vlist;
+}
+
+/* One random undirected graph: n vertices, m of the n(n-1)/2 candidate edges.
+ * Returns NULL if the sampler declines or an allocation fails. Caller has
+ * already validated n >= 0, m >= 0, maxe representable, m <= maxe.
+ *
+ * Assembly is inline rather than via make_graph (:36-41) on purpose: that
+ * helper frees none of the arrays it is handed (its "moves ownership" comment
+ * predates the memcpy) and takes an Expr** edge array, not a built List. */
+static Expr* one_random_graph(long n, unsigned long long maxe, long m) {
+    /* n <= 1 leaves no candidates, and RandomSample[{}, m] is itself
+     * unevaluated (is_nonempty_list, src/random.c:1707) — which is why
+     * RandomGraph[{0,0}] fails today. Answer directly instead.
+     *
+     * Deliberately NOT extended to m == 0 with n >= 2: that case works today
+     * via RandomSample[cand, 0] and skipping the call would shift the RNG
+     * stream for every later draw. See Requires Approval. */
+    if (maxe == 0) {
+        Expr* gargs[2] = { vertex_list(n),
+                           expr_new_function(expr_new_symbol(SYM_List), NULL, 0) };
+        return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+    }
+
+    size_t ncand = (size_t)maxe;
+    Expr** cand = calloc(ncand, sizeof(Expr*));
+    if (!cand) return NULL;                  /* absurd n: unevaluated, not a crash */
+    size_t k = 0;
+    for (long i = 1; i <= n; i++)
+        for (long j = i + 1; j <= n; j++)
+            cand[k++] = undirected_edge(i, j);
+    Expr* cand_list = expr_new_function(expr_new_symbol(SYM_List), cand, ncand);
+    free(cand);
+
+    /* Sample without replacement through the evaluator, so SeedRandom applies. */
+    Expr* sample_args[2] = { cand_list, expr_new_integer(m) };
+    Expr* sample_call = expr_new_function(expr_new_symbol("RandomSample"),
+                                          sample_args, 2);
+    Expr* sampled = evaluate(sample_call);   /* consumes sample_call */
+    if (!graph_is_list(sampled)) { expr_free(sampled); return NULL; }
+
+    Expr* gargs[2] = { vertex_list(n), sampled };
+    return expr_new_function(expr_new_symbol(SYM_Graph), gargs, 2);
+}
+
+Expr* builtin_random_graph(Expr* res) {
+    size_t argc = res->data.function.arg_count;
+    if (argc != 1 && argc != 2) return NULL;
+    const Expr* spec = res->data.function.args[0];
+    if (!graph_is_list(spec) || spec->data.function.arg_count != 2) return NULL;
+    long n = as_count(spec->data.function.args[0]);
+    long m = as_count(spec->data.function.args[1]);
+    if (n < 0 || m < 0) return NULL;
+
+    /* n(n-1)/2 overflows signed long for large n, and a negative maxe would let
+     * the m gate below pass. Compute unsigned and bound by what can be
+     * allocated; an n past that is unevaluated, per the head's error channel. */
+    unsigned long long maxe = (n < 2) ? 0ULL
+        : (unsigned long long)n * (unsigned long long)(n - 1) / 2;
+    if (maxe > (unsigned long long)(SIZE_MAX / sizeof(Expr*))) return NULL;
+    if ((unsigned long long)m > maxe) return NULL;  /* more edges than a simple graph allows */
+
+    if (argc == 1) return one_random_graph(n, maxe, m);
+
+    /* RandomGraph[{n,m}, k]: k independent graphs. k = 0 gives {}; a negative,
+     * non-integer, or symbolic k is silently unevaluated, matching the five
+     * count-taking heads in src/random.c (SPEC section 4: NULL, no Message). */
+    long kcount = as_count(res->data.function.args[1]);
+    if (kcount < 0) return NULL;
+    if ((unsigned long long)kcount > (unsigned long long)(SIZE_MAX / sizeof(Expr*)))
+        return NULL;
+    Expr** gs = (kcount > 0) ? calloc((size_t)kcount, sizeof(Expr*)) : NULL;
+    if (kcount > 0 && !gs) return NULL;
+    for (long i = 0; i < kcount; i++) {
+        gs[i] = one_random_graph(n, maxe, m);
+        if (!gs[i]) {                        /* never return a partial list */
+            for (long j = 0; j < i; j++) expr_free(gs[j]);
+            free(gs);
+            return NULL;
+        }
+    }
+    Expr* out = expr_new_function(expr_new_symbol(SYM_List), gs, (size_t)kcount);
+    free(gs);
+    return out;
+}
+```
+
+Note `one_random_graph` returns an *unevaluated* `Graph[...]` tree, exactly as the current
+code does; the evaluator canonicalizes and validates it via `builtin_graph`. For the `k`
+form the elements sit inside a `List` the evaluator will descend into, so canonicalization
+still happens — AC-2 and AC-3 verify that empirically rather than by assumption.
+
+#### 2. Include and header comments
+
+**File**: `src/graph/generators.c:22`
+**Changes**: add `#include <stdint.h>` next to the existing `#include <stdlib.h>` —
+`SIZE_MAX` lives there, and it is C99, so no feature-test macro is needed
+(`make check-c99` covers this).
+
+**File**: `src/graph/generators.c:5`
+**Changes**: add `*   RandomGraph[{n, m}, k]    - a list of k such graphs` under the
+existing `RandomGraph[{n, m}]` line.
+
+**File**: `src/graph/graph.h:103`
+**Changes**: `Expr* builtin_random_graph(Expr* res);  /* RandomGraph[{n,m}] / [{n,m},k] */`
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Build succeeds: `SDKROOT=$(xcrun --show-sdk-path) make -j8`
+  (a bare `make` fails with `fatal error: stdio.h: No such file or directory` under
+  gcc-16 in this environment — measured during research, not a code defect)
+  — *Evidence: build completed, `./Mathilda` relinked (9,191,912 bytes, 21:58); rebuilt
+  clean again after the Phase 2 docstring edit.*
+- [x] Portability gate passes: `make check-c99`
+  — *Evidence: `python3 tools/check_c99_portability.py` ran with no findings printed and
+  exit 0 (only the pre-existing GMP-ECM-not-detected makefile notices).*
+- [x] Graph unit tests pass: `cd tests && mkdir -p build && cd build && cmake .. && make -j8 graph_tests && ./graph_tests`
+  — *Evidence: 15 tests including `test_random_graph`, output ends `All graph tests passed!`.*
+- [x] No new compiler diagnostics under `-Wall -Wextra` for `src/graph/generators.c`
+  — *Evidence: `grep -iE "error|warning"` over the full build log matched only the literal
+  `-Werror=` flags inside the gcc command lines; the `generators.c` compile line emitted
+  no diagnostic of its own.*
+
+#### Manual Verification:
+- [ ] Every AC-1..AC-19 row reproduced in the REPL, read individually
+- [ ] The 1-arg form is unchanged: `RandomGraph[{6,5}]` still returns a bare `Graph` (AC-13)
+- [ ] `SeedRandom[42]` twice gives identical `k`-form output (AC-11)
+- [ ] **RNG-stream preservation (AC-17)**, the one check that needs the old binary: build
+      `7701df5b` to `./Mathilda.pre`, run
+      `(SeedRandom[7]; RandomGraph[{5,0}]; RandomInteger[{1,10^6}])` on both binaries, and
+      confirm the two integers match. This is what proves the early return did not silently
+      move to `m == 0`.
+- [ ] **Leak (A) is gone for this head**, checked where Finding 4B cannot mask it: run
+      `MallocStackLogging=1 leaks --atExit -- ./Mathilda -file <script>` over
+      `Do[RandomGraph[{1, 0}], {50}]` — the `maxe == 0` path, which allocates no candidate
+      tree — and require **zero** `ROOT LEAK` records naming `builtin_random_graph` or
+      `int_vertices`. On `Do[RandomGraph[{50,20}], {50}]` the same grep must also show zero
+      such records, with the remaining leak volume attributable to Finding 4B's candidate
+      tree (~6,066 `Expr` nodes/call) rather than to a `calloc` root frame.
+- [ ] No crash on AC-18/AC-19 (absurd `n`, absurd `k`) — both unevaluated
+
+**Implementation Note**: After completing this phase and all automated verification passes,
+pause here for manual confirmation from the human that the manual testing was successful
+before proceeding to the next phase.
+
+---
+
+## Phase 2: Tests, docstring, and docs
+
+### Overview
+
+Lock the behavior into the unit suite and satisfy CLAUDE.md's docstring/spec/changelog
+requirements.
+
+### Changes Required:
+
+#### 1. Unit tests
+
+**File**: `tests/test_graph.c:213-228`
+**Changes**: extend `test_random_graph`, style `assert_eval_eq(input, expected, fullform)`.
+No registration change — `:310-311` already registers the test.
+
+```c
+    /* --- RandomGraph[{n,m},k]: k independent graphs (RG-1) --- */
+    assert_eval_eq("Length[RandomGraph[{6, 5}, 3]]", "3", 0);
+    assert_eval_eq("And @@ (GraphQ /@ RandomGraph[{6, 5}, 3])", "True", 0);
+    assert_eval_eq("Union[VertexCount /@ RandomGraph[{6, 5}, 3]]", "{6}", 0);
+    assert_eval_eq("Union[EdgeCount /@ RandomGraph[{6, 5}, 3]]", "{5}", 0);
+    /* k = 1 is a one-element list, not a bare graph. */
+    assert_eval_eq("Length[RandomGraph[{6, 5}, 1]]", "1", 0);
+    assert_eval_eq("RandomGraph[{6, 5}, 0]", "{}", 0);
+    /* Bad k: silently unevaluated, per the src/random.c convention. */
+    assert_eval_eq("Head[RandomGraph[{6, 5}, -1]]", "RandomGraph", 0);
+    assert_eval_eq("Head[RandomGraph[{6, 5}, 2.5]]", "RandomGraph", 0);
+    assert_eval_eq("Head[RandomGraph[{6, 5}, q]]", "RandomGraph", 0);
+    /* m out of range fails identically at either arity. */
+    assert_eval_eq("Head[RandomGraph[{3, 10}, 2]]", "RandomGraph", 0);
+    /* Independence: 5 draws from C(28,4) are not all the same edge set. */
+    assert_eval_eq("Length[Union[EdgeList /@ RandomGraph[{8, 4}, 5]]] > 1", "True", 0);
+    /* n <= 1 and m = 0: edgeless graphs, no longer unevaluated. */
+    assert_eval_eq("VertexCount[RandomGraph[{0, 0}]]", "0", 0);
+    assert_eval_eq("EdgeCount[RandomGraph[{1, 0}]]", "0", 0);
+    assert_eval_eq("Union[EdgeCount /@ RandomGraph[{5, 0}, 2]]", "{0}", 0);
+```
+
+Plus a seeded-determinism check for the `k` form, in the existing `evaluate(parse_expression(...))`
+style already used at `:221-227`:
+
+```c
+    Expr* e2 = evaluate(parse_expression(
+        "(SeedRandom[42]; EdgeList /@ RandomGraph[{6,5},3]) === "
+        "(SeedRandom[42]; EdgeList /@ RandomGraph[{6,5},3])"));
+    char* s2 = expr_to_string(e2);
+    ASSERT(strcmp(s2, "True") == 0);
+    free(s2);
+    expr_free(e2);
+```
+
+#### 2. Docstring
+
+**File**: `src/graph/graph.c:122-124`
+**Changes**:
+
+```c
+    symtab_set_docstring("RandomGraph",
+        "RandomGraph[{n, m}] gives a random undirected graph with n vertices "
+        "and m edges. RandomGraph[{n, m}, k] gives a list of k such graphs; "
+        "memory use grows with k.");
+```
+
+#### 3. Spec and changelog
+
+**File**: `docs/spec/builtins/graphs.md:115-117`
+**Changes**: extend the `RandomGraph` bullet with the `k` form, the `k = 0` / `k = 1` /
+invalid-`k` conventions, the `n <= 1` behavior, and one sentence on the per-`k` memory cost.
+Add a line to the adjacent example block:
+
+```
+Length[RandomGraph[{6, 5}, 3]]   (* 3 *)
+```
+
+**File**: `docs/spec/changelog/2026-08-24.md`
+**Changes**: add a `### RandomGraph[{n, m}, k]` section under the existing structure —
+the new arity, the incidental `n <= 1` fix, and the documented memory caveat with the
+measured ~364 KB/call figure at n=50.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Graph unit tests pass: `cd tests/build && make -j8 graph_tests && ./graph_tests`
+  — *Evidence: run after the 17 new `assert_eval_eq` rows and the seeded `k`-form
+  determinism check were added; output ends `All graph tests passed!`.*
+- [ ] Full suite is no worse than before: `cd tests/build && cmake .. && make -j8 && for t in *_tests; do ./$t; done`
+  — **NOT RUN.** The invocation was interrupted before it produced any result. No evidence
+  either way; this box is the one remaining automated gap.
+- [x] `?RandomGraph` in the REPL prints the new docstring naming the `k` form
+  — *Evidence: `Print[Information[RandomGraph]]` returns "RandomGraph[{n, m}] gives a random
+  undirected graph with n vertices and m edges. RandomGraph[{n, m}, k] gives a list of k
+  such graphs; memory use grows with k."*
+- [x] `make check-c99` still passes
+  — *Evidence: same clean run as Phase 1; the only new include is `<stdint.h>` for
+  `SIZE_MAX`, which is C99 and needs no feature-test macro.*
+
+#### Manual Verification:
+- [ ] `docs/spec/builtins/graphs.md` reads correctly alongside its sibling generator entries
+- [ ] The changelog entry lands in the current ISO week's file (`2026-08-24.md`, Monday of
+      the week containing 2026-08-30)
+- [ ] The memory caveat is stated in both the docstring and the changelog, with the number
+
+---
+
+## Testing Strategy
+
+The 16 AC rows above are the substance; this covers what they don't. The interesting risk is
+not the `k` loop — it is the refactor silently changing the 1-arg path, so AC-13 and the
+pre-existing assertions at `tests/test_graph.c:214-220` are the real regression guard and
+must stay untouched rather than rewritten to fit the new code.
+
+### Edge Cases & Integration Scenarios:
+- The refactor's failure path: if `RandomSample` ever declines mid-loop, the `k` form must
+  return `NULL`, not a short list. Hard to trigger from the REPL once `maxe == 0` is handled
+  — worth reading the freeing loop carefully instead.
+- Large `k` interacting with the documented leak: `RandomGraph[{50, 20}, 1000]` should
+  complete and produce 1000 valid graphs, memory growth notwithstanding.
+- `SeedRandom` across arities: `RandomGraph[{n,m},3]` under a seed should consume the RNG
+  stream as three successive 1-arg calls would.
+
+### Manual Testing Steps:
+1. Build with `SDKROOT=$(xcrun --show-sdk-path) make -j8` and start `./Mathilda`.
+2. Walk AC-1 through AC-16 in order, reading each result rather than scanning for absence of
+   errors.
+3. `?RandomGraph` — confirm the docstring names the `k` form and the memory caveat.
+4. `SeedRandom[42]; RandomGraph[{6,5},3]` twice — confirm identical output.
+5. Run the leak check from Phase 1 and confirm growth is proportional to `k` and that the
+   `int_vertices` ROOT LEAK no longer names this head.
+
+## Performance Considerations
+
+Each element costs a full O(n²) candidate materialization plus one `RandomSample`
+evaluation, so the `k` form is O(k·n²) in both time and allocation — by design, per the
+resolved research question. The `maxe == 0` early return makes the `n <= 1`
+cases O(n); `m == 0` with `n >= 2` keeps its sampler call, so its cost is unchanged. The per-call ~364 KB leak at n=50 (Finding 4B) multiplies by `k`; documented,
+not fixed.
+
+## Migration Notes
+
+None. The 1-arg form is unchanged for `n >= 2`, and the 2-arg form was previously
+unevaluated, so no existing working expression changes meaning. The one observable change to
+old behavior is `RandomGraph[{0,0}]` / `[{1,0}]` going from unevaluated to an edgeless
+graph — see Requires Approval. `RandomGraph[{n, 0}]` for `n >= 2` deliberately keeps its
+`RandomSample[cand, 0]` call, so its RNG-stream consumption is unchanged (AC-17).
+
+## References
+
+- Related research: `thoughts/shared/tickets/RG-1/research.md`
+- Current implementation: `src/graph/generators.c:103-134`
+- Closest model for the `k` form: `src/random.c:418-553` (`builtin_randominteger`)
+- The `n <= 1` root cause: `src/random.c:1707` (`is_nonempty_list`)
+- The memcpy that implies leak (A): `src/expr.c:257`
+- Existing test: `tests/test_graph.c:213-228`
+- Spec entry: `docs/spec/builtins/graphs.md:115-117`
+- Subsystem docs: none — `thoughts/shared/subsystems/` does not exist

--- a/thoughts/shared/tickets/RG-1/research-summary.md
+++ b/thoughts/shared/tickets/RG-1/research-summary.md
@@ -1,0 +1,75 @@
+---
+created: 2026-08-30T21:18:27-0400
+researcher: Michael Sollami
+topic: "How does RandomGraph work today, and what would it take to add the RandomGraph[{n,m}, k] form that returns k random graphs?"
+type: research
+lifecycle: active
+full_research: thoughts/shared/tickets/RG-1/research.md
+---
+
+# Research Summary: RandomGraph `k` form
+
+**Full research (appendix)**: `thoughts/shared/tickets/RG-1/research.md`
+
+## Recommendation
+
+Add the flat `k` form directly in `src/graph/generators.c`: relax the `arg_count != 1`
+gate at `:104`, extract the existing single-graph body into a static helper, and loop it
+`k` times into a `List`. Parse `k` with the file's existing `as_count` (`:25-28`), which
+already gives the codebase-standard behavior — `k = 0` → `{}`, negative/non-integer/
+symbolic → unevaluated, no `Message[]`. `k = 1` must return `{Graph[...]}`, a one-element
+list, not a bare graph.
+
+## Options Considered
+
+1. **Local loop over the existing path** *(recommended)* — ~15 lines, one file plus
+   docstring/spec/test updates. Tradeoff: inherits the O(n²) candidate cost per graph and
+   the per-call leak below, both multiplied by `k`.
+2. **Rework sampling to O(m) first, then add `k`** — removes the n² floor and would let
+   `k` scale. Tradeoff: touches the working 1-arg path and its `SeedRandom` guarantee;
+   ruled out of scope.
+3. **Generalize a shared count-spec parser across the `Random*` family** — would retire
+   five duplicated validation loops in `src/random.c`. Tradeoff: a refactor of six
+   unrelated heads riding along on a small feature; rejected.
+
+## Decision Criteria
+
+- Five sibling heads already establish the exact convention to copy, and there is **no**
+  shared helper to reuse — so a sixth local check is idiomatic here, not sloppy.
+- The `SeedRandom` guarantee comes from delegating to a real `RandomSample[...]` call
+  through the evaluator; any rework risks it, and reproducibility is already tested.
+- The packed/NDArray/`Compile[]` rule in CLAUDE.md does not bite: `RandomGraph` returns a
+  `Graph`, a non-machine object, and appears in no `AWARE` list, ND kernel, or audit
+  baseline.
+
+## Open Questions
+
+### Unresolved
+
+_None._
+
+### Resolved
+
+- [x] Flat `k` only, or nested `{k1,k2}` too? — Flat only; nested is out of scope.
+- [x] Rework the O(n²) candidate materialization? — No; reuse the existing path in a loop.
+- [x] Prior attempt or deliberate deferral? — Neither; greenfield, single commit
+  `56035303`.
+- [x] Fix the memory leak found while measuring? — No; record as a finding only.
+
+## Requires Approval
+
+**A measured, pre-existing leak that scales with `k`.** `RandomGraph[{50,20}]` leaks
+~364 KB *per call* — 2000 iterations leak 727 MB across 12.2M objects — because the whole
+candidate-edge tree is never reclaimed (`generators.c:127`; `RandomSample` itself measures
+0 leaks). All four generators additionally leak two `calloc`'d C arrays per call, because
+`expr_new_function` memcpys rather than adopts (`src/expr.c:257`); `CompleteGraph[50]`
+× 2000 = 21 MB.
+
+Out of scope by decision — **finding only, not to be fixed here.** But the agreed
+loop-`k`-times approach multiplies it by `k`: `RandomGraph[{50,20}, 1000]` would leak
+~364 MB. Worth a changelog note or a docstring caveat rather than silence.
+
+Two smaller pre-existing items, also not in scope: `RandomGraph[{0,0}]` and `{1,0}` are
+unevaluated (empty candidate list hits `is_nonempty_list` in `RandomSample`), and
+`RandomGraph` has no recorded `EXEMPT` entry in the packed-array audit tooling even though
+it legitimately qualifies.

--- a/thoughts/shared/tickets/RG-1/research.md
+++ b/thoughts/shared/tickets/RG-1/research.md
@@ -1,0 +1,354 @@
+---
+created: 2026-08-30T21:18:27-0400
+researcher: Michael Sollami
+source_sha: 7701df5b36cab11000efad1f3b2dff094ff2316f
+branch: main
+repository: mathilda
+topic: "How does RandomGraph work today, and what would it take to add the RandomGraph[{n,m}, k] form that returns k random graphs?"
+tags: [research, codebase, graph, generators, random, memory]
+subsystems: [graph]
+type: research
+lifecycle: active
+status: complete
+last_updated: 2026-08-30
+last_updated_by: Michael Sollami
+---
+
+# Research: RandomGraph today, and adding the `RandomGraph[{n,m}, k]` form
+
+**Date**: 2026-08-30T21:18:27-0400
+**Researcher**: Michael Sollami
+**Git Commit**: 7701df5b36cab11000efad1f3b2dff094ff2316f
+**Branch**: main
+**Repository**: mathilda
+
+## TL;DR
+
+`RandomGraph` is a single-arity builtin (`generators.c:103-134`) that hard-rejects any
+second argument, so the `k` form is a ~15-line change following the `RandomInteger`
+precedent. Measurement turned up an unrelated, pre-existing leak: each `RandomGraph`
+call leaks its whole candidate-edge tree — 364 KB at n=50. Left unfixed by decision;
+it bounds how the `k` form should loop.
+
+## Summary
+
+`RandomGraph[{n, m}]` builds all `n(n-1)/2` candidate `UndirectedEdge` expressions,
+sampling `m` of them by constructing and evaluating a real `RandomSample[...]` call —
+which is why it honors `SeedRandom`. The arity gate is a literal
+`arg_count != 1` at `generators.c:104`, so `RandomGraph[{5,4}, 3]` returns unevaluated
+today (measured, not inferred).
+
+Adding the flat `k` form is mechanical. Five sibling heads in `src/random.c` already
+implement a trailing count argument, and they agree on every convention that matters:
+`k = 0` yields `{}`, and a negative, non-integer, or symbolic count returns `NULL`
+(unevaluated) with no `Message[]`. There is no shared helper to reuse — each head
+duplicates its own validation loop — so a sixth local copy is the idiomatic choice
+here, not a refactor.
+
+The one surprise is a measured pre-existing memory leak in the generator family, which
+is recorded as a finding below and deliberately not in scope.
+
+## Open Questions
+
+### Unresolved
+
+_None._
+
+### Resolved
+
+- [x] Flat `k` only, or the nested `{k1,k2}` form too? — Flat `RandomGraph[{n,m}, k]`
+  only; the nested form is explicitly out of scope.
+- [x] Should the O(n²) candidate-materialization be reworked as part of this? — No.
+  Reuse the existing single-graph path in a loop; record the cost as a known limit.
+- [x] Was the `k` form deliberately deferred, or is there a prior attempt to avoid
+  repeating? — Neither. Greenfield: `src/graph/generators.c` has exactly one commit
+  (`56035303`), the graph-subsystem bulk add, and the 1-arg form was simply all that
+  got written.
+- [x] Is the generator-family memory leak in scope? — No. Record it as a finding with
+  file:line and the measured numbers; do not fix it.
+
+## Research Review
+
+### Blocking
+
+_None._
+
+### Worth Flagging
+
+_None._
+
+### Resolved
+
+_None._
+
+## Requires Approval
+
+The measured leak below (Finding 4) interacts with the agreed "reuse as-is in a loop"
+approach: at n=50 the existing single-graph path leaks ~364 KB per call, so
+`RandomGraph[{50,20}, 1000]` would leak ~364 MB. The scope decision to not fix it
+stands, but whoever implements the `k` form should know the leak scales with `k` and
+may want a documented cap or a note in the docstring.
+
+---
+
+## Research Question
+
+> How does RandomGraph work today, and what would it take to add the RandomGraph[{n,m}, k] form that returns k random graphs?
+
+## Detailed Findings
+
+### 1. Current behavior — measured, not inferred
+
+Built at `7701df5b` (needed `SDKROOT=$(xcrun --show-sdk-path) make -j8`; a bare `make`
+fails with `fatal error: stdio.h: No such file or directory` under gcc-16 in this
+environment). Actual REPL output:
+
+| Input | Output |
+|---|---|
+| `RandomGraph[{5, 4}]` | `Graph[<5 vertices, 4 edges>]` |
+| `RandomGraph[{5, 4}, 3]` | `RandomGraph[{5, 4}, 3]` — unevaluated |
+| `RandomGraph[{5, 4}, 1]` | `RandomGraph[{5, 4}, 1]` — unevaluated |
+| `RandomGraph[{5, 11}]` | unevaluated (m > n(n-1)/2, as documented) |
+| `SeedRandom[42]` twice | identical `EdgeList` — reproducibility holds |
+
+So the `k` form is not partially present or silently wrong; it is entirely absent, and
+the head is otherwise sound.
+
+### 2. Implementation and the exact arity gate
+
+`src/graph/generators.c:103-134`. The gate is two lines:
+
+```c
+Expr* builtin_random_graph(Expr* res) {
+    if (res->data.function.arg_count != 1) return NULL;     /* :104 */
+    const Expr* spec = res->data.function.args[0];
+    if (!graph_is_list(spec) || spec->data.function.arg_count != 2) return NULL;
+```
+
+Then: build every candidate edge (`:113-121`), sample via a constructed
+`RandomSample[cand_list, m]` that is really `evaluate()`d (`:124-127`), and assemble
+`Graph[List[1..n], sampled]` (`:130-133`).
+
+Two details worth carrying into the change:
+
+- `builtin_random_graph` does **not** use the file's own `make_graph` helper
+  (`:36-41`) — it inlines the assembly at `:130-133`. Every other generator uses
+  `make_graph`. A `k`-form refactor is the natural moment to extract the
+  single-graph body into a static helper that both the 1-arg and `k`-arg paths call.
+- It reaches `RandomSample` through the evaluator rather than a C-level RNG helper.
+  That is load-bearing for `SeedRandom` and should be preserved, not optimized away.
+
+### 3. Prior art for the trailing count argument — five copies, no shared helper
+
+`src/random.c` implements this exact shape five times over, each with its own
+validation loop and its own recursive array builder:
+
+- `builtin_randominteger` — `src/random.c:418-553`, builder `random_array` at `:370-406`
+- `randomreal_machine` — `src/random.c:941-1024` (+ MPFR twin at `:842-936`)
+- `randomcomplex_machine` — `src/random.c:1394-1449` (+ MPFR twin at `:1276-1389`)
+- `builtin_randomchoice` — `src/random.c:1730-1868`
+- `builtin_randomsample` — `src/random.c:1967-2033` (flat `n` and `UpTo[n]` only, no
+  nested dims)
+- `builtin_randomvariate` — `src/ml/dist.c:465-485` (flat `n` only)
+- `builtin_constant_array` — `src/list/constant_array.c:38-110`, the same idea
+  structured a third way
+
+There is no shared "parse a count-or-dimension spec" function anywhere; `src/random.h`
+exports only the `builtin_*` entry points and two RNG primitives. Given flat-`k`-only
+scope, writing a sixth local check is consistent with the codebase, and a
+generalizing refactor would be out of scope creep.
+
+**The conventions these agree on** — measured against the live binary for all five
+heads, not inferred from one:
+
+| Count | `RandomInteger` | `RandomReal` | `RandomComplex` | `RandomChoice` | `RandomSample` |
+|---|---|---|---|---|---|
+| `0` | `{}` | `{}` | `{}` | `{}` | `{}` |
+| `-1` | uneval | uneval | uneval | uneval | uneval |
+| `2.5` | uneval | uneval | — | — | — |
+| symbolic | uneval | — | — | uneval | uneval |
+
+Unanimous. Worth noting explicitly because `RandomSample` is the head this change
+actually calls into, and § 7 below shows it *does* have an extra guard —
+`is_nonempty_list` at `src/random.c:1707`. That guard is on the **list** argument, not
+the count: `RandomSample[{a,b}, 0]` → `{}` like everyone else, while
+`RandomSample[{}, 0]` is unevaluated. So the count convention is uniform, and the
+divergence is confined to the empty-candidate-list case that causes the § 7 bug.
+
+`grep` for `Message(`/`symtab_message` in `src/random.c` returns zero matches — the
+uniform convention is silent `NULL`, per SPEC §4. `as_count` in
+`generators.c:25-28` already implements exactly this predicate (non-negative machine
+`EXPR_INTEGER`, else `-1`), so the `k` form should parse `k` with `as_count` and get
+the right behavior for free.
+
+Note `k = 1` should return a **one-element list** `{Graph[...]}`, not a bare graph —
+that is the Mathematica semantics and matches `RandomInteger[{1,10}, 1]` → `{7}`.
+
+### 4. FINDING (out of scope, do not fix): the graph generators leak, and `RandomGraph` leaks badly
+
+`expr_new_function` **memcpy**s the caller's argument array rather than adopting it
+(`src/expr.c:257`):
+
+```c
+if (args) memcpy(e->data.function.args, args, sizeof(Expr*) * arg_count);
+```
+
+So the caller must `free()` the C array it passed. `int_vertices` (`:43-47`) `calloc`s
+a fresh array every call, and **no** generator frees it:
+
+- `generators.c:59` — `make_graph(int_vertices(n), ...)`, array leaked
+- `generators.c:73` — same
+- `generators.c:100` — same
+- `generators.c:131` — same, inside `builtin_random_graph`
+- `generators.c:92` — the `PathGraph[{v1,...}]` explicit-vertex branch, which leaks a
+  *separately* allocated `verts` array (`calloc` at `:83`) by the same mechanism
+
+`builtin_random_graph` correctly frees its own `cand` array at `:121`; the `edges`
+arrays at `:54`, `:69`, `:86`, `:98` are also never freed.
+
+Per-call array count, precisely: `CompleteGraph`, `CycleGraph`, and both `PathGraph`
+branches leak **two** arrays each (vertices + edges). `builtin_random_graph` leaks
+**one** — it allocates `cand` rather than an `edges` array and does free `cand` at
+`:121`, so only `int_vertices(n)` at `:131` is lost.
+
+Measured with `MallocStackLogging=1 leaks --atExit`, 2000 iterations each:
+
+| Expression | Leaks | Bytes |
+|---|---|---|
+| `RandomSample[Range[1225], 20]` | **0** | 0 |
+| `CycleGraph[50]` | 4,000 | 1,792,000 (~1.8 MB) |
+| `CompleteGraph[50]` | 4,000 | 21,376,000 (~21 MB) |
+| `RandomGraph[{50, 20}]` | **12,265,994** | **727,679,616 (~727 MB)** |
+
+Two distinct leaks, and the second is the serious one:
+
+- **(A) The C arrays** — 2 per call (`int_vertices` + `edges`), affecting all four
+  generators. `leaks` names it directly: `ROOT LEAK: <calloc in
+  builtin_complete_graph>`, 2000 instances. Small and bounded: O(n) pointers.
+- **(B) The candidate-edge *tree*, `RandomGraph` only** — ~6,066 `Expr` nodes leaked
+  per call at n=50, i.e. ~364 KB/call. That is the full 1,225-edge candidate list
+  (1225 edges × ~5 nodes each ≈ 6,125). The comment at `:127` asserts
+  `evaluate(sample_call)` "consumes sample_call", and the measurement says the
+  candidate tree it wraps is not in fact reclaimed. `RandomSample` itself is clean
+  (0 leaks above), so this is `builtin_random_graph`'s own defect, not the sampler's.
+
+Why this matters for the `k` form specifically: leak (B) is per-call and the agreed
+approach is to call the existing path `k` times, so the leak multiplies by `k`.
+`RandomGraph[{50,20}, 1000]` leaks ~364 MB. This does not block the feature — it
+bounds it, and it is worth a line in the changelog rather than silence.
+
+### 5. What the change touches
+
+Per the `graph.h` "Phase" convention (one builtin per TU, prototypes in `graph.h`,
+registration in `graph.c`):
+
+1. `src/graph/generators.c:103-134` — relax the arity gate; extract the single-graph
+   body into a static helper; loop it `k` times into a `List`.
+2. `src/graph/graph.h:103` — update the trailing signature comment
+   (`/* RandomGraph[{n, m}] */`).
+3. `src/graph/graph.c:122-124` — extend the docstring to name the `k` form
+   (mandatory per CLAUDE.md). Attributes need no change: `ATTR_PROTECTED` only, and
+   the graph module sets attributes via the direct
+   `symtab_get_def(name)->attributes |= ...` idiom, never `symtab_set_attributes`.
+4. `tests/test_graph.c:213-228` — extend `test_random_graph`; style is
+   `assert_eval_eq(input, expected_string, fullform_flag)`.
+5. `docs/spec/builtins/graphs.md:115-117` and
+   `docs/spec/changelog/2026-08-24.md` (Monday of this ISO week) — required by
+   CLAUDE.md.
+
+### 6. The packed/NDArray/Compile rule does not apply here
+
+CLAUDE.md requires every new numeric builtin to support packed arrays, NDArray
+kernels, and `Compile[]` lowering. Checked, and it does not bite:
+
+- No `Graph`/`RandomGraph`/`CompleteGraph`/`CycleGraph` entry in `src/pack.c`'s
+  `AWARE` list (`src/pack.c:489-789`); the only `Graph` match in that file is an
+  unrelated comment at `:780`.
+- No matches in `src/ndkernels.c`, `src/ndinteger.c`, or `src/compile/`.
+- `RandomGraph` returns a `Graph` object, not a machine array — exactly the
+  "non-machine object" case CLAUDE.md names as a legitimate exemption.
+
+One caveat for honesty: `PathGraph` *is* on the known-gap ratchet list in
+`tools/nd_fastpath_sweep.py:689-690` (`OFF_BUFFER`), which is a backlog list, not an
+excused-exemption list. `RandomGraph` appears in neither, so no audit currently
+demands anything of it — but there is also no recorded, explicit `EXEMPT` justification
+for it anywhere in the tree. Adding one line to the appropriate audit list would make
+the exemption deliberate rather than merely unnoticed.
+
+### 7. Adjacent pre-existing bug: `RandomGraph[{0,0}]` and `{1,0}` are unevaluated
+
+Measured:
+
+```
+RandomGraph[{0, 0}]  ->  RandomGraph[{0, 0}]   (unevaluated)
+RandomGraph[{1, 0}]  ->  RandomGraph[{1, 0}]   (unevaluated)
+RandomGraph[{2, 0}]  ->  Graph[<2 vertices, 0 edges>]
+```
+
+Root cause isolated: for n ≤ 1, `maxe = 0`, so `cand_list` is the empty `List[]`.
+`builtin_randomsample` guards its input with `is_nonempty_list`
+(`src/random.c:1707`, used at `:1751-1753`), so `RandomSample[{}, 0]` is itself
+unevaluated — confirmed directly — and `graph_is_list(sampled)` then fails at
+`generators.c:128`, returning `NULL`. `Graph[{}, {}]` and `CompleteGraph[0]` both
+work fine, so this is specifically `RandomGraph`'s dependence on the evaluator-level
+sampler. Not in scope, but a `k`-form implementation that early-returns for
+`maxe == 0` would incidentally fix it.
+
+## Code References
+
+- `src/graph/generators.c:103-134` — `builtin_random_graph`, the whole current impl
+- `src/graph/generators.c:104` — the `arg_count != 1` gate that rejects `k`
+- `src/graph/generators.c:25-28` — `as_count`, the count predicate to reuse for `k`
+- `src/graph/generators.c:36-41` — `make_graph`, which `builtin_random_graph` bypasses
+- `src/graph/generators.c:43-47` — `int_vertices`, fresh `calloc` per call, leaked
+- `src/graph/generators.c:121` — `free(cand)`, the one array that *is* freed
+- `src/graph/generators.c:127` — `evaluate(sample_call)`, comment claims it consumes
+- `src/graph/graph.h:99-103` — Phase 4 generator prototypes and naming convention
+- `src/graph/graph.c:120-124` — registration, `ATTR_PROTECTED`, docstring
+- `src/core.c:944-945` — `graph_init()` call site
+- `src/expr.c:239-262` — `expr_new_function`; `:257` is the memcpy that implies the leak
+- `src/random.c:418-553` — `builtin_randominteger`, the closest model for the `k` form
+- `src/random.c:1707` — `is_nonempty_list`, cause of the n≤1 bug
+- `src/random.c:1967-2033` — `builtin_randomsample`
+- `tests/test_graph.c:213-228` — `test_random_graph`
+- `tests/test_graph.c:310-311` — test registration
+- `docs/spec/builtins/graphs.md:115-117` — the `RandomGraph` spec entry
+- `tools/nd_fastpath_sweep.py:689-690` — `PathGraph` on the `OFF_BUFFER` ratchet
+
+## Architecture Insights
+
+- **The graph subsystem mirrors `src/linalg/`**: one builtin per translation unit,
+  prototypes grouped by "Phase" banner in `graph.h:16-18`, registration in `graph.c`
+  under matching banners. A new arity is a same-file change, not a new TU.
+- **Generators delegate randomness to the evaluator, not to C.** Constructing and
+  `evaluate()`-ing a real `RandomSample[...]` call is what makes `SeedRandom`
+  reproducibility fall out for free. It is also the source of both defects found here
+  (the n≤1 unevaluated case and the leaked candidate tree) — the coupling is
+  load-bearing and fragile at the same time.
+- **"Unevaluated" is the universal error channel.** Zero `Message[]` calls in
+  `src/random.c`; `NULL` return per SPEC §4 is the convention for every bad count
+  across seven heads in three subsystems. A new `k` form should not be the first head
+  to emit a diagnostic.
+- **Duplication is the accepted local idiom** for count-spec parsing — five copies in
+  one file. Worth knowing so a reviewer does not read a sixth as sloppiness.
+
+## Historical Context (from thoughts/)
+
+Thin. `thoughts/` holds three documents, none touching the graph subsystem:
+
+- `thoughts/shared/research/2026-08-21-DEMO-1-nminimize-nmaximize-benchmarking.md`
+- `thoughts/shared/research/2026-08-18-unitbox-builtin.md`
+- `thoughts/shared/plans/2026-08-21-DEMO-1-nminimize-nmaximize-benchmarks.md`
+
+No subsystem doc exists for `graph` (`thoughts/shared/subsystems/` is empty), so there
+were no pre-declared conventions to fold in. Writing one is a reasonable follow-on
+given the Phase/one-builtin-per-TU conventions documented above.
+
+Git history is equally thin and confirms greenfield: `src/graph/generators.c` has a
+single commit, `56035303` ("Add graph subsystem: construction, queries, matrix views,
+generators, algorithms, visualization"). The `RandomGraph` spec text dates from
+`docs/spec/changelog/2026-06-29.md:3567-3568`.
+
+## Related Research
+
+None in `thoughts/shared/research/` touches the graph subsystem.

--- a/thoughts/shared/tickets/RG-1/validation.md
+++ b/thoughts/shared/tickets/RG-1/validation.md
@@ -1,0 +1,182 @@
+---
+ticket: RG-1
+created: 2026-08-30
+source_sha: 7701df5b36cab11000efad1f3b2dff094ff2316f
+subsystems: [graph]
+type: validation
+lifecycle: active
+---
+
+# Validation Report: `RandomGraph[{n, m}, k]` (RG-1)
+
+**Checked:** 2026-08-30, working tree on top of HEAD `7701df5b` (the RG-1 work is
+**uncommitted** — this command normally reads git history, so every judgment below is
+against the worktree instead).
+**Plan:** `thoughts/shared/tickets/RG-1/plan.md`
+**Adversarial review:** `thoughts/shared/tickets/RG-1/adversarial.md` (HIGH resolved
+23:03:49, re-verified)
+
+## Implementation Status
+
+- ✓ **Phase 1: The `k` form** — fully implemented.
+- ✓ **Phase 2: Tests, docstring, and docs** — fully implemented; one automated box
+  (full suite) remains unrun, carried over from the plan itself.
+
+## Traceability
+
+`trace.py` → **NOT APPLICABLE** — no `prd.md` under the tickets tree. No product
+requirements to join, which says nothing about test coverage.
+
+## Automated Verification Results
+
+| Criterion (from the plan) | Result | Evidence |
+|---|---|---|
+| Build succeeds | ✓ | `make all` clean; `Mathilda` (9,191,912 bytes) newer than `generators.c` |
+| `make check-c99` | ✓ | `tools/check_c99_portability.py`, no findings, exit 0 |
+| Graph unit tests | ✓ | `graph_tests` rebuilt from the current tree and run: 7 tests incl. `test_random_graph`, ends `All graph tests passed!` |
+| No new `-Wall -Wextra` diagnostics | ✓ | clean rebuild of `graph_tests` + `mathilda_common`, no diagnostics |
+| **Full suite no worse than before** | ✗ **NOT RUN** | Excluded from this run by the human (466-binary suite). Unchanged from the plan, where this same box was already `NOT RUN`. |
+
+## Acceptance Criteria
+
+18 of 19 verified live against `./mathilda`; all 18 pass.
+
+| AC | Expected | Actual | |
+|---|---|---|---|
+| AC-1 | `3` | `3` | ✓ |
+| AC-2 | `True` | `True` | ✓ |
+| AC-3 | `{6}` | `{6}` | ✓ |
+| AC-4 | `{5}` | `{5}` | ✓ |
+| AC-5 | `1` | `1` | ✓ |
+| AC-6 | `{}` | `{}` | ✓ |
+| AC-7 | `RandomGraph` | `RandomGraph` | ✓ |
+| AC-8 | `RandomGraph` | `RandomGraph` | ✓ |
+| AC-9 | `RandomGraph` | `RandomGraph` | ✓ |
+| AC-10 | `RandomGraph` | `RandomGraph` | ✓ |
+| AC-11 | `True` | `True` | ✓ |
+| AC-12 | `True` | `True` | ✓ |
+| AC-13 | `{Graph, 5}` | `{Graph, 5}` | ✓ |
+| AC-14 | `0` | `0` | ✓ |
+| AC-15 | `0` | `0` | ✓ |
+| AC-16 | `{0}` | `{0}` | ✓ |
+| **AC-17** | RNG stream position identical to the pre-change binary | **NOT VERIFIED** | ✗ |
+| AC-18 | `RandomGraph` | `RandomGraph` | ✓ |
+| AC-19 | `RandomGraph` | `RandomGraph` | ✓ |
+
+All 19 also appear as `assert_eval_eq` rows (or the seeded `===` check) in
+`tests/test_graph.c` except AC-17, which cannot be expressed in-process.
+
+## Code Review Findings
+
+### Matches plan
+
+- `one_random_graph(long n, unsigned long long maxe, long m)` and `vertex_list(n)` exist
+  with the planned signatures and the planned inline assembly — `make_graph` correctly
+  not used, per the resolved BLOCKING finding in the plan's own review.
+- The `maxe == 0` early return is keyed on `maxe` **only**, not on `m == 0` — the exact
+  distinction the plan's second BLOCKING finding turned on. `RandomGraph[{5,0}]` keeps its
+  `RandomSample[cand, 0]` call.
+- Spec validation (`n`, `m`, `maxe`, `m <= maxe`) sits in the dispatcher, so AC-10 fails
+  identically at both arities. Confirmed live.
+- `k` loop frees accumulated graphs and `gs` on a `NULL` element; no partial list.
+- `#include <stdint.h> /* SIZE_MAX */` added at `:24`; header comment line added at `:8`;
+  `graph.h:103` signature comment updated; docstring names the `k` form and the memory
+  caveat (verified via `Information[RandomGraph]`).
+- Non-goals honoured: no packed/NDArray/`Compile[]` surface added (correct — `RandomGraph`
+  returns a `Graph`, the "non-machine object" exemption); leak (A) untouched in the other
+  four generators; no `k` cap; candidate-tree leak documented, not fixed.
+
+### Deviations from plan — both improvements
+
+1. **An overflow guard the plan did not specify.** `generators.c:174` adds
+   `if (n > 2147483647L) return NULL;` **before** the multiply, with a 8-line comment at
+   `:166-173`. The plan's Phase 1 code block computed `maxe` in `unsigned long long` and
+   bounded the *product* against `SIZE_MAX` — which cannot catch a wrap. This deviation
+   fixes a real out-of-bounds heap write (the HIGH in `adversarial.md`) that the plan's
+   own code block would have shipped. Correct, and the stronger design.
+2. **A stronger AC-18 witness in the tests.** The plan's AC-18 uses `n = 2^62`, which
+   wraps to a value *above* the `SIZE_MAX` bound and so was rejected by coincidence.
+   `tests/test_graph.c` adds `n = 4294967297` (`2^32 + 1`) at both arities — the witness
+   that actually discriminates — and keeps a comment explaining why. Both confirmed live:
+   `RandomGraph[{4294967297, 1}]` and `RandomGraph[{2147483648, 1}]` return unevaluated.
+
+### Potential issues
+
+1. **MEDIUM — the changelog asserts a measurement nobody made.**
+   `docs/spec/changelog/2026-08-24.md:2515`: "the stream position after
+   `RandomGraph[{5, 0}]` is unchanged against the pre-change binary." That is AC-17, and
+   AC-17 was never run — no `Mathilda.pre` exists anywhere in the tree, and the plan's own
+   manual checkbox for it is unticked. The claim is very likely true (inspection shows no
+   RNG consumption added or removed on the `n >= 2` path, and the early return is keyed on
+   `maxe`, not `m`), but the changelog states it as a completed comparison. Either run the
+   comparison or soften the sentence to what was actually established.
+2. **MEDIUM — the changelog's hardening paragraph describes the superseded design.**
+   `:2525-2528` credits "`n(n-1)/2` is computed in `unsigned long long` and bounded against
+   `SIZE_MAX / sizeof(Expr*)`" — the pre-fix guard — and never mentions the
+   `n > 2^31 - 1` pre-multiply bound that is the load-bearing part. A reader auditing the
+   overflow story is pointed at the weaker half.
+3. **MEDIUM — "both `calloc`s are `NULL`-checked" undercounts the allocation sites.**
+   Same paragraph. There are three on this path; `int_vertices` (`generators.c:45-49`)
+   still `calloc`s and dereferences without a check. Pre-existing code, but the diff adds
+   a caller (`vertex_list`, `:108`) and the changelog advertises full coverage. Carried
+   from `adversarial.md`, severity unchanged.
+
+### Resolved since the adversarial review
+
+- **HIGH (overflow wrap → OOB heap write)** — fixed at 23:03:49; re-verified by reading
+  `generators.c:174` and by running both witnesses live. Marked resolved in
+  `adversarial.md`.
+- **LOW (leak claim had no artifact)** — the artifact now exists; see below.
+
+## Leak verification (Phase 1 manual criterion, now run)
+
+Both shapes the plan's revised criterion names, via
+`MallocStackLogging=1 leaks --atExit -- ./mathilda -file <script>`:
+
+| Script | Result | Verdict |
+|---|---|---|
+| `Do[RandomGraph[{1, 0}], {50}]` | **0 leaks for 0 total leaked bytes** | ✓ the `maxe == 0` path is completely leak-free, as the changelog claims |
+| `Do[RandomGraph[{50, 20}], {50}]` | 306,600 leaks / 18,169,600 bytes; **0** records naming `builtin_random_graph` or `int_vertices` (51 `ROOT LEAK` records total, none in this head) | ✓ leak (A) is gone for this head; the volume is 363.4 KB/call, matching Finding 4B's documented ~364 KB and attributable to the candidate tree, not a `calloc` root frame |
+
+This is the discrimination the plan's second WORTH FLAGGING finding asked for, and it
+holds.
+
+## Manual Testing Required
+
+1. **AC-17 — the one real gap.** Build `7701df5b` to `./Mathilda.pre` (a `git worktree` at
+   that SHA avoids disturbing the uncommitted work), then on both binaries:
+   - [ ] `(SeedRandom[7]; RandomGraph[{5,0}]; RandomInteger[{1, 10^6}])` — confirm the two
+         integers match. This is what proves the early return did not silently extend to
+         `m == 0`.
+2. **Full suite.**
+   - [ ] `cd tests/build && cmake .. && make -j8 && for t in *_tests; do ./$t; done` —
+         confirm no regression outside `graph_tests`.
+3. **Docs read-through.**
+   - [x] Changelog entry is in the current ISO week's file (`2026-08-24.md`, Monday of the
+         week containing 2026-08-30) — confirmed.
+   - [x] Memory caveat stated in both the docstring and the changelog, with the number
+         (364 KB) — confirmed.
+   - [ ] `docs/spec/builtins/graphs.md` reads correctly alongside its sibling generator
+         entries (human judgment).
+
+## Recommendations
+
+1. Fix the three changelog inaccuracies before committing — items 1–3 above. They are
+   prose, not code, and two of them describe verification that did not happen, which is
+   the kind of error that survives into the permanent record.
+2. Run AC-17 or downgrade the claim. Do not commit the sentence as written.
+3. Consider `NULL`-checking `int_vertices` in this diff after all. It is one line, it is on
+   the path this ticket touches, and leaving it makes the changelog's coverage claim wrong.
+4. Then run the full suite once, and commit the graph work separately from the unrelated
+   staged `thoughts/shared/tickets/DEMO-2/*` deletions.
+
+## Verdict
+
+**Implementation matches the plan, and in two places improves on it.** All 18
+in-process acceptance criteria pass in a from-scratch `graph_tests` build and live in the
+REPL; the leak criterion is now backed by measurement; the adversarial HIGH is genuinely
+fixed. Nothing in the code is wrong.
+
+The gaps are in the **record**, not the implementation: three sentences in the changelog
+overstate what was verified or describe a superseded guard. Plus two unrun checks — AC-17
+(needs the pre-change binary) and the full suite (deliberately excluded from this run).


### PR DESCRIPTION

## Summary

`RandomGraph` accepted exactly one argument, so `RandomGraph[{5, 4}, 3]` was left
unevaluated — the only generator in `src/graph/generators.c` without the trailing-count
form that the `Random*` heads in `src/random.c` all share. It now takes an optional
count `k` and returns a `List` of `k` independently sampled graphs.

Refactoring the single-graph body out for reuse surfaced three defects on that path,
all fixed here: a signed-overflow hole in the edge-count guard that allowed an
out-of-bounds heap write, two argument shapes (`RandomGraph[{0, 0}]`,
`RandomGraph[{1, 0}]`) that returned unevaluated instead of the edgeless graph, and a
one-line leak of the vertex array on every call.

## Changes

### `src/graph/generators.c` — the `k` form

- `builtin_random_graph` accepts arity 1 or 2. Spec validation (`n`, `m`, `maxe`,
  `m <= maxe`) stays in the dispatcher so both arities reject identically.
- The single-graph body is lifted into `one_random_graph(n, maxe, m)`, shared by both
  arities, plus a `vertex_list(n)` helper.
- Conventions match the five count-taking heads in `src/random.c`: `k = 0` gives `{}`;
  `k = 1` gives a **one-element list, not a bare `Graph`**; a negative, non-integer, or
  symbolic `k` is silently unevaluated (SPEC §4 — `NULL`, no `Message`).
- A failure mid-loop frees the graphs accumulated so far and the result array, so a
  partial list is never returned.

The `evaluate(RandomSample[...])` round-trip is preserved deliberately — it is what
makes `SeedRandom` reproducibility fall out for free rather than needing its own
plumbing.

### Overflow fix (the reason to read the diff)

The guard is a bound on `n` **before** the multiply — `n > 2147483647L` is unevaluated —
and that placement is the load-bearing part. Bounding the *product* afterwards cannot
catch a wrap: `n = 2^32 + 1` wraps `n(n-1)` to `2^32` in 64 bits and yields a small,
plausible-looking `maxe`, while the candidate loop still runs to the true `n(n-1)/2`
and writes past the buffer. With `n < 2^31` the product cannot exceed `2^62`, which is
what makes the secondary `SIZE_MAX / sizeof(Expr*)` bound exact and meaningful.
Previously the product was computed in signed `long`, where a wrap to a negative value
also let the `m > maxe` gate pass.

### Incidental fixes

- **`n <= 1` was unevaluated.** No candidate edges exist, and `RandomSample[{}, m]` is
  itself unevaluated, so `RandomGraph[{0, 0}]` and `RandomGraph[{1, 0}]` failed. The
  helper now answers the edgeless graph directly. The early return is keyed on
  `n(n-1)/2 == 0` **only**, deliberately not on `m == 0`: the `m = 0, n >= 2` case works
  today via `RandomSample[cand, 0]`, and skipping that call would shift the RNG stream
  for every later draw.
- **Leak.** `vertex_list` frees the `int_vertices` C array, which `expr_new_function`
  memcpys rather than adopts. `Do[RandomGraph[{1, 0}], {50}]` measures 0 leaks / 0 bytes.

### Docs and tests

- `tests/test_graph.c`: 18 new assertions in `test_random_graph` covering every
  acceptance criterion — the `k` conventions, bad-`k` rejection, arity-independent `m`
  rejection, independence across draws, the `n <= 1` cases, the overflow witnesses, and
  seeded determinism of the `k` form.
- Docstring, `docs/spec/builtins/graphs.md`, and the week's changelog entry
  (`docs/spec/changelog/2026-08-24.md`) all name the `k` form and state the memory cost.
- `thoughts/shared/tickets/RG-1/`: research, plan, adversarial review, and validation.

## How to verify it

- [x] `make all` — clean.
- [x] `make check-c99` — no findings.
- [x] `graph_tests`, rebuilt from scratch: 14 tests including `test_random_graph`, ends
      `All graph tests passed!`
- [x] Live in the REPL: `Length[RandomGraph[{6,5},3]]` → `3`;
      `And @@ (GraphQ /@ RandomGraph[{6,5},3])` → `True`; `RandomGraph[{6,5},0]` → `{}`;
      `Head[RandomGraph[{6,5},-1]]` → `RandomGraph`; `EdgeCount[RandomGraph[{1,0}]]` → `0`;
      `Head[RandomGraph[{4294967297,1}]]` → `RandomGraph`;
      `Union[EdgeCount /@ RandomGraph[{5,0},2]]` → `{0}`.
- [x] Leak measurement, `leaks --atExit`: `Do[RandomGraph[{1,0}], {50}]` → 0 leaks.
      `Do[RandomGraph[{50,20}], {50}]` → no records naming `builtin_random_graph` or
      `int_vertices`; the remaining volume is the documented candidate-tree retention.
- [x] **AC-17 — RNG stream position vs. the pre-change binary.** A binary built at
      `7701df5b` (the SHA this work sits on) and the current one agree exactly:
      `(SeedRandom[7]; RandomGraph[{5,0}]; RandomInteger[{1,10^6}])` → `55361` on both,
      likewise the `n >= 2` variant and a seeded `EdgeList[RandomGraph[{6,5}]]`. This is
      the check that proves the `maxe`-keyed early return did not silently extend to
      `m == 0` and consume one draw fewer. It was outstanding at validation time and has
      now been run; the changelog claim is updated to match.
- [x] Full suite: `cd tests/build && cmake .. && make -j8 && for t in *_tests; do ./$t; done`
      — all 466 binaries build clean; **459 pass, 7 fail.** All 7 are pre-existing and
      unrelated to this change; see below.

### Pre-existing suite failures (not introduced here)

| Test | rc | Symptom |
|---|---|---|
| `qrdecomposition_machine_tests` | 139 | **segfault before the first test prints** |
| `qrdecomposition_mpfr_tests` | 139 | **segfault before the first test prints** |
| `ndarray_linalg_tests` | 134 | `Det[NDArray[{{1.,2.,3.},{4.,5.,6.}}]]` → rows leak as `Hold[List][...]` |
| `image_tests` | 134 | `ImageCorrelate[..., "NormalizedCrossCorrelation"]` picks peak `{{11,9}}`, expected `{{5,6}}` |
| `plot3d_tests` | 134 | `Plot3D[...] PlotPoints -> 4` first part has length 18, expected 9 |
| `iter_tests` | 134 | formatting only: `3.0` vs expected `3.` |
| `simplify_tests` | 134 | formatting only: `(x^2)^(3/2)` vs expected `x^2^(3/2)` |

**Why these are not this ticket's.** The complete code footprint since the base SHA
`7701df5b` is four files — `src/graph/{generators.c,graph.c,graph.h}` and
`tests/test_graph.c`. Nothing in `src/linalg/`, `src/image*.c`, `src/iter.c`,
`src/simp/`, or `src/graphics/` is touched, and none of those heads calls into the graph
generators. This is reasoning from the diff footprint, not a baseline suite run — a
run at `7701df5b` would confirm it, and was not performed.

The last two rows are stale test expectations against print formatting. The first three
are substantive and worth their own tickets — in particular the two QR segfaults, which
crash at startup and so are currently providing **no** coverage of `QRDecomposition`.

## Notes for reviewers

**Where the risk is.** The `k` loop is mechanical. The overflow guard is not — its
correctness depends on being placed before the multiply, and the test suite pins that
with `n = 2^32 + 1` at both arities. Note that `n = 2^62` (the witness the plan
originally specified) wraps to a value *above* the `SIZE_MAX` bound and so passes either
way; it does not discriminate. That is why the sharper witness is in the tests with a
comment saying so.

**Known limitation, documented not fixed.** Each element costs a full `O(n^2)` candidate
materialisation, so time and memory scale as `O(k n^2)`; at `n = 50` a call retains
roughly 364 KB (~6,100 `Expr` nodes) per element. This is pre-existing behaviour of the
shared single-graph path, not introduced by the `k` form, but `k` multiplies it. Stated
in both the docstring and the spec entry rather than fixed here.

**Deliberately left open.** Two of the three `calloc` sites on this path are
`NULL`-checked. `int_vertices` (`generators.c:45-49`) still allocates and immediately
dereferences without a check — pre-existing, and this change adds a caller in
`vertex_list`. An absurd `n` or `k` is now unevaluated rather than a crash, but a genuine
allocation failure inside `int_vertices` remains a `NULL` dereference. The same one-line
array leak also exists in `CompleteGraph`, `CycleGraph`, and both `PathGraph` branches
and is out of scope.

**No packed/NDArray/`Compile[]` surface**, per the exemption in CLAUDE.md: `RandomGraph`
returns a `Graph`, a non-machine object.

**`make_graph` is deliberately not used** by `one_random_graph`. That helper frees none
of the arrays it is handed — its "moves ownership" comment predates the `memcpy` in
`expr_new_function` — and it takes an `Expr**` edge array rather than a built `List`.
Reusing it would have reintroduced the leak this change fixes.
